### PR TITLE
[Feature] Force CommonName for certificates from ACME provisioner

### DIFF
--- a/acme/order.go
+++ b/acme/order.go
@@ -262,6 +262,13 @@ func (o *order) finalize(db nosql.DB, csr *x509.CertificateRequest, auth SignAut
 	if csr.Subject.CommonName != "" {
 		csr.DNSNames = append(csr.DNSNames, csr.Subject.CommonName)
 	}
+
+	// Generate Subject CommonName for supporting `conservative` systems
+	// which does not accept certificates with empty subject
+	if csr.Subject.CommonName == "" && p.(*provisioner.ACME).ForceCN {
+		csr.Subject.CommonName = csr.DNSNames[0]
+	}
+
 	csr.DNSNames = uniqueLowerNames(csr.DNSNames)
 	orderNames := make([]string, len(o.Identifiers))
 	for i, n := range o.Identifiers {

--- a/acme/order.go
+++ b/acme/order.go
@@ -262,13 +262,6 @@ func (o *order) finalize(db nosql.DB, csr *x509.CertificateRequest, auth SignAut
 	if csr.Subject.CommonName != "" {
 		csr.DNSNames = append(csr.DNSNames, csr.Subject.CommonName)
 	}
-
-	// Generate Subject CommonName for supporting `conservative` systems
-	// which does not accept certificates with empty subject
-	if csr.Subject.CommonName == "" && p.(*provisioner.ACME).ForceCN {
-		csr.Subject.CommonName = csr.DNSNames[0]
-	}
-
 	csr.DNSNames = uniqueLowerNames(csr.DNSNames)
 	orderNames := make([]string, len(o.Identifiers))
 	for i, n := range o.Identifiers {

--- a/acme/order_test.go
+++ b/acme/order_test.go
@@ -1137,7 +1137,7 @@ func TestOrderFinalize(t *testing.T) {
 				csr: csr,
 				sa: &mockSignAuth{
 					sign: func(csr *x509.CertificateRequest, pops provisioner.Options, signOps ...provisioner.SignOption) ([]*x509.Certificate, error) {
-						assert.Equals(t, len(signOps), 4)
+						assert.Equals(t, len(signOps), 5)
 						return []*x509.Certificate{crt, inter}, nil
 					},
 				},
@@ -1186,7 +1186,7 @@ func TestOrderFinalize(t *testing.T) {
 				csr: csr,
 				sa: &mockSignAuth{
 					sign: func(csr *x509.CertificateRequest, pops provisioner.Options, signOps ...provisioner.SignOption) ([]*x509.Certificate, error) {
-						assert.Equals(t, len(signOps), 4)
+						assert.Equals(t, len(signOps), 5)
 						return []*x509.Certificate{crt, inter}, nil
 					},
 				},
@@ -1233,7 +1233,7 @@ func TestOrderFinalize(t *testing.T) {
 				csr: csr,
 				sa: &mockSignAuth{
 					sign: func(csr *x509.CertificateRequest, pops provisioner.Options, signOps ...provisioner.SignOption) ([]*x509.Certificate, error) {
-						assert.Equals(t, len(signOps), 4)
+						assert.Equals(t, len(signOps), 5)
 						return []*x509.Certificate{crt, inter}, nil
 					},
 				},

--- a/authority/provisioner/acme.go
+++ b/authority/provisioner/acme.go
@@ -15,6 +15,7 @@ type ACME struct {
 	Type    string  `json:"type"`
 	Name    string  `json:"name"`
 	Claims  *Claims `json:"claims,omitempty"`
+	ForceCN bool    `json:"forceCN,omitempty"`
 	claimer *Claimer
 }
 

--- a/authority/provisioner/acme.go
+++ b/authority/provisioner/acme.go
@@ -68,6 +68,7 @@ func (p *ACME) AuthorizeSign(ctx context.Context, token string) ([]SignOption, e
 	return []SignOption{
 		// modifiers / withOptions
 		newProvisionerExtensionOption(TypeACME, p.Name, ""),
+		newForceCNOption(p.ForceCN),
 		profileDefaultDuration(p.claimer.DefaultTLSCertDuration()),
 		// validators
 		defaultPublicKeyValidator{},

--- a/authority/provisioner/acme_test.go
+++ b/authority/provisioner/acme_test.go
@@ -168,7 +168,7 @@ func TestACME_AuthorizeSign(t *testing.T) {
 				}
 			} else {
 				if assert.Nil(t, tc.err) && assert.NotNil(t, opts) {
-					assert.Len(t, 4, opts)
+					assert.Len(t, 5, opts)
 					for _, o := range opts {
 						switch v := o.(type) {
 						case *provisionerExtensionOption:
@@ -176,6 +176,8 @@ func TestACME_AuthorizeSign(t *testing.T) {
 							assert.Equals(t, v.Name, tc.p.GetName())
 							assert.Equals(t, v.CredentialID, "")
 							assert.Len(t, 0, v.KeyValuePairs)
+						case *forceCNOption:
+							assert.Equals(t, v.ForceCN, tc.p.ForceCN)
 						case profileDefaultDuration:
 							assert.Equals(t, time.Duration(v), tc.p.claimer.DefaultTLSCertDuration())
 						case defaultPublicKeyValidator:

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -316,6 +316,32 @@ type stepProvisionerASN1 struct {
 	KeyValuePairs []string `asn1:"optional,omitempty"`
 }
 
+type forceCNOption struct {
+	ForceCN bool
+}
+
+func newForceCNOption(forceCN bool) *forceCNOption {
+	return &forceCNOption{forceCN}
+}
+
+func (o *forceCNOption) Option(Options) x509util.WithOption {
+	return func(p x509util.Profile) error {
+		if !o.ForceCN {
+			// Forcing CN is disabled, do nothing to certificate
+			return nil
+		}
+		crt := p.Subject()
+		if crt.Subject.CommonName == "" {
+			if len(crt.DNSNames) > 0 {
+				crt.Subject.CommonName = crt.DNSNames[0]
+			} else {
+				return errors.New("Cannot force CN, DNSNames is empty")
+			}
+		}
+		return nil
+	}
+}
+
 type provisionerExtensionOption struct {
 	Type          int
 	Name          string


### PR DESCRIPTION
### Description
As described in #259, some systems require certificate's Subject field to be non-empty. At the same time, `certbot` does not send CommonName in its certificate request. LetsEncrypt automatically generates CN for certificate based on the first SAN in the request. It is implemented under the `forceCN` config option.

This PR duplicates the described behavior for step-ca.

Closes #259 