### PR TITLE
Add new acmeHost config option

### DIFF
--- a/authority/config.go
+++ b/authority/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	IntermediateKey  string               `json:"key"`
 	Address          string               `json:"address"`
 	DNSNames         []string             `json:"dnsNames"`
+	ACMEHost         string               `json:"acmeHost,omitempty"`
 	KMS              *kms.Options         `json:"kms,omitempty"`
 	SSH              *SSHConfig           `json:"ssh,omitempty"`
 	Logger           json.RawMessage      `json:"logger,omitempty"`

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -113,18 +113,22 @@ func (ca *CA) Init(config *authority.Config) (*CA, error) {
 	})
 
 	//Add ACME api endpoints in /acme and /1.0/acme
-	dns := config.DNSNames[0]
-	u, err := url.Parse("https://" + config.Address)
-	if err != nil {
-		return nil, err
-	}
-	port := u.Port()
-	if port != "" && port != "443" {
-		dns = fmt.Sprintf("%s:%s", dns, port)
+	acmeHost := config.ACMEHost
+	if acmeHost == "" {
+		dns := config.DNSNames[0]
+		u, err := url.Parse("https://" + config.Address)
+		if err != nil {
+			return nil, err
+		}
+		port := u.Port()
+		if port != "" && port != "443" {
+			dns = fmt.Sprintf("%s:%s", dns, port)
+		}
+		acmeHost = dns
 	}
 
 	prefix := "acme"
-	acmeAuth, err := acme.NewAuthority(auth.GetDatabase().(nosql.DB), dns, prefix, auth)
+	acmeAuth, err := acme.NewAuthority(auth.GetDatabase().(nosql.DB), acmeHost, prefix, auth)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating ACME authority")
 	}


### PR DESCRIPTION
### Description

In order to be able to override the calculated host name used
by the ACME directory (dns[0] + <port if not 443>), add an extra
config option called acmeHost, which will be used instead. It's
optional, and if not specified, behaviour will be as before.

Related to #193 and #235 also step-ca helm chart issue nr 4

This is my very first foray into golang, hence I'd really appreciate some help vis-a-vis
how best to test this change and generally any feedback :)