### PR TITLE
Perform domain normalization for wildcard domains

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -385,11 +385,21 @@ func (dc *dns01Challenge) validate(db nosql.DB, jwk *jose.JSONWebKey, vo validat
 		return dc, nil
 	}
 
-	txtRecords, err := vo.lookupTxt("_acme-challenge." + dc.Value)
+	// Normalize domain for wildcard DNS names
+	// This is done to avoid making TXT lookups for domains like
+	// _acme-challenge.*.example.com
+	// Instead perform txt lookup for _acme-challenge.example.com
+	domain := dc.Value
+	if strings.HasPrefix(domain, "*") {
+		domain = strings.TrimPrefix(domain, "*.")
+	}
+
+	txtRecords, err := vo.lookupTxt("_acme-challenge." + domain)
+	fmt.Printf("Lookup TXT for _acme-challenge." + domain)
 	if err != nil {
 		if err = dc.storeError(db,
 			DNSErr(errors.Wrapf(err, "error looking up TXT "+
-				"records for domain %s", dc.Value))); err != nil {
+				"records for domain %s", domain))); err != nil {
 			return nil, err
 		}
 		return dc, nil

--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -395,7 +395,6 @@ func (dc *dns01Challenge) validate(db nosql.DB, jwk *jose.JSONWebKey, vo validat
 	}
 
 	txtRecords, err := vo.lookupTxt("_acme-challenge." + domain)
-	fmt.Printf("Lookup TXT for _acme-challenge." + domain)
 	if err != nil {
 		if err = dc.storeError(db,
 			DNSErr(errors.Wrapf(err, "error looking up TXT "+


### PR DESCRIPTION
### Description

Perform domain normalization for wildcard domains, so we do query
TXT records for _acme-challenge.example.domain instead of
_acme-challenge.*.example.domain when performing DNS-01 challenge. In
this way the behavior is consistent with letsencrypt and records queried
are in sync with the ones that are shown in certbot manual mode.