### PR TITLE
Update go jose

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,8 +276,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:8b36444f30009b5e124a3ac48b353558024a95c3fccdf3e6bb557a091e67342b"
+  branch = "update-go-jose"
+  digest = "1:253eec7c89c6fe08ae020877b0b44343e86da68dac99207280e7ddcacd441f1f"
   name = "github.com/smallstep/cli"
   packages = [
     "command",
@@ -298,7 +298,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "3e1e2dcfa54298e0fb86e0be86ab36d79f36473e"
+  revision = "2d5a5c509e72613d59349bee8638047877b3b2a0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -460,7 +460,7 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:7fbe10f3790dc4e6296c7c844c5a9b35513e5521c29c47e10ba99cd2956a2719"
+  digest = "1:005cbf8b937fcb1694b9dbb845b0aef618627be7faf7bb330eb2490e3f506ef8"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -469,8 +469,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "ef984e69dd356202fd4e4910d4d9c24468bdf0b8"
-  version = "v2.1.9"
+  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
+  version = "v2.3.0"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,7 +298,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "2d5a5c509e72613d59349bee8638047877b3b2a0"
+  revision = "b0dd6172f37a12153084edbd170ae95dd35ef9a8"
 
 [[projects]]
   branch = "master"
@@ -460,7 +460,8 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:005cbf8b937fcb1694b9dbb845b0aef618627be7faf7bb330eb2490e3f506ef8"
+  branch = "v2"
+  digest = "1:9593bab40e981b1f90b7e07faeab0d09b75fe338880d08880f986a9d3283c53f"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -469,8 +470,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
-  version = "v2.3.0"
+  revision = "fd0b35a2f1ec103c6bb76cc6d4b8077fa5844fb2"
+  source = "github.com/maraino/go-jose"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,4 +62,7 @@ required = [
 
 [[constraint]]
   name = "gopkg.in/square/go-jose.v2"
-  version = "2.1.9"
+  # version = "2.3.0"
+  # Using special branch with ed25519 fix
+  source = "github.com/maraino/go-jose"
+  branch = "v2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,7 +45,7 @@ required = [
   name = "github.com/go-chi/chi"
 
 [[override]]
-  branch = "master"
+  branch = "update-go-jose"
   name = "github.com/smallstep/cli"
 
 [prune]

--- a/authority/authorize.go
+++ b/authority/authorize.go
@@ -47,7 +47,7 @@ func (a *Authority) Authorize(ott string) ([]provisioner.SignOption, error) {
 	// Do not accept tokens issued before the start of the ca.
 	// This check is meant as a stopgap solution to the current lack of a persistence layer.
 	if a.config.AuthorityConfig != nil && !a.config.AuthorityConfig.DisableIssuedAtCheck {
-		if claims.IssuedAt > 0 && claims.IssuedAt.Time().Before(a.startTime) {
+		if claims.IssuedAt != nil && claims.IssuedAt.Time().Before(a.startTime) {
 			return nil, &apiError{errors.New("authorize: token issued before the bootstrap of certificate authority"),
 				http.StatusUnauthorized, errContext}
 		}


### PR DESCRIPTION
### Description
This PR adapts certificates code to go-jose@2.3.0, claims `iat`, `nbf`, and `exp` are now pointers instead of values. 

~This PR won't be merged until square/go-jose#224 gets merged~. Instead of waiting for the merge we are using our fork.

Related to smallstep/cli#105