### PR TITLE
Always convert empty list to nil when saving orderIDs index.

### DIFF
--- a/acme/order_test.go
+++ b/acme/order_test.go
@@ -516,7 +516,7 @@ func Test_newOrder(t *testing.T) {
 	}
 }
 
-func TestOrderIDsSave(t *testing.T) {
+func TestOrderIDs_save(t *testing.T) {
 	accID := "acc-id"
 	newOids := func() orderIDs {
 		return []string{"1", "2"}
@@ -584,6 +584,26 @@ func TestOrderIDsSave(t *testing.T) {
 					MCmpAndSwap: func(bucket, key, old, newval []byte) ([]byte, bool, error) {
 						assert.Equals(t, old, oldb)
 						assert.Equals(t, newval, b)
+						assert.Equals(t, bucket, ordersByAccountIDTable)
+						assert.Equals(t, key, []byte(accID))
+						return nil, true, nil
+					},
+				},
+			}
+		},
+		"ok/new-empty-saved-as-nil": func(t *testing.T) test {
+			oldOids := newOids()
+			oids := []string{}
+
+			oldb, err := json.Marshal(oldOids)
+			assert.FatalError(t, err)
+			return test{
+				oids: oids,
+				old:  oldOids,
+				db: &db.MockNoSQLDB{
+					MCmpAndSwap: func(bucket, key, old, newval []byte) ([]byte, bool, error) {
+						assert.Equals(t, old, oldb)
+						assert.Equals(t, newval, nil)
 						assert.Equals(t, bucket, ordersByAccountIDTable)
 						assert.Equals(t, key, []byte(accID))
 						return nil, true, nil


### PR DESCRIPTION
`func save(bucket, key, old, newval []byte) error`

The orderIDs list can now have items removed from it. This is important because without this commit it was possible to save an empty list (`newval`) as the value of orderIDs (`json.Marshal([]string{})`). However, the value of `old` was always converted to `nil` if the `len(old) == 0`.  This would lead to a conflict where the actual `old` value in the db was an empty list, but the `save` method would always try to use `nil` as the comparator.

To "fix" this issue we'll make it impossible to store an empty list as the value for the orderIDs index. It will always be converted to `nil` if empty. 