### PR TITLE
Allow custom principals on cloud identity provisioners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.13.x
+- 1.14.x
 addons:
   apt:
     packages:

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -318,14 +318,20 @@ func (p *Azure) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOptio
 		return nil, errs.Wrap(http.StatusInternalServerError, err, "azure.AuthorizeSSHSign")
 	}
 	signOptions := []SignOption{
-		// set the key id to the token subject
+		// set the key id to the instance name
 		sshCertKeyIDModifier(name),
+	}
+
+	// Only enforce known principals if disable custom sans is true.
+	var principals []string
+	if p.DisableCustomSANs {
+		principals = []string{name}
 	}
 
 	// Default to host + known hostnames
 	defaults := SSHOptions{
 		CertType:   SSHHostCert,
-		Principals: []string{name},
+		Principals: principals,
 	}
 	// Validate user options
 	signOptions = append(signOptions, sshCertOptionsValidator(defaults))

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
### Description
This PR adds support for custom SSH principals on cloud identity provisioners.

It also upgrades builds to use Go 1.14 and fix a lint error.
