### PR TITLE
Add provisioner option to disable renewal

### DIFF
--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -15,6 +15,7 @@ func testAuthority(t *testing.T) *Authority {
 	assert.FatalError(t, err)
 	clijwk, err := stepJOSE.ParseKey("testdata/secrets/step_cli_key_pub.jwk")
 	assert.FatalError(t, err)
+	disableRenewal := true
 	p := []*Provisioner{
 		{
 			Name: "Max",
@@ -25,6 +26,14 @@ func testAuthority(t *testing.T) *Authority {
 			Name: "step-cli",
 			Type: "JWK",
 			Key:  clijwk,
+		},
+		{
+			Name: "dev",
+			Type: "JWK",
+			Key:  maxjwk,
+			Claims: &ProvisionerClaims{
+				DisableRenewal: &disableRenewal,
+			},
 		},
 	}
 	c := &Config{

--- a/authority/config.go
+++ b/authority/config.go
@@ -23,10 +23,12 @@ var (
 		MaxVersion:    1.2,
 		Renegotiation: false,
 	}
+	defaultDisableRenewal   = false
 	globalProvisionerClaims = ProvisionerClaims{
-		MinTLSDur:     &duration{5 * time.Minute},
-		MaxTLSDur:     &duration{24 * time.Hour},
-		DefaultTLSDur: &duration{24 * time.Hour},
+		MinTLSDur:      &duration{5 * time.Minute},
+		MaxTLSDur:      &duration{24 * time.Hour},
+		DefaultTLSDur:  &duration{24 * time.Hour},
+		DisableRenewal: &defaultDisableRenewal,
 	}
 )
 

--- a/authority/provisioner.go
+++ b/authority/provisioner.go
@@ -11,10 +11,11 @@ import (
 
 // ProvisionerClaims so that individual provisioners can override global claims.
 type ProvisionerClaims struct {
-	globalClaims  *ProvisionerClaims
-	MinTLSDur     *duration `json:"minTLSCertDuration,omitempty"`
-	MaxTLSDur     *duration `json:"maxTLSCertDuration,omitempty"`
-	DefaultTLSDur *duration `json:"defaultTLSCertDuration,omitempty"`
+	globalClaims   *ProvisionerClaims
+	MinTLSDur      *duration `json:"minTLSCertDuration,omitempty"`
+	MaxTLSDur      *duration `json:"maxTLSCertDuration,omitempty"`
+	DefaultTLSDur  *duration `json:"defaultTLSCertDuration,omitempty"`
+	DisableRenewal *bool     `json:"disableRenewal,omitempty"`
 }
 
 // Init initializes and validates the individual provisioner claims.
@@ -55,6 +56,16 @@ func (pc *ProvisionerClaims) MaxTLSCertDuration() time.Duration {
 		return pc.globalClaims.MaxTLSCertDuration()
 	}
 	return pc.MaxTLSDur.Duration
+}
+
+// IsDisableRenewal returns if the renewal flow is disabled for the
+// provisioner. If the property is not set withing the provisioner, then the
+// global value from the authority configuration will be used.
+func (pc *ProvisionerClaims) IsDisableRenewal() bool {
+	if pc.DisableRenewal == nil {
+		return pc.globalClaims.IsDisableRenewal()
+	}
+	return *pc.DisableRenewal
 }
 
 // Validate validates and modifies the Claims with default values.

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -169,6 +169,12 @@ func (a *Authority) Sign(csr *x509.CertificateRequest, signOpts SignOptions, ext
 // Renew creates a new Certificate identical to the old certificate, except
 // with a validity window that begins 'now'.
 func (a *Authority) Renew(ocx *x509.Certificate) (*x509.Certificate, *x509.Certificate, error) {
+	// Check step provisioner extensions
+	if err := a.authorizeRenewal(ocx); err != nil {
+		return nil, nil, err
+	}
+
+	// Issuer
 	issIdentity := a.intermediateIdentity
 
 	// Convert a realx509.Certificate to the step x509 Certificate.


### PR DESCRIPTION
### Description
This PR adds support for blocking certificate renewals if a provisioner is configured to do this.

A new property `disableRenewal` has been added in provisioner claims that will cause unauthorized errors on `/renew` requests for those certificates created using that provisioner. 