### PR TITLE
Add helpers to add direct support for mTLS.

### DIFF
--- a/examples/bootstrap-mtls-server/server.go
+++ b/examples/bootstrap-mtls-server/server.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/smallstep/certificates/ca"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <token>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	token := os.Args[1]
+
+	// make sure to cancel the renew goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := ca.BootstrapServerWithMTLS(ctx, token, &http.Server{
+		Addr: ":8443",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			name := "nobody"
+			if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+				name = r.TLS.PeerCertificates[0].Subject.CommonName
+			}
+			w.Write([]byte(fmt.Sprintf("Hello %s at %s!!!", name, time.Now().UTC())))
+		}),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Listening on :8443 ...")
+	if err := srv.ListenAndServeTLS("", ""); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
### Description
This PR adds new helpers in the SDK to add direct support for mTLS. It adds a new method Client. GetServerMutualTLSConfig that configures the ClientAuth to tls.RequireAndVerifyClientCert instead of tls.VerifyClientCertIfGiven, and a new function BootstrapServerWithMTLS, that uses the previous function to configure an http.Server.

This PR also adds a new example using BootstrapServerWithMTLS.

Open questions: should we use mTLS by default, and with by default I mean with the shorter/nice function names (BootstrapServer, GetServerTLSConfig)?