### PR TITLE
Add support for multi-tenant OIDC provisioners

### DIFF
--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -84,7 +84,7 @@ type Azure struct {
 	*base
 	Type                   string   `json:"type"`
 	Name                   string   `json:"name"`
-	TenantID               string   `json:"tenantId"`
+	TenantID               string   `json:"tenantID"`
 	ResourceGroups         []string `json:"resourceGroups"`
 	Audience               string   `json:"audience,omitempty"`
 	DisableCustomSANs      bool     `json:"disableCustomSANs"`

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -57,6 +57,7 @@ type OIDC struct {
 	ClientID              string   `json:"clientID"`
 	ClientSecret          string   `json:"clientSecret"`
 	ConfigurationEndpoint string   `json:"configurationEndpoint"`
+	TenantID              string   `json:"tenantID,omitempty"`
 	Admins                []string `json:"admins,omitempty"`
 	Domains               []string `json:"domains,omitempty"`
 	Groups                []string `json:"groups,omitempty"`
@@ -165,6 +166,10 @@ func (o *OIDC) Init(config Config) (err error) {
 	}
 	if err := o.configuration.Validate(); err != nil {
 		return errors.Wrapf(err, "error parsing %s", o.ConfigurationEndpoint)
+	}
+	// Replace {tenantid} with the configured one
+	if o.TenantID != "" {
+		o.configuration.Issuer = strings.Replace(o.configuration.Issuer, "{tenantid}", o.TenantID, -1)
 	}
 	// Get JWK key set
 	o.keyStore, err = newKeyStore(o.configuration.JWKSetURI)

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -943,6 +943,8 @@ func generateJWKServer(n int) *httptest.Server {
 			writeJSON(w, hits)
 		case "/.well-known/openid-configuration":
 			writeJSON(w, openIDConfiguration{Issuer: "the-issuer", JWKSetURI: srv.URL + "/jwks_uri"})
+		case "/common/.well-known/openid-configuration":
+			writeJSON(w, openIDConfiguration{Issuer: "https://login.microsoftonline.com/{tenantid}/v2.0", JWKSetURI: srv.URL + "/jwks_uri"})
 		case "/random":
 			keySet := must(generateJSONWebKeySet(n))[0].(jose.JSONWebKeySet)
 			w.Header().Add("Cache-Control", "max-age=5")


### PR DESCRIPTION
### Description
This PR adds an option to setup multi-tenant OIDC provisioners for Azure. Multi-tenant applications uses a common openid-configuration [1] where the issuer is formed replacing the string `{tenantid}` with the actual tenant.

[1] https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration


