### PR TITLE
Initialize the required config fields on embedded authorities

### DIFF
--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -207,6 +207,7 @@ func TestNewEmbedded(t *testing.T) {
 		wantErr bool
 	}{
 		{"ok", args{[]Option{WithX509RootBundle(caPEM), WithX509Signer(crt, key.(crypto.Signer))}}, false},
+		{"ok empty config", args{[]Option{WithConfig(&Config{}), WithX509RootBundle(caPEM), WithX509Signer(crt, key.(crypto.Signer))}}, false},
 		{"ok config file", args{[]Option{WithConfigFile("../ca/testdata/ca.json")}}, false},
 		{"ok config", args{[]Option{WithConfig(&Config{
 			Root:             []string{"testdata/certs/root_ca.crt"},
@@ -216,6 +217,7 @@ func TestNewEmbedded(t *testing.T) {
 			AuthorityConfig:  &AuthConfig{},
 		})}}, false},
 		{"fail options", args{[]Option{WithX509RootBundle([]byte("bad data"))}}, true},
+		{"fail missing config", args{[]Option{WithConfig(nil), WithX509RootBundle(caPEM), WithX509Signer(crt, key.(crypto.Signer))}}, true},
 		{"fail missing root", args{[]Option{WithX509Signer(crt, key.(crypto.Signer))}}, true},
 		{"fail missing signer", args{[]Option{WithX509RootBundle(caPEM)}}, true},
 		{"fail missing root file", args{[]Option{WithConfig(&Config{

--- a/authority/config.go
+++ b/authority/config.go
@@ -75,13 +75,20 @@ type AuthConfig struct {
 	Backdate             *provisioner.Duration `json:"backdate,omitempty"`
 }
 
-// defaultAuthConfig used when skipping validation.
-var defaultAuthConfig = &AuthConfig{
-	Provisioners: provisioner.List{},
-	Template:     &x509util.ASN1DN{},
-	Backdate: &provisioner.Duration{
-		Duration: defaultBackdate,
-	},
+// init initializes the required fields in the AuthConfig if they are not
+// provided.
+func (c *AuthConfig) init() {
+	if c.Provisioners == nil {
+		c.Provisioners = provisioner.List{}
+	}
+	if c.Template == nil {
+		c.Template = &x509util.ASN1DN{}
+	}
+	if c.Backdate == nil {
+		c.Backdate = &provisioner.Duration{
+			Duration: defaultBackdate,
+		}
+	}
 }
 
 // Validate validates the authority configuration.
@@ -89,6 +96,9 @@ func (c *AuthConfig) Validate(audiences provisioner.Audiences) error {
 	if c == nil {
 		return errors.New("authority cannot be undefined")
 	}
+
+	// Initialize required fields.
+	c.init()
 
 	// Check that only one K8sSA is enabled
 	var k8sCount int
@@ -101,16 +111,8 @@ func (c *AuthConfig) Validate(audiences provisioner.Audiences) error {
 		return errors.New("cannot have more than one kubernetes service account provisioner")
 	}
 
-	if c.Template == nil {
-		c.Template = defaultAuthConfig.Template
-	}
-
-	if c.Backdate != nil {
-		if c.Backdate.Duration < 0 {
-			return errors.New("authority.backdate cannot be less than 0")
-		}
-	} else {
-		c.Backdate = defaultAuthConfig.Backdate
+	if c.Backdate.Duration < 0 {
+		return errors.New("authority.backdate cannot be less than 0")
 	}
 
 	return nil
@@ -131,6 +133,21 @@ func LoadConfiguration(filename string) (*Config, error) {
 	}
 
 	return &c, nil
+}
+
+// initializes the minimal configuration required to create an authority. This
+// is mainly used on embedded authorities.
+func (c *Config) init() {
+	if c.DNSNames == nil {
+		c.DNSNames = []string{"localhost", "127.0.0.1", "::1"}
+	}
+	if c.TLS == nil {
+		c.TLS = &DefaultTLSOptions
+	}
+	if c.AuthorityConfig == nil {
+		c.AuthorityConfig = &AuthConfig{}
+	}
+	c.AuthorityConfig.init()
 }
 
 // Save saves the configuration to the given filename.


### PR DESCRIPTION
### Description

This change is to make easier the use of embedded authorities. It can be difficult for third parties to know what fields are required. The new init methods will define the minimum usable configuration.
