### PR TITLE
Add root fingerprint to pki if certificate given

### DIFF
--- a/pki/pki.go
+++ b/pki/pki.go
@@ -289,6 +289,10 @@ func (p *PKI) WriteRootCertificate(rootCrt *x509.Certificate, rootKey interface{
 	if err != nil {
 		return err
 	}
+
+	sum := sha256.Sum256(rootCrt.Raw)
+	p.rootFingerprint = strings.ToLower(hex.EncodeToString(sum[:]))
+
 	return nil
 }
 


### PR DESCRIPTION
### Description

If a root certificate is provided to init an authority the fingerprint is not currently stored in the default.json file. This patch simply stores the fingerprint of the supplied certificate.

For example

./step ca init --name="test" --dns="b.ca" --address=":443" --provisioner=a@b.ca --root=root-ca.crt --key=root-ca.key

Copying root certificate...
all done!

Generating intermediate certificate...
all done!

✔ Root certificate: /home/dev/.step/certs/root_ca.crt
✔ Root private key: /home/dev/.step/secrets/root_ca_key
✔ Root fingerprint:
✔ Intermediate certificate: /home/dev/.step/certs/intermediate_ca.crt
✔ Intermediate private key: /home/dev/.step/secrets/intermediate_ca_key
✔ Database folder: /home/dev/.step/db
✔ Default configuration: /home/dev/.step/config/defaults.json
✔ Certificate Authority configuration: /home/dev/.step/config/ca.json

💔Thank you!

Note the missing fingerprint above - this patch will result in the fingerprint being outputted as well as stored in defaults.json