### PR TITLE
Move load of kms to main package.

### DIFF
--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -23,6 +23,14 @@ import (
 	"github.com/smallstep/cli/config"
 	"github.com/smallstep/cli/usage"
 	"github.com/urfave/cli"
+
+	// Enabled kms interfaces.
+	_ "github.com/smallstep/certificates/kms/awskms"
+	_ "github.com/smallstep/certificates/kms/cloudkms"
+	_ "github.com/smallstep/certificates/kms/softkms"
+
+	// Experimental kms interfaces.
+	_ "github.com/smallstep/certificates/kms/yubikey"
 )
 
 // commit and buildTime are filled in during build by the Makefile

--- a/cmd/step-yubikey-init/main.go
+++ b/cmd/step-yubikey-init/main.go
@@ -22,6 +22,9 @@ import (
 	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils"
+
+	// Enable yubikey.
+	_ "github.com/smallstep/certificates/kms/yubikey"
 )
 
 type Config struct {

--- a/kms/kms.go
+++ b/kms/kms.go
@@ -7,13 +7,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/kms/apiv1"
 
-	// Enabled kms interfaces.
-	_ "github.com/smallstep/certificates/kms/awskms"
-	_ "github.com/smallstep/certificates/kms/cloudkms"
+	// Enable default implementation
 	_ "github.com/smallstep/certificates/kms/softkms"
-
-	// Experimental kms interfaces.
-	_ "github.com/smallstep/certificates/kms/yubikey"
 )
 
 // KeyManager is the interface implemented by all the KMS.


### PR DESCRIPTION
### Description
This PR moves the import of kms packages to the main package. With this, packages that import the authority won't load by default all the supported kms with all its dependencies.

Fixes #228