### PR TITLE
Create ACME database tables when initializing ACME autority.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -233,7 +233,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7d03323edb817ca94efaee5489cde6acd06ceeaca9e6eee106d2d6a90deca997"
+  digest = "1:b232e9d74b340b03395b935562aac1ca13ea2704f37372863a210ffd0b89efca"
   name = "github.com/smallstep/nosql"
   packages = [
     ".",
@@ -243,7 +243,7 @@
     "mysql",
   ]
   pruneopts = "UT"
-  revision = "f80b3f432de0662f07ebd58fe52b0a119fe5dcd9"
+  revision = "4b26d8029e613d7ad3e77c9718f9e8e37ab48ddb"
 
 [[projects]]
   branch = "master"

--- a/acme/api/handler_test.go
+++ b/acme/api/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smallstep/assert"
 	"github.com/smallstep/certificates/acme"
 	"github.com/smallstep/certificates/authority/provisioner"
+	"github.com/smallstep/certificates/db"
 	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/jose"
 )
@@ -230,7 +231,8 @@ func TestHandlerGetNonce(t *testing.T) {
 }
 
 func TestHandlerGetDirectory(t *testing.T) {
-	auth := acme.NewAuthority(nil, "ca.smallstep.com", "acme", nil)
+	auth, err := acme.NewAuthority(new(db.MockNoSQLDB), "ca.smallstep.com", "acme", nil)
+	assert.FatalError(t, err)
 	prov := newProv()
 	url := fmt.Sprintf("http://ca.smallstep.com/acme/%s/directory", acme.URLSafeProvisionerName(prov))
 

--- a/acme/common.go
+++ b/acme/common.go
@@ -23,17 +23,6 @@ type Identifier struct {
 }
 
 var (
-	accountTable           = []byte("acme-accounts")
-	accountByKeyIDTable    = []byte("acme-keyID-accountID-index")
-	authzTable             = []byte("acme-authzs")
-	challengeTable         = []byte("acme-challenges")
-	nonceTable             = []byte("nonce-table")
-	orderTable             = []byte("acme-orders")
-	ordersByAccountIDTable = []byte("acme-account-orders-index")
-	certTable              = []byte("acme-certs")
-)
-
-var (
 	// StatusValid -- valid
 	StatusValid = "valid"
 	// StatusInvalid -- invalid

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -124,7 +124,10 @@ func (ca *CA) Init(config *authority.Config) (*CA, error) {
 	}
 
 	prefix := "acme"
-	acmeAuth := acme.NewAuthority(auth.GetDatabase().(nosql.DB), dns, prefix, auth)
+	acmeAuth, err := acme.NewAuthority(auth.GetDatabase().(nosql.DB), dns, prefix, auth)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating ACME authority")
+	}
 	acmeRouterHandler := acmeAPI.New(acmeAuth)
 	mux.Route("/"+prefix, func(r chi.Router) {
 		acmeRouterHandler.Route(r)


### PR DESCRIPTION
@maraino Thoughts on making this change? Didn't realize that `-`s were special / illegal characters in table names. This change won't break existing operation, but people using the badger DB will have a bunch of "tables" (really just keys) that won't be used anymore.
