### PR TITLE
Let step-ca bind to ports < 1024

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -7,6 +7,10 @@ ENV PWDPATH="/home/step/secrets/password"
 
 COPY $BINPATH "/usr/local/bin/step-ca"
 
+USER root
+RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
+USER step
+
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
 


### PR DESCRIPTION
### Description
This PR allows the `step-ca` binary in the Docker container to bind to ports lower than 1024.

### Explanation
I'm trying to use Smallstep in an environment that blocks many outgoing ports and doesn't let me set Docker's `--port` argument directly, so I'd like to run `step-ca` from the Docker container directly on port 443. Unfortunately, this isn't allowed as the daemon is not being started as root, but rather as the `step` user. This commit resolves that issue by adding the `CAP_NET_BIND_SERVICE` to the `step-ca` binary, allowing ports lower than 1024 to be used (https://superuser.com/a/892391).

As a nice side-effect, this also makes the example value ":443" from `step ca init` work from inside a Docker container.

Oh, and thank you a lot for the awesome work with Smallstep! :heart:
