### PR TITLE
Force the renew of the CA server.

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -121,6 +121,7 @@ func (ca *CA) Run() error {
 
 // Stop stops the CA calling to the server Shutdown method.
 func (ca *CA) Stop() error {
+	ca.renewer.Stop()
 	return ca.srv.Shutdown()
 }
 
@@ -185,7 +186,7 @@ func (ca *CA) getTLSConfig(auth *authority.Authority) (*tls.Config, error) {
 	// empty we are implicitly forcing GetCertificate to be the only mechanism
 	// by which the server can find it's own leaf Certificate.
 	tlsConfig.Certificates = []tls.Certificate{}
-	tlsConfig.GetCertificate = ca.renewer.GetCertificate
+	tlsConfig.GetCertificate = ca.renewer.GetCertificateForCA
 
 	// Add support for mutual tls to renew certificates
 	tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven

--- a/ca/renew.go
+++ b/ca/renew.go
@@ -14,7 +14,7 @@ import (
 // certificate.
 type RenewFunc func() (*tls.Certificate, error)
 
-// TLSRenewer automatically renews a tls certificate using a give RenewFunc.
+// TLSRenewer automatically renews a tls certificate using a RenewFunc.
 type TLSRenewer struct {
 	sync.RWMutex
 	RenewCertificate RenewFunc


### PR DESCRIPTION
### Description
Force the renew of the CA server cert if it's about to expire. This only happens after a wake up after a hibernation if enough time has passed to expire the certificate.

This PR only solves the problem for the CA server and not server or clients using CA certificates, as those won't be able to use TLS requests with expired certs.