### PR TITLE
ssh/api: Use host tags instead of groups

### DIFF
--- a/api/ssh_test.go
+++ b/api/ssh_test.go
@@ -570,8 +570,8 @@ func Test_caHandler_SSHCheckHost(t *testing.T) {
 
 func Test_caHandler_SSHGetHosts(t *testing.T) {
 	hosts := []sshutil.Host{
-		{HostID: "1", HostGroups: []sshutil.HostGroup{{ID: "1", Name: "group 1"}}, Hostname: "host1"},
-		{HostID: "2", HostGroups: []sshutil.HostGroup{{ID: "1", Name: "group 1"}, {ID: "2", Name: "group 2"}}, Hostname: "host2"},
+		{HostID: "1", HostTags: []sshutil.HostTag{{ID: "1", Name: "group", Value: "1"}}, Hostname: "host1"},
+		{HostID: "2", HostTags: []sshutil.HostTag{{ID: "1", Name: "group", Value: "1"}, {ID: "2", Name: "group", Value: "2"}}, Hostname: "host2"},
 	}
 	hostsJSON, err := json.Marshal(hosts)
 	assert.FatalError(t, err)

--- a/sshutil/types.go
+++ b/sshutil/types.go
@@ -1,14 +1,16 @@
 package sshutil
 
-// HostGroup defines expected attributes for a host group that a host might belong to.
-type HostGroup struct {
-	ID   string
-	Name string
+// Hosts are tagged with k,v pairs. These tags are how a user is ultimately
+// associated with a host.
+type HostTag struct {
+	ID    string
+	Name  string
+	Value string
 }
 
 // Host defines expected attributes for an ssh host.
 type Host struct {
-	HostID     string      `json:"hid"`
-	HostGroups []HostGroup `json:"host_groups"`
-	Hostname   string      `json:"hostname"`
+	HostID   string    `json:"hid"`
+	HostTags []HostTag `json:"host_tags"`
+	Hostname string    `json:"hostname"`
 }


### PR DESCRIPTION
Tags are more flexible and what we use in the managed offering.
