### PR TITLE
SDK should update certificate pools safely

### DIFF
--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -579,7 +579,6 @@ func TestBootstrapListener(t *testing.T) {
 				t.Errorf("BootstrapClient() error = %v", err)
 				return
 			}
-			println("https://" + lis.Addr().String())
 			resp, err := client.Get("https://" + lis.Addr().String())
 			if err != nil {
 				t.Errorf("client.Get() error = %v", err)

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -8,13 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/api"
 	"github.com/smallstep/certificates/authority"
-
 	"github.com/smallstep/cli/crypto/randutil"
 	stepJOSE "github.com/smallstep/cli/jose"
 	jose "gopkg.in/square/go-jose.v2"
@@ -529,4 +529,72 @@ func doReload(ca *CA) error {
 	// Use same address in new server
 	newCA.srv.Addr = ca.srv.Addr
 	return ca.srv.Reload(newCA.srv)
+}
+
+func TestBootstrapListener(t *testing.T) {
+	srv := startCABootstrapServer()
+	defer srv.Close()
+	token := func() string {
+		return generateBootstrapToken(srv.URL, "127.0.0.1", "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7")
+	}
+	type args struct {
+		token string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"ok", args{token()}, false},
+		{"fail", args{"bad-token"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := newLocalListener()
+			defer inner.Close()
+			lis, err := BootstrapListener(context.Background(), tt.args.token, inner)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BootstrapListener() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if lis != nil {
+					t.Errorf("BootstrapListener() = %v, want nil", lis)
+				}
+				return
+			}
+			wg := new(sync.WaitGroup)
+			go func() {
+				wg.Add(1)
+				http.Serve(lis, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Write([]byte("ok"))
+				}))
+				wg.Done()
+			}()
+			defer wg.Wait()
+			defer lis.Close()
+
+			client, err := BootstrapClient(context.Background(), token())
+			if err != nil {
+				t.Errorf("BootstrapClient() error = %v", err)
+				return
+			}
+			println("https://" + lis.Addr().String())
+			resp, err := client.Get("https://" + lis.Addr().String())
+			if err != nil {
+				t.Errorf("client.Get() error = %v", err)
+				return
+			}
+			defer resp.Body.Close()
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("ioutil.ReadAll() error = %v", err)
+				return
+			}
+			if string(b) != "ok" {
+				t.Errorf("client.Get() = %s, want ok", string(b))
+				return
+			}
+		})
+	}
 }

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -363,6 +363,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 
 	// doTest does a request that requires mTLS
 	doTest := func(client *http.Client) error {
+		time.Sleep(1 * time.Second)
 		// test with ca
 		resp, err := client.Post(caURL+"/renew", "application/json", http.NoBody)
 		if err != nil {

--- a/ca/mutable_tls_config.go
+++ b/ca/mutable_tls_config.go
@@ -1,0 +1,109 @@
+package ca
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"sync"
+
+	"github.com/smallstep/certificates/api"
+)
+
+// mutableTLSConfig allows to use a tls.Config with mutable cert pools.
+type mutableTLSConfig struct {
+	sync.RWMutex
+	config         *tls.Config
+	clientCerts    []*x509.Certificate
+	rootCerts      []*x509.Certificate
+	mutClientCerts []*x509.Certificate
+	mutRootCerts   []*x509.Certificate
+}
+
+// newMutableTLSConfig creates a new mutableTLSConfig using the passed one as
+// the base one.
+func newMutableTLSConfig() *mutableTLSConfig {
+	return &mutableTLSConfig{
+		clientCerts:    []*x509.Certificate{},
+		rootCerts:      []*x509.Certificate{},
+		mutClientCerts: []*x509.Certificate{},
+		mutRootCerts:   []*x509.Certificate{},
+	}
+}
+
+// Init initializes the mutable tls.Config with the given tls.Config.
+func (c *mutableTLSConfig) Init(base *tls.Config) {
+	c.Lock()
+	c.config = base.Clone()
+	c.Unlock()
+}
+
+// TLSConfig returns the updated tls.Config it it has changed. It's is used in
+// the tls.Config GetConfigForClient.
+func (c *mutableTLSConfig) TLSConfig() (config *tls.Config) {
+	c.RLock()
+	config = c.config
+	c.RUnlock()
+	return
+}
+
+// Reload reloads the tls.Config with the new CAs.
+func (c *mutableTLSConfig) Reload() {
+	// Prepare new pools
+	c.RLock()
+	rootCAs := x509.NewCertPool()
+	clientCAs := x509.NewCertPool()
+	// Fixed certs
+	for _, cert := range c.rootCerts {
+		rootCAs.AddCert(cert)
+	}
+	for _, cert := range c.clientCerts {
+		clientCAs.AddCert(cert)
+	}
+	// Mutable certs
+	for _, cert := range c.mutRootCerts {
+		rootCAs.AddCert(cert)
+	}
+	for _, cert := range c.mutClientCerts {
+		clientCAs.AddCert(cert)
+	}
+	c.RUnlock()
+
+	// Set new pool
+	c.Lock()
+	c.config.RootCAs = rootCAs
+	c.config.ClientCAs = clientCAs
+	c.mutRootCerts = []*x509.Certificate{}
+	c.mutClientCerts = []*x509.Certificate{}
+	c.Unlock()
+}
+
+// AddFixedClientCACert add an in-mutable cert to ClientCAs.
+func (c *mutableTLSConfig) AddInmutableClientCACert(cert *x509.Certificate) {
+	c.Lock()
+	c.clientCerts = append(c.clientCerts, cert)
+	c.Unlock()
+}
+
+// AddInmutableRootCACert add an in-mutable cert to RootCas.
+func (c *mutableTLSConfig) AddInmutableRootCACert(cert *x509.Certificate) {
+	c.Lock()
+	c.rootCerts = append(c.rootCerts, cert)
+	c.Unlock()
+}
+
+// AddClientCAs add mutable certs to ClientCAs.
+func (c *mutableTLSConfig) AddClientCAs(certs []api.Certificate) {
+	c.Lock()
+	for _, cert := range certs {
+		c.mutClientCerts = append(c.mutClientCerts, cert.Certificate)
+	}
+	c.Unlock()
+}
+
+// AddRootCAs add mutable certs to RootCAs.
+func (c *mutableTLSConfig) AddRootCAs(certs []api.Certificate) {
+	c.Lock()
+	for _, cert := range certs {
+		c.mutRootCerts = append(c.mutRootCerts, cert.Certificate)
+	}
+	c.Unlock()
+}

--- a/ca/mutable_tls_config.go
+++ b/ca/mutable_tls_config.go
@@ -36,8 +36,8 @@ func (c *mutableTLSConfig) Init(base *tls.Config) {
 	c.Unlock()
 }
 
-// TLSConfig returns the updated tls.Config it it has changed. It's is used in
-// the tls.Config GetConfigForClient.
+// TLSConfig returns the updated tls.Config it it has changed. It's used in the
+// tls.Config GetConfigForClient.
 func (c *mutableTLSConfig) TLSConfig() (config *tls.Config) {
 	c.RLock()
 	config = c.config

--- a/ca/mutable_tls_config.go
+++ b/ca/mutable_tls_config.go
@@ -76,14 +76,14 @@ func (c *mutableTLSConfig) Reload() {
 	c.Unlock()
 }
 
-// AddImmutableClientCACert add an in-mutable cert to ClientCAs.
+// AddImmutableClientCACert add an immutable cert to ClientCAs.
 func (c *mutableTLSConfig) AddImmutableClientCACert(cert *x509.Certificate) {
 	c.Lock()
 	c.clientCerts = append(c.clientCerts, cert)
 	c.Unlock()
 }
 
-// AddImmutableRootCACert add an in-mutable cert to RootCas.
+// AddImmutableRootCACert add an immutable cert to RootCas.
 func (c *mutableTLSConfig) AddImmutableRootCACert(cert *x509.Certificate) {
 	c.Lock()
 	c.rootCerts = append(c.rootCerts, cert)

--- a/ca/mutable_tls_config.go
+++ b/ca/mutable_tls_config.go
@@ -18,8 +18,8 @@ type mutableTLSConfig struct {
 	mutRootCerts   []*x509.Certificate
 }
 
-// newMutableTLSConfig creates a new mutableTLSConfig using the passed one as
-// the base one.
+// newMutableTLSConfig creates a new mutableTLSConfig that will be later
+// initialized with a tls.Config.
 func newMutableTLSConfig() *mutableTLSConfig {
 	return &mutableTLSConfig{
 		clientCerts:    []*x509.Certificate{},

--- a/ca/mutable_tls_config.go
+++ b/ca/mutable_tls_config.go
@@ -76,15 +76,15 @@ func (c *mutableTLSConfig) Reload() {
 	c.Unlock()
 }
 
-// AddFixedClientCACert add an in-mutable cert to ClientCAs.
-func (c *mutableTLSConfig) AddInmutableClientCACert(cert *x509.Certificate) {
+// AddImmutableClientCACert add an in-mutable cert to ClientCAs.
+func (c *mutableTLSConfig) AddImmutableClientCACert(cert *x509.Certificate) {
 	c.Lock()
 	c.clientCerts = append(c.clientCerts, cert)
 	c.Unlock()
 }
 
-// AddInmutableRootCACert add an in-mutable cert to RootCas.
-func (c *mutableTLSConfig) AddInmutableRootCACert(cert *x509.Certificate) {
+// AddImmutableRootCACert add an in-mutable cert to RootCas.
+func (c *mutableTLSConfig) AddImmutableRootCACert(cert *x509.Certificate) {
 	c.Lock()
 	c.rootCerts = append(c.rootCerts, cert)
 	c.Unlock()

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -153,7 +153,7 @@ func (c *Client) buildDialTLS(ctx *TLSOptionCtx) func(network, addr string) (net
 // Certificate returns the server or client certificate from the sign response.
 func Certificate(sign *api.SignResponse) (*x509.Certificate, error) {
 	if sign.ServerPEM.Certificate == nil {
-		return nil, errors.New("ca: certificate does not exists")
+		return nil, errors.New("ca: certificate does not exist")
 	}
 	return sign.ServerPEM.Certificate, nil
 }
@@ -162,7 +162,7 @@ func Certificate(sign *api.SignResponse) (*x509.Certificate, error) {
 // response.
 func IntermediateCertificate(sign *api.SignResponse) (*x509.Certificate, error) {
 	if sign.CaPEM.Certificate == nil {
-		return nil, errors.New("ca: certificate does not exists")
+		return nil, errors.New("ca: certificate does not exist")
 	}
 	return sign.CaPEM.Certificate, nil
 }
@@ -170,11 +170,11 @@ func IntermediateCertificate(sign *api.SignResponse) (*x509.Certificate, error) 
 // RootCertificate returns the root certificate from the sign response.
 func RootCertificate(sign *api.SignResponse) (*x509.Certificate, error) {
 	if sign == nil || sign.TLS == nil || len(sign.TLS.VerifiedChains) == 0 {
-		return nil, errors.New("ca: certificate does not exists")
+		return nil, errors.New("ca: certificate does not exist")
 	}
 	lastChain := sign.TLS.VerifiedChains[len(sign.TLS.VerifiedChains)-1]
 	if len(lastChain) == 0 {
-		return nil, errors.New("ca: certificate does not exists")
+		return nil, errors.New("ca: certificate does not exist")
 	}
 	return lastChain[len(lastChain)-1], nil
 }

--- a/ca/tls_options.go
+++ b/ca/tls_options.go
@@ -48,7 +48,7 @@ func (ctx *TLSOptionCtx) apply(options []TLSOption) error {
 				ctx.Config.RootCAs = x509.NewCertPool()
 			}
 			ctx.Config.RootCAs.AddCert(root)
-			ctx.mutableConfig.AddInmutableRootCACert(root)
+			ctx.mutableConfig.AddImmutableRootCACert(root)
 		}
 
 		if !ctx.hasClientCA && ctx.Config.ClientAuth != tls.NoClientCert {
@@ -56,7 +56,7 @@ func (ctx *TLSOptionCtx) apply(options []TLSOption) error {
 				ctx.Config.ClientCAs = x509.NewCertPool()
 			}
 			ctx.Config.ClientCAs.AddCert(root)
-			ctx.mutableConfig.AddInmutableClientCACert(root)
+			ctx.mutableConfig.AddImmutableClientCACert(root)
 		}
 	}
 
@@ -116,7 +116,7 @@ func AddRootCA(cert *x509.Certificate) TLSOption {
 			ctx.Config.RootCAs = x509.NewCertPool()
 		}
 		ctx.Config.RootCAs.AddCert(cert)
-		ctx.mutableConfig.AddInmutableRootCACert(cert)
+		ctx.mutableConfig.AddImmutableRootCACert(cert)
 		return nil
 	}
 }
@@ -130,7 +130,7 @@ func AddClientCA(cert *x509.Certificate) TLSOption {
 			ctx.Config.ClientCAs = x509.NewCertPool()
 		}
 		ctx.Config.ClientCAs.AddCert(cert)
-		ctx.mutableConfig.AddInmutableClientCACert(cert)
+		ctx.mutableConfig.AddImmutableClientCACert(cert)
 		return nil
 	}
 }

--- a/ca/tls_options_test.go
+++ b/ca/tls_options_test.go
@@ -26,7 +26,7 @@ func Test_newTLSOptionCtx(t *testing.T) {
 		args args
 		want *TLSOptionCtx
 	}{
-		{"ok", args{client, &tls.Config{}}, &TLSOptionCtx{Client: client, Config: &tls.Config{}}},
+		{"ok", args{client, &tls.Config{}}, &TLSOptionCtx{Client: client, Config: &tls.Config{}, mutableConfig: newMutableTLSConfig()}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -63,7 +63,8 @@ func TestTLSOptionCtx_apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Config: tt.fields.Config,
+				Config:        tt.fields.Config,
+				mutableConfig: newMutableTLSConfig(),
 			}
 			if err := ctx.apply(tt.args.options); (err != nil) != tt.wantErr {
 				t.Errorf("TLSOptionCtx.apply() error = %v, wantErr %v", err, tt.wantErr)
@@ -82,7 +83,8 @@ func TestRequireAndVerifyClientCert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Config: &tls.Config{},
+				Config:        &tls.Config{},
+				mutableConfig: newMutableTLSConfig(),
 			}
 			if err := RequireAndVerifyClientCert()(ctx); err != nil {
 				t.Errorf("RequireAndVerifyClientCert() error = %v", err)
@@ -105,7 +107,8 @@ func TestVerifyClientCertIfGiven(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Config: &tls.Config{},
+				Config:        &tls.Config{},
+				mutableConfig: newMutableTLSConfig(),
 			}
 			if err := VerifyClientCertIfGiven()(ctx); err != nil {
 				t.Errorf("VerifyClientCertIfGiven() error = %v", err)
@@ -136,7 +139,8 @@ func TestAddRootCA(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Config: &tls.Config{},
+				Config:        &tls.Config{},
+				mutableConfig: newMutableTLSConfig(),
 			}
 			if err := AddRootCA(tt.args.cert)(ctx); err != nil {
 				t.Errorf("AddRootCA() error = %v", err)
@@ -167,7 +171,8 @@ func TestAddClientCA(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Config: &tls.Config{},
+				Config:        &tls.Config{},
+				mutableConfig: newMutableTLSConfig(),
 			}
 			if err := AddClientCA(tt.args.cert)(ctx); err != nil {
 				t.Errorf("AddClientCA() error = %v", err)
@@ -219,13 +224,15 @@ func TestAddRootsToRootCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddRootsToRootCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddRootsToRootCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddRootsToRootCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if !reflect.DeepEqual(ctx.Config, tt.want) {
 				t.Errorf("AddRootsToRootCAs() = %v, want %v", ctx.Config, tt.want)
 			}
@@ -272,10 +279,11 @@ func TestAddRootsToClientCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddRootsToClientCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddRootsToClientCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddRootsToClientCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -332,10 +340,11 @@ func TestAddFederationToRootCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddFederationToRootCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddFederationToRootCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddFederationToRootCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -395,10 +404,11 @@ func TestAddFederationToClientCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddFederationToClientCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddFederationToClientCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddFederationToClientCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -451,10 +461,11 @@ func TestAddRootsToCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddRootsToCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddRootsToCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddRootsToCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -511,10 +522,11 @@ func TestAddFederationToCAs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &TLSOptionCtx{
-				Client: tt.args.client,
-				Config: tt.args.config,
+				Client:        tt.args.client,
+				Config:        tt.args.config,
+				mutableConfig: newMutableTLSConfig(),
 			}
-			if err := AddFederationToCAs()(ctx); (err != nil) != tt.wantErr {
+			if err := ctx.apply([]TLSOption{AddFederationToCAs()}); (err != nil) != tt.wantErr {
 				t.Errorf("AddFederationToCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/ca/tls_options_test.go
+++ b/ca/tls_options_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/smallstep/certificates/api"
 )
 
 func Test_newTLSOptionCtx(t *testing.T) {
@@ -20,17 +22,18 @@ func Test_newTLSOptionCtx(t *testing.T) {
 	type args struct {
 		c      *Client
 		config *tls.Config
+		sign   *api.SignResponse
 	}
 	tests := []struct {
 		name string
 		args args
 		want *TLSOptionCtx
 	}{
-		{"ok", args{client, &tls.Config{}}, &TLSOptionCtx{Client: client, Config: &tls.Config{}, mutableConfig: newMutableTLSConfig()}},
+		{"ok", args{client, &tls.Config{}, &api.SignResponse{}}, &TLSOptionCtx{Client: client, Config: &tls.Config{}, Sign: &api.SignResponse{}, mutableConfig: newMutableTLSConfig()}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newTLSOptionCtx(tt.args.c, tt.args.config); !reflect.DeepEqual(got, tt.want) {
+			if got := newTLSOptionCtx(tt.args.c, tt.args.config, tt.args.sign); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newTLSOptionCtx() = %v, want %v", got, tt.want)
 			}
 		})
@@ -232,8 +235,7 @@ func TestAddRootsToRootCAs(t *testing.T) {
 				t.Errorf("AddRootsToRootCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
-			if !reflect.DeepEqual(ctx.Config, tt.want) {
+			if !reflect.DeepEqual(ctx.Config.RootCAs, tt.want.RootCAs) {
 				t.Errorf("AddRootsToRootCAs() = %v, want %v", ctx.Config, tt.want)
 			}
 		})
@@ -287,7 +289,7 @@ func TestAddRootsToClientCAs(t *testing.T) {
 				t.Errorf("AddRootsToClientCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(ctx.Config, tt.want) {
+			if !reflect.DeepEqual(ctx.Config.ClientCAs, tt.want.ClientCAs) {
 				t.Errorf("AddRootsToClientCAs() = %v, want %v", ctx.Config, tt.want)
 			}
 		})
@@ -469,7 +471,7 @@ func TestAddRootsToCAs(t *testing.T) {
 				t.Errorf("AddRootsToCAs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(ctx.Config, tt.want) {
+			if !reflect.DeepEqual(ctx.Config.RootCAs, tt.want.RootCAs) || !reflect.DeepEqual(ctx.Config.ClientCAs, tt.want.ClientCAs) {
 				t.Errorf("AddRootsToCAs() = %v, want %v", ctx.Config, tt.want)
 			}
 		})


### PR DESCRIPTION
### Description
Certificate pools should be safely updated when root or federation certificates are rotated. A server uses `tls.Config.GetConfigForClient` to provide the refreshed version of the tls.Config while clients use a custom http.Transport.DialTLS that uses the refreshed tls.Config. Fixes #23

This PR also adds the method `BootstrapListener` that creates a `net.Listener` configured with the TLS certificate provided by the CA