### PR TITLE
Set nbf and nbf for ACME orders even when they are not set in the request.

### DIFF
--- a/acme/account_test.go
+++ b/acme/account_test.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func newProv() provisioner.Interface {
+func newProv() Provisioner {
 	// Initialize provisioners
 	p := &provisioner.ACME{
 		Type: "ACME",

--- a/acme/api/handler_test.go
+++ b/acme/api/handler_test.go
@@ -244,7 +244,11 @@ func TestHandlerGetNonce(t *testing.T) {
 }
 
 func TestHandlerGetDirectory(t *testing.T) {
-	auth, err := acme.NewAuthority(new(db.MockNoSQLDB), "ca.smallstep.com", "acme", nil)
+	auth, err := acme.New(nil, acme.AuthorityOptions{
+		DB:     new(db.MockNoSQLDB),
+		DNS:    "ca.smallstep.com",
+		Prefix: "acme",
+	})
 	assert.FatalError(t, err)
 
 	prov := newProv()

--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -278,11 +278,12 @@ func (h *Handler) lookupProvisioner(next nextHTTP) nextHTTP {
 			api.WriteError(w, err)
 			return
 		}
-		if p.GetType() != provisioner.TypeACME {
+		acmeProv, ok := p.(*provisioner.ACME)
+		if !ok {
 			api.WriteError(w, acme.AccountDoesNotExistErr(errors.New("provisioner must be of type ACME")))
 			return
 		}
-		ctx = context.WithValue(ctx, acme.ProvisionerContextKey, p)
+		ctx = context.WithValue(ctx, acme.ProvisionerContextKey, acme.Provisioner(acmeProv))
 		next(w, r.WithContext(ctx))
 	}
 }

--- a/authority/provisioner/acme.go
+++ b/authority/provisioner/acme.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"crypto/x509"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/errs"
@@ -42,6 +43,12 @@ func (p *ACME) GetType() Type {
 // GetEncryptedKey returns the base provisioner encrypted key if it's defined.
 func (p *ACME) GetEncryptedKey() (string, string, bool) {
 	return "", "", false
+}
+
+// DefaultTLSCertDuration returns the default TLS cert duration enforced by
+// the provisioner.
+func (p *ACME) DefaultTLSCertDuration() time.Duration {
+	return p.claimer.DefaultTLSCertDuration()
 }
 
 // Init initializes and validates the fields of a JWK type.

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -124,7 +124,12 @@ func (ca *CA) Init(config *authority.Config) (*CA, error) {
 	}
 
 	prefix := "acme"
-	acmeAuth, err := acme.NewAuthority(auth.GetDatabase().(nosql.DB), dns, prefix, auth)
+	acmeAuth, err := acme.New(auth, acme.AuthorityOptions{
+		Backdate: *config.AuthorityConfig.Backdate,
+		DB:       auth.GetDatabase().(nosql.DB),
+		DNS:      dns,
+		Prefix:   prefix,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating ACME authority")
 	}


### PR DESCRIPTION
According to the ACME spec (https://tools.ietf.org/html/rfc8555#section-7.1.3), ACME Order responses must contain the `notBefore` and `notAfter` attributes that will later be used to set the validity bounds on the certificate. If these values are not set as part of the NewOrder request `step-ca` does not set them in the Order object stored in the database (and returned to the user). This results in Order responses that have the `NotBefore` and `NotAfter` values set to the zero timestamp (e.g. `\"notAfter\":\"0001-01-01T00:00:00Z\"`). 

`step-ca` should set `notBefore` and `notAfter` at the time of order creation to the proper values based on the inputs and the ACME provisioner claims. 