### PR TITLE
Do not return bastion for the configured bastion host.

### DIFF
--- a/authority/ssh.go
+++ b/authority/ssh.go
@@ -177,7 +177,17 @@ func (a *Authority) GetSSHBastion(ctx context.Context, user string, hostname str
 	}
 	if a.config.SSH != nil {
 		if a.config.SSH.Bastion != nil && a.config.SSH.Bastion.Hostname != "" {
-			return a.config.SSH.Bastion, nil
+			// Do not return a bastion for a bastion host.
+			//
+			// This condition might fail if a different name or IP is used.
+			// Trying to resolve hostnames to IPs and compare them won't be a
+			// complete solution because it depends on the network
+			// configuration, of the CA and clients and can also return false
+			// positives. Although not perfect, this simple solution will work
+			// in most cases.
+			if !strings.EqualFold(hostname, a.config.SSH.Bastion.Hostname) {
+				return a.config.SSH.Bastion, nil
+			}
 		}
 		return nil, nil
 	}

--- a/authority/ssh_test.go
+++ b/authority/ssh_test.go
@@ -629,6 +629,7 @@ func TestAuthority_GetSSHBastion(t *testing.T) {
 		wantErr bool
 	}{
 		{"config", fields{&Config{SSH: &SSHConfig{Bastion: bastion}}, nil}, args{"user", "host.local"}, bastion, false},
+		{"bastion", fields{&Config{SSH: &SSHConfig{Bastion: bastion}}, nil}, args{"user", "bastion.local"}, nil, false},
 		{"nil", fields{&Config{SSH: &SSHConfig{Bastion: nil}}, nil}, args{"user", "host.local"}, nil, false},
 		{"empty", fields{&Config{SSH: &SSHConfig{Bastion: &Bastion{}}}, nil}, args{"user", "host.local"}, nil, false},
 		{"func", fields{&Config{}, func(_ context.Context, _, _ string) (*Bastion, error) { return bastion, nil }}, args{"user", "host.local"}, bastion, false},


### PR DESCRIPTION
### Description
This PR does not return a bastion for the bastion configured, avoiding this way infinite loops. Although not a perfect solution, because a bastion can have different names, as we cannot guarantee that the client and CA are in the same network, the simple solution is in some cases the safest. 

Fixes #296
