### PR TITLE
Do not allow pods in one namespace to create certificates for hostnames from another namespace.

### DIFF
--- a/autocert/controller/main.go
+++ b/autocert/controller/main.go
@@ -55,6 +55,8 @@ type Config struct {
 	ClusterDomain                   string           `yaml:"clusterDomain"`
 }
 
+// GetClusterDomain returns the Kubernetes cluster domain, defaults to
+// "cluster.local" if not specified in the configuration.
 func (c Config) GetClusterDomain() string {
 	if c.ClusterDomain != "" {
 		return c.ClusterDomain
@@ -409,7 +411,7 @@ func shouldMutate(metadata *metav1.ObjectMeta, namespace string, clusterDomain s
 
 	subject := strings.Trim(annotations[admissionWebhookAnnotationKey], ".")
 
-	err := fmt.Errorf("Subject \"%s\" matches a namespace other than \"%s\" and is not permitted. This check can be disabled by setting restrictCertificatesToNamespace to false in the autocert-config ConfigMap.", subject, namespace)
+	err := fmt.Errorf("subject \"%s\" matches a namespace other than \"%s\" and is not permitted. This check can be disabled by setting restrictCertificatesToNamespace to false in the autocert-config ConfigMap", subject, namespace)
 
 	if strings.HasSuffix(subject, ".svc") && !strings.HasSuffix(subject, fmt.Sprintf(".%s.svc", namespace)) {
 		return false, err

--- a/autocert/controller/main_test.go
+++ b/autocert/controller/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestShouldMutate(t *testing.T) {
+	testCases := []struct {
+		description string
+		subject string
+		namespace string
+		expected bool
+	} {
+		{ "full cluster domain", "test.default.svc.cluster.local", "default", true },
+		{ "full cluster domain wrong ns", "test.default.svc.cluster.local", "kube-system", false },
+		{ "left dots get stripped", ".test.default.svc.cluster.local", "default", true },
+		{ "left dots get stripped wrong ns", ".test.default.svc.cluster.local", "kube-system", false },
+		{ "right dots get stripped", "test.default.svc.cluster.local.", "default", true },
+		{ "right dots get stripped wrong ns", "test.default.svc.cluster.local.", "kube-system", false },
+		{ "dots get stripped", ".test.default.svc.cluster.local.", "default", true },
+		{ "dots get stripped wrong ns", ".test.default.svc.cluster.local.", "kube-system", false },
+		{ "cluster domain", "test.default.svc.cluster", "default", true },
+		{ "cluster domain wrong ns", "test.default.svc.cluster", "kube-system", false },
+		{ "service domain", "test.default.svc", "default", true },
+		{ "service domain wrong ns", "test.default.svc", "kube-system", false },
+		{ "two part domain", "test.default", "default", true },
+		{ "two part domain different ns", "test.default", "kube-system", true },
+		{ "one hostname", "test", "default", true },
+		{ "no subject specified", "", "default", false },
+		{ "three part not cluster", "test.default.com", "kube-system", true },
+		{ "four part not cluster", "test.default.svc.com", "kube-system", true },
+		{ "five part not cluster", "test.default.svc.cluster.com", "kube-system", true },
+		{ "six part not cluster", "test.default.svc.cluster.local.com", "kube-system", true },
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			if shouldMutate(&metav1.ObjectMeta{
+				Annotations: map[string]string{
+					admissionWebhookAnnotationKey: testCase.subject,
+				},
+			}, testCase.namespace) != testCase.expected {
+				t.Errorf("shouldMutate did not return %t for %s", testCase.expected, testCase.description)
+			}
+		})
+	}
+}

--- a/autocert/controller/main_test.go
+++ b/autocert/controller/main_test.go
@@ -5,33 +5,45 @@ import (
 	"testing"
 )
 
+func TestGetClusterDomain(t *testing.T) {
+	c := Config{}
+	if c.GetClusterDomain() != "cluster.local" {
+		t.Errorf("cluster domain should default to cluster.local, not: %s", c.GetClusterDomain())
+	}
+
+	c.ClusterDomain = "mydomain.com"
+	if c.GetClusterDomain() != "mydomain.com" {
+		t.Errorf("cluster domain should default to cluster.local, not: %s", c.GetClusterDomain())
+	}
+}
+
 func TestShouldMutate(t *testing.T) {
 	testCases := []struct {
 		description string
-		subject string
-		namespace string
-		expected bool
-	} {
-		{ "full cluster domain", "test.default.svc.cluster.local", "default", true },
-		{ "full cluster domain wrong ns", "test.default.svc.cluster.local", "kube-system", false },
-		{ "left dots get stripped", ".test.default.svc.cluster.local", "default", true },
-		{ "left dots get stripped wrong ns", ".test.default.svc.cluster.local", "kube-system", false },
-		{ "right dots get stripped", "test.default.svc.cluster.local.", "default", true },
-		{ "right dots get stripped wrong ns", "test.default.svc.cluster.local.", "kube-system", false },
-		{ "dots get stripped", ".test.default.svc.cluster.local.", "default", true },
-		{ "dots get stripped wrong ns", ".test.default.svc.cluster.local.", "kube-system", false },
-		{ "cluster domain", "test.default.svc.cluster", "default", true },
-		{ "cluster domain wrong ns", "test.default.svc.cluster", "kube-system", false },
-		{ "service domain", "test.default.svc", "default", true },
-		{ "service domain wrong ns", "test.default.svc", "kube-system", false },
-		{ "two part domain", "test.default", "default", true },
-		{ "two part domain different ns", "test.default", "kube-system", true },
-		{ "one hostname", "test", "default", true },
-		{ "no subject specified", "", "default", false },
-		{ "three part not cluster", "test.default.com", "kube-system", true },
-		{ "four part not cluster", "test.default.svc.com", "kube-system", true },
-		{ "five part not cluster", "test.default.svc.cluster.com", "kube-system", true },
-		{ "six part not cluster", "test.default.svc.cluster.local.com", "kube-system", true },
+		subject     string
+		namespace   string
+		expected    bool
+	}{
+		{"full cluster domain", "test.default.svc.cluster.local", "default", true},
+		{"full cluster domain wrong ns", "test.default.svc.cluster.local", "kube-system", false},
+		{"left dots get stripped", ".test.default.svc.cluster.local", "default", true},
+		{"left dots get stripped wrong ns", ".test.default.svc.cluster.local", "kube-system", false},
+		{"right dots get stripped", "test.default.svc.cluster.local.", "default", true},
+		{"right dots get stripped wrong ns", "test.default.svc.cluster.local.", "kube-system", false},
+		{"dots get stripped", ".test.default.svc.cluster.local.", "default", true},
+		{"dots get stripped wrong ns", ".test.default.svc.cluster.local.", "kube-system", false},
+		{"partial cluster domain", "test.default.svc.cluster", "default", true},
+		{"partial cluster domain wrong ns is still allowed because not valid hostname", "test.default.svc.cluster", "kube-system", true},
+		{"service domain", "test.default.svc", "default", true},
+		{"service domain wrong ns", "test.default.svc", "kube-system", false},
+		{"two part domain", "test.default", "default", true},
+		{"two part domain different ns", "test.default", "kube-system", true},
+		{"one hostname", "test", "default", true},
+		{"no subject specified", "", "default", false},
+		{"three part not cluster", "test.default.com", "kube-system", true},
+		{"four part not cluster", "test.default.svc.com", "kube-system", true},
+		{"five part not cluster", "test.default.svc.cluster.com", "kube-system", true},
+		{"six part not cluster", "test.default.svc.cluster.local.com", "kube-system", true},
 	}
 
 	for _, testCase := range testCases {
@@ -40,9 +52,19 @@ func TestShouldMutate(t *testing.T) {
 				Annotations: map[string]string{
 					admissionWebhookAnnotationKey: testCase.subject,
 				},
-			}, testCase.namespace) != testCase.expected {
+			}, testCase.namespace, "cluster.local", true) != testCase.expected {
 				t.Errorf("shouldMutate did not return %t for %s", testCase.expected, testCase.description)
 			}
 		})
+	}
+}
+
+func TestShouldMutateNotRestrictToNamespace(t *testing.T) {
+	if shouldMutate(&metav1.ObjectMeta{
+		Annotations: map[string]string{
+			admissionWebhookAnnotationKey: "test.default.svc.cluster.local",
+		},
+	}, "kube-system", "cluster.local", false) == false {
+		t.Errorf("shouldMutate should return true even with a wrong namespace if restrictToNamespace is false.")
 	}
 }

--- a/autocert/install/02-autocert.yaml
+++ b/autocert/install/02-autocert.yaml
@@ -21,6 +21,8 @@ metadata:
 data:
   config.yaml: |
     logFormat: json # or text
+    restrictCertificatesToNamespace: true
+    clusterDomain: cluster.local
     caUrl: https://ca.step.svc.cluster.local
     certLifetime: 24h
     renewer:


### PR DESCRIPTION
I would like to prevent pods in one namespace from minting certificates for another namespace.

This seems like a decent approach, but thought I'd open the PR to get feedback.