### PR TITLE
Update FAQ: "I already have PKI"

### DIFF
--- a/docs/questions.md
+++ b/docs/questions.md
@@ -120,7 +120,7 @@ The root certificate can be in PEM or DER format, and the signing key can be a P
 
 ### Option 2: More secure
 
-That said, CAs are usually pretty locked down and it's bad practice to move the private key around. So I'm gonna assume that's not an option and give you the more complex instructions to do this "the right way", by generating a CSR for `step-ca`, getting it signed by your exiting root, and configuring `step-ca` to use it.
+That said, CAs are usually pretty locked down and it's bad practice to move the private key around. So I'm gonna assume that's not an option and give you the more complex instructions to do this "the right way", by generating a CSR for `step-ca`, getting it signed by your existing root, and configuring `step-ca` to use it.
 
 When you run `step ca init` we create a couple artifacts under `~/.step/`. The important ones for us are:
 

--- a/docs/questions.md
+++ b/docs/questions.md
@@ -193,7 +193,36 @@ openssl ca -config [ROOT_CA_CONFIG_FILE] \
   -out intermediate.crt
 ```
 
-This process will yield an `intermediate.crt` certificate.  Transfer this file back to the machine running `step-ca`.
+**CFSSL**
+
+For CFSSL you'll need a signing profile that specifies a 10-year expiry:
+
+```bash
+cat > ca-smallstep-config.json <<EOF
+{
+  "signing": {
+    "profiles": {
+      "smallstep": {
+        "expiry": "87660h",
+        "usages": ["signing"]
+      }
+    }
+  }
+}
+EOF
+```
+
+Now use that config to sign the intermediate certificate:
+
+```bash
+cfssl sign -ca ca.pem \
+    -ca-key ca-key.pem \
+    -config ca-smallstep-config.json \
+    -profile smallstep
+    -csr intermediate.csr | cfssljson -bare
+```
+
+This process will yield a signed `intermediate.crt` certificate (or `cert.pem` for CFSSL). Transfer this file back to the machine running `step-ca`.
 
 Finally, replace the intermediate .crt and signing key produced by `step ca init` with the new ones we just created:
 

--- a/docs/questions.md
+++ b/docs/questions.md
@@ -171,7 +171,7 @@ aws acm-pca issue-certificate \
 --csr intermediate.csr \
 --template-arn "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen1/V1" \
 --signing-algorithm "SHA256WITHRSA" \
---validity Value=365,Type="DAYS"
+--validity Value=3650,Type="DAYS"
 ```
 
 This command will return the ARN of the certificate created. Now use [get-certificate](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/get-certificate.html) to fetch the intermediate certificate:
@@ -188,7 +188,7 @@ aws acm-pca get-certificate \
 ```bash
 openssl ca -config [ROOT_CA_CONFIG_FILE] \
   -extensions v3_intermediate_ca \
-  -days 365 -notext -md sha512 \
+  -days 3650 -notext -md sha512 \
   -in intermediate.csr \
   -out intermediate.crt
 ```


### PR DESCRIPTION
This addresses issue #160 

I extended @mmalone's example a bit and added it to the FAQ.
In addition to Mike's directions for AD CS, I added directions for AWS private CA, CFSSL, and OpenSSL.

Some small lingering questions:

- [x] Which CAs are most important to support in the directions?
- [x] Add CFSSL instructions
- [x] When issuing an intermediate cert for `step-ca`, which signing algo is best?
- [x] How long should the intermediate cert be valid for? 10 years
- [x] Test the AWS ACM PCA directions

The AD CS directions were confirmed by some folks in #160 
