### PR TITLE
Flip default for certificate restriction to namespace to false

### DIFF
--- a/autocert/install/02-autocert.yaml
+++ b/autocert/install/02-autocert.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   config.yaml: |
     logFormat: json # or text
-    restrictCertificatesToNamespace: true
+    restrictCertificatesToNamespace: false
     clusterDomain: cluster.local
     caUrl: https://ca.step.svc.cluster.local
     certLifetime: 24h


### PR DESCRIPTION
### Description
Change default to false until we have more elaborate documentation plus verification hook to bubble errors up to kubectl.

Consider switching default back on once these issues are resolved:
* https://github.com/smallstep/certificates/issues/61
* https://github.com/smallstep/certificates/issues/62