### PR TITLE
Allow dots and other symbols in principals for OIDC

### DIFF
--- a/authority/provisioner/provisioner_test.go
+++ b/authority/provisioner/provisioner_test.go
@@ -109,6 +109,13 @@ func TestDefaultIdentityFunc(t *testing.T) {
 				identity: &Identity{Usernames: []string{"john", "John@smallstep.com"}},
 			}
 		},
+		"ok symbol": func(t *testing.T) test {
+			return test{
+				p:        &OIDC{},
+				email:    "John+Doe@smallstep.com",
+				identity: &Identity{Usernames: []string{"john_doe", "John+Doe", "John+Doe@smallstep.com"}},
+			}
+		},
 	}
 	for name, get := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/authority/provisioner/provisioner_test.go
+++ b/authority/provisioner/provisioner_test.go
@@ -85,7 +85,28 @@ func TestDefaultIdentityFunc(t *testing.T) {
 			return test{
 				p:        &OIDC{},
 				email:    "max.furman@smallstep.com",
-				identity: &Identity{Usernames: []string{"maxfurman", "max.furman@smallstep.com"}},
+				identity: &Identity{Usernames: []string{"maxfurman", "max.furman", "max.furman@smallstep.com"}},
+			}
+		},
+		"ok letter case": func(t *testing.T) test {
+			return test{
+				p:        &OIDC{},
+				email:    "Max.Furman@smallstep.com",
+				identity: &Identity{Usernames: []string{"maxfurman", "Max.Furman", "Max.Furman@smallstep.com"}},
+			}
+		},
+		"ok simple": func(t *testing.T) test {
+			return test{
+				p:        &OIDC{},
+				email:    "john@smallstep.com",
+				identity: &Identity{Usernames: []string{"john", "john@smallstep.com"}},
+			}
+		},
+		"ok simple letter case": func(t *testing.T) test {
+			return test{
+				p:        &OIDC{},
+				email:    "John@smallstep.com",
+				identity: &Identity{Usernames: []string{"john", "John@smallstep.com"}},
 			}
 		},
 	}


### PR DESCRIPTION
### Description
This PR will create principals with dot symbols in it when an OIDC provisioner is used. We are not changing the sanitation logic, we append the third principal if necessary:

This PR will create SSH certificates with the following principals:
```
firsstlast@example.com => ["firstlast", "firstlast@example.com"]
first.last@example.com => ["firstlast", "first.last", "first.last@example.com"]

FirstLast@example.com => ["firstlast", "FirstLlast@example.com"]
First.Last@example.com => ["firstlast", "First.Last", "First.Last@example.com"]
First+Last@example.com => ["first_last", "First+Last", "First+Last@example.com"]
```
Fixes #253, #254
