### PR TITLE
Truncate to seconds ValidAfter

### DIFF
--- a/authority/provisioner/sign_ssh_options.go
+++ b/authority/provisioner/sign_ssh_options.go
@@ -216,7 +216,7 @@ func (m *sshCertificateValidityModifier) Modify(cert *ssh.Certificate) error {
 	}
 
 	if cert.ValidAfter == 0 {
-		cert.ValidAfter = uint64(now().Add(-1 * time.Minute).Unix())
+		cert.ValidAfter = uint64(now().Truncate(time.Second).Unix())
 	}
 	if cert.ValidBefore == 0 {
 		t := time.Unix(int64(cert.ValidAfter), 0)

--- a/authority/provisioner/sign_ssh_options.go
+++ b/authority/provisioner/sign_ssh_options.go
@@ -216,7 +216,7 @@ func (m *sshCertificateValidityModifier) Modify(cert *ssh.Certificate) error {
 	}
 
 	if cert.ValidAfter == 0 {
-		cert.ValidAfter = uint64(now().Unix())
+		cert.ValidAfter = uint64(now().Add(-1 * time.Minute).Unix())
 	}
 	if cert.ValidBefore == 0 {
 		t := time.Unix(int64(cert.ValidAfter), 0)


### PR DESCRIPTION
### Description
This PR truncate to seconds ValidAfter if it's generated in step-certificates. Truncating avoids that the certs are not yet valid if they are immediately used.