### PR TITLE
Add identity if username contains dots.

### DIFF
--- a/authority/provisioner/provisioner_test.go
+++ b/authority/provisioner/provisioner_test.go
@@ -85,7 +85,7 @@ func TestDefaultIdentityFunc(t *testing.T) {
 			return test{
 				p:        &OIDC{},
 				email:    "max.furman@smallstep.com",
-				identity: &Identity{Usernames: []string{"maxfurman", "max.furman@smallstep.com"}},
+				identity: &Identity{Usernames: []string{"maxfurman", "max.furman", "max.furman@smallstep.com"}},
 			}
 		},
 	}
@@ -94,6 +94,7 @@ func TestDefaultIdentityFunc(t *testing.T) {
 			tc := get(t)
 			identity, err := DefaultIdentityFunc(context.Background(), tc.p, tc.email)
 			if err != nil {
+				t.Log(err)
 				if assert.NotNil(t, tc.err) {
 					assert.Equals(t, tc.err.Error(), err.Error())
 				}


### PR DESCRIPTION
### Description
Before this patch, an email address like first.last@company.com would result in two identities:
firstlast
first.last@company.com

With this change, the first.last identity is also added.

Fixes #253