### PR TITLE
Avoid nil pointer panic on step ssh config with no templates.

### DIFF
--- a/authority/ssh.go
+++ b/authority/ssh.go
@@ -125,6 +125,10 @@ func (a *Authority) GetSSHConfig(ctx context.Context, typ string, data map[strin
 		return nil, errs.NotFound("getSSHConfig: ssh is not configured")
 	}
 
+	if a.config.Templates == nil {
+		return nil, errs.NotFound("getSSHConfig: ssh templates are not configured")
+	}
+
 	var ts []templates.Template
 	switch typ {
 	case provisioner.SSHUserCert:

--- a/authority/ssh_test.go
+++ b/authority/ssh_test.go
@@ -455,6 +455,7 @@ func TestAuthority_GetSSHConfig(t *testing.T) {
 		{"badType", fields{tmplConfig, userSigner, hostSigner}, args{"bad", nil}, nil, true},
 		{"userError", fields{tmplConfigErr, userSigner, hostSigner}, args{"user", nil}, nil, true},
 		{"hostError", fields{tmplConfigErr, userSigner, hostSigner}, args{"host", map[string]string{"Function": "foo"}}, nil, true},
+		{"noTemplates", fields{nil, userSigner, hostSigner}, args{"user", nil}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description
This PR returns an error if we try to get the ssh configuration if the ca doesn't define templates.

Fixes #289