### PR TITLE
Remove the requirement for CSR to have a common name

### DIFF
--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -108,9 +108,10 @@ func (v defaultPublicKeyValidator) Valid(req *x509.CertificateRequest) error {
 type commonNameValidator string
 
 // Valid checks that certificate request common name matches the one configured.
+// An empty common name is considered valid.
 func (v commonNameValidator) Valid(req *x509.CertificateRequest) error {
 	if req.Subject.CommonName == "" {
-		return errors.New("certificate request cannot contain an empty common name")
+		return nil
 	}
 	if req.Subject.CommonName != string(v) {
 		return errors.Errorf("certificate request does not contain the valid common name; requested common name = %s, token subject = %s", req.Subject.CommonName, v)
@@ -118,12 +119,13 @@ func (v commonNameValidator) Valid(req *x509.CertificateRequest) error {
 	return nil
 }
 
-// commonNameSliceValidator validates thats the common name of a certificate request is present in the slice.
+// commonNameSliceValidator validates thats the common name of a certificate
+// request is present in the slice. An empty common name is considered valid.
 type commonNameSliceValidator []string
 
 func (v commonNameSliceValidator) Valid(req *x509.CertificateRequest) error {
 	if req.Subject.CommonName == "" {
-		return errors.New("certificate request cannot contain an empty common name")
+		return nil
 	}
 	for _, cn := range v {
 		if req.Subject.CommonName == cn {

--- a/authority/provisioner/sign_options_test.go
+++ b/authority/provisioner/sign_options_test.go
@@ -125,7 +125,7 @@ func Test_commonNameValidator_Valid(t *testing.T) {
 		wantErr bool
 	}{
 		{"ok", "foo.bar.zar", args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: "foo.bar.zar"}}}, false},
-		{"empty", "", args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}}}, true},
+		{"empty", "", args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}}}, false},
 		{"wrong", "foo.bar.zar", args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: "example.com"}}}, true},
 	}
 	for _, tt := range tests {
@@ -149,7 +149,7 @@ func Test_commonNameSliceValidator_Valid(t *testing.T) {
 	}{
 		{"ok", []string{"foo.bar.zar"}, args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: "foo.bar.zar"}}}, false},
 		{"ok", []string{"example.com", "foo.bar.zar"}, args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: "foo.bar.zar"}}}, false},
-		{"empty", []string{""}, args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}}}, true},
+		{"empty", []string{""}, args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}}}, false},
 		{"wrong", []string{"foo.bar.zar"}, args{&x509.CertificateRequest{Subject: pkix.Name{CommonName: "example.com"}}}, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Description
This PR removes the requirement for a certificate request to have a common name. Certificate requests will be accepted if the common name matches the token subject or the common name is empty.

Fixes #226