### PR TITLE
authority/provisioners: fix overflow on 32-bit systems

### DIFF
--- a/authority/provisioners.go
+++ b/authority/provisioners.go
@@ -49,7 +49,7 @@ type uidProvisioner struct {
 }
 
 func newSortedProvisioners(provisioners []*Provisioner) (provisionerSlice, error) {
-	if len(provisioners) > math.MaxUint32 {
+	if len(provisioners) > math.MaxInt32 {
 		return nil, errors.New("too many provisioners")
 	}
 


### PR DESCRIPTION
In Go, len returns signed ints, not unsigned ints; consequently, this code
comparison overflows on 32-bit systems, like ARM.