### PR TITLE
Fix Docker example build on Linux

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -341,6 +341,8 @@ This example creates 3 different docker images:
   certificate and sets a cron that renews the certificate (the cron
   runs every minute for testing purposes).
 
+On Linux, you will need the `libpcsclite-dev` package.
+
 To run this test you need to have the docker daemon running. With docker running
 swith to the `examples/docker directory` and run `make`:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -341,8 +341,6 @@ This example creates 3 different docker images:
   certificate and sets a cron that renews the certificate (the cron
   runs every minute for testing purposes).
 
-On Linux, you will need the `libpcsclite-dev` package.
-
 To run this test you need to have the docker daemon running. With docker running
 swith to the `examples/docker directory` and run `make`:
 

--- a/examples/docker/Makefile
+++ b/examples/docker/Makefile
@@ -1,8 +1,8 @@
 all: binaries build up
 
 binaries:
-	GOOS=linux go build -o ca/step-ca github.com/smallstep/certificates/cmd/step-ca
-	GOOS=linux go build -o renewer/step github.com/smallstep/cli/cmd/step
+	CGO_ENABLED=0 GOOS=linux go build -o ca/step-ca github.com/smallstep/certificates/cmd/step-ca
+	CGO_ENABLED=0 GOOS=linux go build -o renewer/step github.com/smallstep/cli/cmd/step
 
 build: build-nginx build-ca build-renewer
 build-nginx:


### PR DESCRIPTION
This fixes #295, which was caused by libc incompatibility between the host OS and Alpine.
Tested on Ubuntu and macOS.
