### PR TITLE
Use go 1.13 to build certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.14.x
+- 1.13.x
 addons:
   apt:
     packages:

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -57,7 +57,7 @@ func (c *Client) getClientTLSConfig(ctx context.Context, sign *api.SignResponse,
 	}
 	// Use mutable tls.Config on renew
 	tr.DialTLS = c.buildDialTLS(tlsCtx) //nolint:deprecated
-	tr.DialTLSContext = c.buildDialTLSContext(tlsCtx)
+	// tr.DialTLSContext = c.buildDialTLSContext(tlsCtx)
 	renewer.RenewCertificate = getRenewFunc(tlsCtx, c, tr, pk)
 
 	// Update client transport
@@ -109,7 +109,7 @@ func (c *Client) GetServerTLSConfig(ctx context.Context, sign *api.SignResponse,
 	}
 	// Use mutable tls.Config on renew
 	tr.DialTLS = c.buildDialTLS(tlsCtx) //nolint:deprecated
-	tr.DialTLSContext = c.buildDialTLSContext(tlsCtx)
+	// tr.DialTLSContext = c.buildDialTLSContext(tlsCtx)
 	renewer.RenewCertificate = getRenewFunc(tlsCtx, c, tr, pk)
 
 	// Update client transport

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -153,6 +153,7 @@ func (c *Client) buildDialTLS(ctx *TLSOptionCtx) func(network, addr string) (net
 }
 
 // buildDialTLSContext returns an implementation of DialTLSContext callback in http.Transport.
+// nolint:unused
 func (c *Client) buildDialTLSContext(tlsCtx *TLSOptionCtx) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		// TLS dialers do not support context, but we can use the context


### PR DESCRIPTION
### Description
Use go 1.13 to build certificates, tests are probably hanging due to https://github.com/golang/go/issues/38023