### PR TITLE
Backdate

### DIFF
--- a/authority/config.go
+++ b/authority/config.go
@@ -28,6 +28,7 @@ var (
 		MaxVersion:    1.2,
 		Renegotiation: false,
 	}
+	defaultBackdate         = time.Minute
 	defaultDisableRenewal   = false
 	defaultEnableSSHCA      = false
 	globalProvisionerClaims = provisioner.Claims{
@@ -65,10 +66,11 @@ type Config struct {
 
 // AuthConfig represents the configuration options for the authority.
 type AuthConfig struct {
-	Provisioners         provisioner.List    `json:"provisioners"`
-	Template             *x509util.ASN1DN    `json:"template,omitempty"`
-	Claims               *provisioner.Claims `json:"claims,omitempty"`
-	DisableIssuedAtCheck bool                `json:"disableIssuedAtCheck,omitempty"`
+	Provisioners         provisioner.List      `json:"provisioners"`
+	Template             *x509util.ASN1DN      `json:"template,omitempty"`
+	Claims               *provisioner.Claims   `json:"claims,omitempty"`
+	DisableIssuedAtCheck bool                  `json:"disableIssuedAtCheck,omitempty"`
+	Backdate             *provisioner.Duration `json:"backdate,omitempty"`
 }
 
 // Validate validates the authority configuration.
@@ -91,6 +93,17 @@ func (c *AuthConfig) Validate(audiences provisioner.Audiences) error {
 	if c.Template == nil {
 		c.Template = &x509util.ASN1DN{}
 	}
+
+	if c.Backdate != nil {
+		if c.Backdate.Duration < 0 {
+			return errors.New("authority.backdate cannot be less than 0")
+		}
+	} else {
+		c.Backdate = &provisioner.Duration{
+			Duration: defaultBackdate,
+		}
+	}
+
 	return nil
 }
 

--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -469,7 +469,7 @@ func (p *AWS) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 		// Set the default extensions.
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(p.claimer),
+		&sshDefaultDuration{p.claimer},
 		// Validate public key
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -209,7 +209,7 @@ func (p *Azure) Init(config Config) (err error) {
 	return nil
 }
 
-// parseToken returuns the claims, name, group, error.
+// parseToken returns the claims, name, group, error.
 func (p *Azure) parseToken(token string) (*azurePayload, string, string, error) {
 	jwt, err := jose.ParseSigned(token)
 	if err != nil {
@@ -335,7 +335,7 @@ func (p *Azure) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOptio
 		// Set the default extensions.
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(p.claimer),
+		&sshDefaultDuration{p.claimer},
 		// Validate public key
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.

--- a/authority/provisioner/claims.go
+++ b/authority/provisioner/claims.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
 )
 
 // Claims so that individual provisioners can override global claims.
@@ -93,6 +94,21 @@ func (c *Claimer) IsDisableRenewal() bool {
 		return *c.global.DisableRenewal
 	}
 	return *c.claims.DisableRenewal
+}
+
+// DefaultSSHCertDuration returns the default SSH certificate duration for the
+// given certificate type.
+func (c *Claimer) DefaultSSHCertDuration(certType uint32) (time.Duration, error) {
+	switch certType {
+	case ssh.UserCert:
+		return c.DefaultUserSSHCertDuration(), nil
+	case ssh.HostCert:
+		return c.DefaultHostSSHCertDuration(), nil
+	case 0:
+		return 0, errors.New("ssh certificate type has not been set")
+	default:
+		return 0, errors.Errorf("ssh certificate has an unknown type: %d", certType)
+	}
 }
 
 // DefaultUserSSHCertDuration returns the default SSH user cert duration for the

--- a/authority/provisioner/claims_test.go
+++ b/authority/provisioner/claims_test.go
@@ -1,0 +1,51 @@
+package provisioner
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestClaimer_DefaultSSHCertDuration(t *testing.T) {
+	duration := Duration{
+		Duration: time.Hour,
+	}
+	type fields struct {
+		global Claims
+		claims *Claims
+	}
+	type args struct {
+		certType uint32
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    time.Duration
+		wantErr bool
+	}{
+		{"user", fields{globalProvisionerClaims, &Claims{DefaultUserSSHDur: &duration}}, args{1}, time.Hour, false},
+		{"user global", fields{globalProvisionerClaims, nil}, args{ssh.UserCert}, 16 * time.Hour, false},
+		{"host global", fields{globalProvisionerClaims, &Claims{DefaultHostSSHDur: &duration}}, args{2}, time.Hour, false},
+		{"host global", fields{globalProvisionerClaims, nil}, args{ssh.HostCert}, 30 * 24 * time.Hour, false},
+		{"invalid", fields{globalProvisionerClaims, nil}, args{0}, 0, true},
+		{"invalid global", fields{globalProvisionerClaims, nil}, args{3}, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Claimer{
+				global: tt.fields.global,
+				claims: tt.fields.claims,
+			}
+			got, err := c.DefaultSSHCertDuration(tt.args.certType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Claimer.DefaultSSHCertDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Claimer.DefaultSSHCertDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -378,7 +378,7 @@ func (p *GCP) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 		// Set the default extensions
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(p.claimer),
+		&sshDefaultDuration{p.claimer},
 		// Validate public key
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.

--- a/authority/provisioner/jwk.go
+++ b/authority/provisioner/jwk.go
@@ -188,6 +188,7 @@ func (p *JWK) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	if claims.Step == nil || claims.Step.SSH == nil {
 		return nil, errors.New("authorization token must be an SSH provisioning token")
 	}
+
 	opts := claims.Step.SSH
 	signOptions := []SignOption{
 		// validates user's SSHOptions with the ones in the token
@@ -222,7 +223,7 @@ func (p *JWK) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 		// Set the default extensions.
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(p.claimer),
+		&sshDefaultDuration{p.claimer},
 		// Validate that the keyID is equivalent to the token subject.
 		sshCertKeyIDValidator(claims.Subject),
 		// Validate public key

--- a/authority/provisioner/k8sSA.go
+++ b/authority/provisioner/k8sSA.go
@@ -235,13 +235,15 @@ func (p *K8sSA) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOptio
 	}
 
 	// Default to a user certificate with no principals if not set
-	signOptions := []SignOption{sshCertificateDefaultsModifier{CertType: SSHUserCert}}
+	signOptions := []SignOption{
+		sshCertificateDefaultsModifier{CertType: SSHUserCert},
+	}
 
 	return append(signOptions,
 		// Set the default extensions.
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(p.claimer),
+		&sshDefaultDuration{p.claimer},
 		// Validate public key
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -360,7 +360,7 @@ func (o *OIDC) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption
 		// Set the default extensions
 		&sshDefaultExtensionModifier{},
 		// Set the validity bounds if not set.
-		sshDefaultValidityModifier(o.claimer),
+		&sshDefaultDuration{o.claimer},
 		// Validate public key
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -194,7 +194,7 @@ func (v profileDefaultDuration) Option(so Options) x509util.WithOption {
 	var backdate time.Duration
 	notBefore := so.NotBefore.Time()
 	if notBefore.IsZero() {
-		notBefore = time.Now()
+		notBefore = now()
 		backdate = -1 * so.Backdate
 	}
 	notAfter := so.NotAfter.RelativeTime(notBefore)

--- a/authority/provisioner/sign_options_test.go
+++ b/authority/provisioner/sign_options_test.go
@@ -390,7 +390,7 @@ func Test_profileDefaultDuration_Option(t *testing.T) {
 
 			fn := tt.v.Option(tt.args.so)
 			if err := fn(profile); err != nil {
-				t.Errorf("profileDefaultDuration.Option() error %v", err)
+				t.Errorf("profileDefaultDuration.Option() error = %v", err)
 			}
 			if !reflect.DeepEqual(cert, tt.want) {
 				t.Errorf("profileDefaultDuration.Option() = %v, \nwant %v", cert, tt.want)

--- a/authority/provisioner/sign_ssh_options.go
+++ b/authority/provisioner/sign_ssh_options.go
@@ -276,7 +276,6 @@ func (m *sshLimitDuration) Option(o SSHOptions) SSHCertificateModifier {
 			certValidBefore := certValidAfter.Add(d)
 			if m.NotAfter.Before(certValidBefore) {
 				certValidBefore = m.NotAfter
-				println(2, certValidBefore.String())
 			}
 			cert.ValidBefore = uint64(certValidBefore.Unix())
 		} else {

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -31,7 +31,7 @@ var (
 		DisableRenewal:    &defaultDisableRenewal,
 		MinUserSSHDur:     &Duration{Duration: 5 * time.Minute}, // User SSH certs
 		MaxUserSSHDur:     &Duration{Duration: 24 * time.Hour},
-		DefaultUserSSHDur: &Duration{Duration: 4 * time.Hour},
+		DefaultUserSSHDur: &Duration{Duration: 16 * time.Hour},
 		MinHostSSHDur:     &Duration{Duration: 5 * time.Minute}, // Host SSH certs
 		MaxHostSSHDur:     &Duration{Duration: 30 * 24 * time.Hour},
 		DefaultHostSSHDur: &Duration{Duration: 30 * 24 * time.Hour},

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -228,6 +228,7 @@ func (p *X5C) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	if claims.Step == nil || claims.Step.SSH == nil {
 		return nil, errors.New("authorization token must be an SSH provisioning token")
 	}
+
 	opts := claims.Step.SSH
 	signOptions := []SignOption{
 		// validates user's SSHOptions with the ones in the token
@@ -261,7 +262,7 @@ func (p *X5C) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 		// Set the default extensions.
 		&sshDefaultExtensionModifier{},
 		// Checks the validity bounds, and set the validity if has not been set.
-		sshLimitValidityModifier(p.claimer, claims.chains[0][0].NotAfter),
+		&sshLimitDuration{p.claimer, claims.chains[0][0].NotAfter},
 		// set the key id to the token subject
 		sshCertKeyIDValidator(claims.Subject),
 		// Validate public key.

--- a/authority/provisioner/x5c_test.go
+++ b/authority/provisioner/x5c_test.go
@@ -646,9 +646,9 @@ func TestX5C_AuthorizeSSHSign(t *testing.T) {
 								assert.Equals(t, int64(v), tc.claims.Step.SSH.ValidBefore.RelativeTime(nw).Unix())
 							case sshCertificateDefaultsModifier:
 								assert.Equals(t, SSHOptions(v), SSHOptions{CertType: SSHUserCert})
-							case *sshValidityModifier:
+							case *sshLimitDuration:
 								assert.Equals(t, v.Claimer, tc.p.claimer)
-								assert.Equals(t, v.validBefore, tc.claims.chains[0][0].NotAfter)
+								assert.Equals(t, v.NotAfter, tc.claims.chains[0][0].NotAfter)
 							case *sshCertificateValidityValidator:
 								assert.Equals(t, v.Claimer, tc.p.claimer)
 							case *sshDefaultExtensionModifier, *sshDefaultPublicKeyValidator,

--- a/authority/ssh.go
+++ b/authority/ssh.go
@@ -496,9 +496,12 @@ func (a *Authority) RekeySSH(oldCert *ssh.Certificate, pub ssh.PublicKey, signOp
 	if oldCert.ValidAfter == 0 || oldCert.ValidBefore == 0 {
 		return nil, errors.New("rekeySSH: cannot rekey certificate without validity period")
 	}
-	dur := time.Duration(oldCert.ValidBefore-oldCert.ValidAfter) * time.Second
-	va := time.Now()
-	vb := va.Add(dur)
+
+	backdate := a.config.AuthorityConfig.Backdate.Duration
+	duration := time.Duration(oldCert.ValidBefore-oldCert.ValidAfter) * time.Second
+	now := time.Now()
+	va := now.Add(-1 * backdate)
+	vb := now.Add(duration - backdate)
 
 	// Build base certificate with the key and some random values
 	cert := &ssh.Certificate{

--- a/ca/client_test.go
+++ b/ca/client_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smallstep/certificates/errs"
+
 	"github.com/smallstep/assert"
 	"github.com/smallstep/certificates/api"
 	"github.com/smallstep/certificates/authority"
@@ -152,8 +154,8 @@ func equalJSON(t *testing.T, a interface{}, b interface{}) bool {
 
 func TestClient_Version(t *testing.T) {
 	ok := &api.VersionResponse{Version: "test"}
-	internal := api.InternalServerError(fmt.Errorf("Internal Server Error"))
-	notFound := api.NotFound(fmt.Errorf("Not Found"))
+	internal := errs.InternalServerError(fmt.Errorf("Internal Server Error"))
+	notFound := errs.NotFound(fmt.Errorf("Not Found"))
 
 	tests := []struct {
 		name         string
@@ -207,7 +209,7 @@ func TestClient_Version(t *testing.T) {
 
 func TestClient_Health(t *testing.T) {
 	ok := &api.HealthResponse{Status: "ok"}
-	nok := api.InternalServerError(fmt.Errorf("Internal Server Error"))
+	nok := errs.InternalServerError(fmt.Errorf("Internal Server Error"))
 
 	tests := []struct {
 		name         string
@@ -262,7 +264,7 @@ func TestClient_Root(t *testing.T) {
 	ok := &api.RootResponse{
 		RootPEM: api.Certificate{Certificate: parseCertificate(rootPEM)},
 	}
-	notFound := api.NotFound(fmt.Errorf("Not Found"))
+	notFound := errs.NotFound(fmt.Errorf("Not Found"))
 
 	tests := []struct {
 		name         string
@@ -332,8 +334,8 @@ func TestClient_Sign(t *testing.T) {
 		NotBefore: api.NewTimeDuration(time.Now()),
 		NotAfter:  api.NewTimeDuration(time.Now().AddDate(0, 1, 0)),
 	}
-	unauthorized := api.Unauthorized(fmt.Errorf("Unauthorized"))
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	unauthorized := errs.Unauthorized(fmt.Errorf("Unauthorized"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string
@@ -407,8 +409,8 @@ func TestClient_Revoke(t *testing.T) {
 		OTT:        "the-ott",
 		ReasonCode: 4,
 	}
-	unauthorized := api.Unauthorized(fmt.Errorf("Unauthorized"))
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	unauthorized := errs.Unauthorized(fmt.Errorf("Unauthorized"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string
@@ -483,8 +485,8 @@ func TestClient_Renew(t *testing.T) {
 			{Certificate: parseCertificate(rootPEM)},
 		},
 	}
-	unauthorized := api.Unauthorized(fmt.Errorf("Unauthorized"))
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	unauthorized := errs.Unauthorized(fmt.Errorf("Unauthorized"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string
@@ -541,7 +543,7 @@ func TestClient_Provisioners(t *testing.T) {
 	ok := &api.ProvisionersResponse{
 		Provisioners: provisioner.List{},
 	}
-	internalServerError := api.InternalServerError(fmt.Errorf("Internal Server Error"))
+	internalServerError := errs.InternalServerError(fmt.Errorf("Internal Server Error"))
 
 	tests := []struct {
 		name         string
@@ -603,7 +605,7 @@ func TestClient_ProvisionerKey(t *testing.T) {
 	ok := &api.ProvisionerKeyResponse{
 		Key: "an encrypted key",
 	}
-	notFound := api.NotFound(fmt.Errorf("Not Found"))
+	notFound := errs.NotFound(fmt.Errorf("Not Found"))
 
 	tests := []struct {
 		name         string
@@ -664,8 +666,8 @@ func TestClient_Roots(t *testing.T) {
 			{Certificate: parseCertificate(rootPEM)},
 		},
 	}
-	unauthorized := api.Unauthorized(fmt.Errorf("Unauthorized"))
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	unauthorized := errs.Unauthorized(fmt.Errorf("Unauthorized"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string
@@ -724,8 +726,8 @@ func TestClient_Federation(t *testing.T) {
 			{Certificate: parseCertificate(rootPEM)},
 		},
 	}
-	unauthorized := api.Unauthorized(fmt.Errorf("Unauthorized"))
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	unauthorized := errs.Unauthorized(fmt.Errorf("Unauthorized"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string
@@ -788,7 +790,7 @@ func TestClient_SSHRoots(t *testing.T) {
 		HostKeys: []api.SSHPublicKey{{PublicKey: key}},
 		UserKeys: []api.SSHPublicKey{{PublicKey: key}},
 	}
-	notFound := api.NotFound(fmt.Errorf("Not Found"))
+	notFound := errs.NotFound(fmt.Errorf("Not Found"))
 
 	tests := []struct {
 		name         string
@@ -879,7 +881,7 @@ func Test_parseEndpoint(t *testing.T) {
 
 func TestClient_RootFingerprint(t *testing.T) {
 	ok := &api.HealthResponse{Status: "ok"}
-	nok := api.InternalServerError(fmt.Errorf("Internal Server Error"))
+	nok := errs.InternalServerError(fmt.Errorf("Internal Server Error"))
 
 	httpsServer := httptest.NewTLSServer(nil)
 	defer httpsServer.Close()
@@ -946,7 +948,7 @@ func TestClient_SSHBastion(t *testing.T) {
 			Hostname: "bastion.local",
 		},
 	}
-	badRequest := api.BadRequest(fmt.Errorf("Bad Request"))
+	badRequest := errs.BadRequest(fmt.Errorf("Bad Request"))
 
 	tests := []struct {
 		name         string

--- a/ca/testdata/ca.json
+++ b/ca/testdata/ca.json
@@ -18,6 +18,7 @@
         ]
     },
     "authority": {
+        "backdate": "0s",
         "provisioners": [
             {
                 "name": "max",

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/smallstep/assert v0.0.0-20180720014142-de77670473b5
+	github.com/smallstep/assert v0.0.0-20200103212524-b99dc1097b15
 	github.com/smallstep/cli v0.14.0-rc.1.0.20191218000521-3e7348324838
 	github.com/smallstep/nosql v0.2.0
 	github.com/urfave/cli v1.20.1-0.20181029213200-b67dcf995b6a

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 h1:0hQKqeLdqlt5iIwVOBErRi
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smallstep/assert v0.0.0-20180720014142-de77670473b5 h1:lX6ybsQW9Agn3qK/W1Z39Z4a6RyEMGem/gXUYW0axYk=
 github.com/smallstep/assert v0.0.0-20180720014142-de77670473b5/go.mod h1:TC9A4+RjIOS+HyTH7wG17/gSqVv95uDw2J64dQZx7RE=
+github.com/smallstep/assert v0.0.0-20200103212524-b99dc1097b15 h1:kSImCuenAkXtCaBeQ1UhmzzJGRhSm8sVH7I3sHE2Qdg=
+github.com/smallstep/assert v0.0.0-20200103212524-b99dc1097b15/go.mod h1:MyOHs9Po2fbM1LHej6sBUT8ozbxmMOFG+E+rx/GSGuc=
 github.com/smallstep/certificates v0.14.0-rc.1.0.20191023014154-4669bef8c700/go.mod h1:/WOAB2LkcjkEbKG5rDol+A22Lp3UsttkLPLkY7tVtuk=
 github.com/smallstep/certificates v0.14.0-rc.1.0.20191025192352-8ef9b020ed24/go.mod h1:043iBnsMvNhQ+QFwSh0N6JR3H2yamHPPAc78vCf+8Tc=
 github.com/smallstep/certificates v0.14.0-rc.1.0.20191126035953-e88034bea402/go.mod h1:r2UTcAZNriKlwvNNXymNAcF3iKL6mTYOYrOCtBYYGJU=


### PR DESCRIPTION
### Description

This PR changes the x509 and SSH certificates to the NotBefore or ValidAfter are one minute before the current time.
