### PR TITLE
Add context to ssh methods

### DIFF
--- a/api/sshRekey.go
+++ b/api/sshRekey.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -56,7 +55,7 @@ func (h *caHandler) SSHRekey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := provisioner.NewContextWithMethod(context.Background(), provisioner.SSHRekeyMethod)
+	ctx := provisioner.NewContextWithMethod(r.Context(), provisioner.SSHRekeyMethod)
 	signOpts, err := h.Authority.Authorize(ctx, body.OTT)
 	if err != nil {
 		WriteError(w, errs.UnauthorizedErr(err))
@@ -67,7 +66,7 @@ func (h *caHandler) SSHRekey(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, errs.InternalServerErr(err))
 	}
 
-	newCert, err := h.Authority.RekeySSH(oldCert, publicKey, signOpts...)
+	newCert, err := h.Authority.RekeySSH(ctx, oldCert, publicKey, signOpts...)
 	if err != nil {
 		WriteError(w, errs.ForbiddenErr(err))
 		return

--- a/api/sshRenew.go
+++ b/api/sshRenew.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -46,7 +45,7 @@ func (h *caHandler) SSHRenew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := provisioner.NewContextWithMethod(context.Background(), provisioner.SSHRenewMethod)
+	ctx := provisioner.NewContextWithMethod(r.Context(), provisioner.SSHRenewMethod)
 	_, err := h.Authority.Authorize(ctx, body.OTT)
 	if err != nil {
 		WriteError(w, errs.UnauthorizedErr(err))
@@ -57,7 +56,7 @@ func (h *caHandler) SSHRenew(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, errs.InternalServerErr(err))
 	}
 
-	newCert, err := h.Authority.RenewSSH(oldCert)
+	newCert, err := h.Authority.RenewSSH(ctx, oldCert)
 	if err != nil {
 		WriteError(w, errs.ForbiddenErr(err))
 		return

--- a/api/sshRevoke.go
+++ b/api/sshRevoke.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/smallstep/certificates/authority"
@@ -65,7 +64,7 @@ func (h *caHandler) SSHRevoke(w http.ResponseWriter, r *http.Request) {
 		PassiveOnly: body.Passive,
 	}
 
-	ctx := provisioner.NewContextWithMethod(context.Background(), provisioner.SSHRevokeMethod)
+	ctx := provisioner.NewContextWithMethod(r.Context(), provisioner.SSHRevokeMethod)
 	// A token indicates that we are using the api via a provisioner token,
 	// otherwise it is assumed that the certificate is revoking itself over mTLS.
 	logOtt(w, body.OTT)

--- a/api/ssh_test.go
+++ b/api/ssh_test.go
@@ -319,10 +319,10 @@ func Test_caHandler_SSHSign(t *testing.T) {
 				authorizeSign: func(ott string) ([]provisioner.SignOption, error) {
 					return []provisioner.SignOption{}, tt.authErr
 				},
-				signSSH: func(key ssh.PublicKey, opts provisioner.SSHOptions, signOpts ...provisioner.SignOption) (*ssh.Certificate, error) {
+				signSSH: func(ctx context.Context, key ssh.PublicKey, opts provisioner.SSHOptions, signOpts ...provisioner.SignOption) (*ssh.Certificate, error) {
 					return tt.signCert, tt.signErr
 				},
-				signSSHAddUser: func(key ssh.PublicKey, cert *ssh.Certificate) (*ssh.Certificate, error) {
+				signSSHAddUser: func(ctx context.Context, key ssh.PublicKey, cert *ssh.Certificate) (*ssh.Certificate, error) {
 					return tt.addUserCert, tt.addUserErr
 				},
 				sign: func(cr *x509.CertificateRequest, opts provisioner.Options, signOpts ...provisioner.SignOption) ([]*x509.Certificate, error) {
@@ -379,7 +379,7 @@ func Test_caHandler_SSHRoots(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := New(&mockAuthority{
-				getSSHRoots: func() (*authority.SSHKeys, error) {
+				getSSHRoots: func(ctx context.Context) (*authority.SSHKeys, error) {
 					return tt.keys, tt.keysErr
 				},
 			}).(*caHandler)
@@ -433,7 +433,7 @@ func Test_caHandler_SSHFederation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := New(&mockAuthority{
-				getSSHFederation: func() (*authority.SSHKeys, error) {
+				getSSHFederation: func(ctx context.Context) (*authority.SSHKeys, error) {
 					return tt.keys, tt.keysErr
 				},
 			}).(*caHandler)
@@ -493,7 +493,7 @@ func Test_caHandler_SSHConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := New(&mockAuthority{
-				getSSHConfig: func(typ string, data map[string]string) ([]templates.Output, error) {
+				getSSHConfig: func(ctx context.Context, typ string, data map[string]string) ([]templates.Output, error) {
 					return tt.output, tt.err
 				},
 			}).(*caHandler)
@@ -591,7 +591,7 @@ func Test_caHandler_SSHGetHosts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := New(&mockAuthority{
-				getSSHHosts: func(*x509.Certificate) ([]sshutil.Host, error) {
+				getSSHHosts: func(context.Context, *x509.Certificate) ([]sshutil.Host, error) {
 					return tt.hosts, tt.err
 				},
 			}).(*caHandler)
@@ -646,7 +646,7 @@ func Test_caHandler_SSHBastion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := New(&mockAuthority{
-				getSSHBastion: func(user, hostname string) (*authority.Bastion, error) {
+				getSSHBastion: func(ctx context.Context, user, hostname string) (*authority.Bastion, error) {
 					return tt.bastion, tt.bastionErr
 				},
 			}).(*caHandler)

--- a/authority/authority.go
+++ b/authority/authority.go
@@ -51,9 +51,9 @@ type Authority struct {
 	startTime time.Time
 
 	// Custom functions
-	sshBastionFunc   func(user, hostname string) (*Bastion, error)
+	sshBastionFunc   func(ctx context.Context, user, hostname string) (*Bastion, error)
 	sshCheckHostFunc func(ctx context.Context, principal string, tok string, roots []*x509.Certificate) (bool, error)
-	sshGetHostsFunc  func(cert *x509.Certificate) ([]sshutil.Host, error)
+	sshGetHostsFunc  func(ctx context.Context, cert *x509.Certificate) ([]sshutil.Host, error)
 	getIdentityFunc  provisioner.GetIdentityFunc
 }
 
@@ -227,7 +227,7 @@ func (a *Authority) init() error {
 	// TODO: should we also be combining the ssh federated roots here?
 	// If we rotate ssh roots keys, sshpop provisioner will lose ability to
 	// validate old SSH certificates, unless they are added as federated certs.
-	sshKeys, err := a.GetSSHRoots()
+	sshKeys, err := a.GetSSHRoots(context.Background())
 	if err != nil {
 		return err
 	}

--- a/authority/options.go
+++ b/authority/options.go
@@ -28,7 +28,7 @@ func WithDatabase(db db.AuthDB) Option {
 
 // WithGetIdentityFunc sets a custom function to retrieve the identity from
 // an external resource.
-func WithGetIdentityFunc(fn func(p provisioner.Interface, email string) (*provisioner.Identity, error)) Option {
+func WithGetIdentityFunc(fn func(ctx context.Context, p provisioner.Interface, email string) (*provisioner.Identity, error)) Option {
 	return func(a *Authority) error {
 		a.getIdentityFunc = fn
 		return nil
@@ -37,7 +37,7 @@ func WithGetIdentityFunc(fn func(p provisioner.Interface, email string) (*provis
 
 // WithSSHBastionFunc sets a custom function to get the bastion for a
 // given user-host pair.
-func WithSSHBastionFunc(fn func(user, host string) (*Bastion, error)) Option {
+func WithSSHBastionFunc(fn func(ctx context.Context, user, host string) (*Bastion, error)) Option {
 	return func(a *Authority) error {
 		a.sshBastionFunc = fn
 		return nil
@@ -46,7 +46,7 @@ func WithSSHBastionFunc(fn func(user, host string) (*Bastion, error)) Option {
 
 // WithSSHGetHosts sets a custom function to get the bastion for a
 // given user-host pair.
-func WithSSHGetHosts(fn func(cert *x509.Certificate) ([]sshutil.Host, error)) Option {
+func WithSSHGetHosts(fn func(ctx context.Context, cert *x509.Certificate) ([]sshutil.Host, error)) Option {
 	return func(a *Authority) error {
 		a.sshGetHostsFunc = fn
 		return nil

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -339,7 +339,7 @@ func (o *OIDC) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption
 
 	// Get the identity using either the default identityFunc or one injected
 	// externally.
-	iden, err := o.getIdentityFunc(o, claims.Email)
+	iden, err := o.getIdentityFunc(ctx, o, claims.Email)
 	if err != nil {
 		return nil, errs.Wrap(http.StatusInternalServerError, err, "oidc.AuthorizeSSHSign")
 	}

--- a/authority/provisioner/oidc_test.go
+++ b/authority/provisioner/oidc_test.go
@@ -485,10 +485,10 @@ func TestOIDC_AuthorizeSSHSign(t *testing.T) {
 	assert.FatalError(t, p4.Init(config))
 	assert.FatalError(t, p5.Init(config))
 
-	p4.getIdentityFunc = func(p Interface, email string) (*Identity, error) {
+	p4.getIdentityFunc = func(ctx context.Context, p Interface, email string) (*Identity, error) {
 		return &Identity{Usernames: []string{"max", "mariano"}}, nil
 	}
-	p5.getIdentityFunc = func(p Interface, email string) (*Identity, error) {
+	p5.getIdentityFunc = func(ctx context.Context, p Interface, email string) (*Identity, error) {
 		return nil, errors.New("force")
 	}
 

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -330,10 +330,10 @@ type Identity struct {
 }
 
 // GetIdentityFunc is a function that returns an identity.
-type GetIdentityFunc func(p Interface, email string) (*Identity, error)
+type GetIdentityFunc func(ctx context.Context, p Interface, email string) (*Identity, error)
 
 // DefaultIdentityFunc return a default identity depending on the provisioner type.
-func DefaultIdentityFunc(p Interface, email string) (*Identity, error) {
+func DefaultIdentityFunc(ctx context.Context, p Interface, email string) (*Identity, error) {
 	switch k := p.(type) {
 	case *OIDC:
 		name := SanitizeSSHUserPrincipal(email)

--- a/authority/provisioner/provisioner_test.go
+++ b/authority/provisioner/provisioner_test.go
@@ -92,7 +92,7 @@ func TestDefaultIdentityFunc(t *testing.T) {
 	for name, get := range tests {
 		t.Run(name, func(t *testing.T) {
 			tc := get(t)
-			identity, err := DefaultIdentityFunc(tc.p, tc.email)
+			identity, err := DefaultIdentityFunc(context.Background(), tc.p, tc.email)
 			if err != nil {
 				if assert.NotNil(t, tc.err) {
 					assert.Equals(t, tc.err.Error(), err.Error())


### PR DESCRIPTION
### Description
This PR Adds a `context.Context` to all the SSH methods.

