### PR TITLE
Fix typos

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -243,7 +243,7 @@ $ systemctl status step-ca
 # Configure the `step-ca` process to startup on reboot automatically
 $ systemctl enable step-ca
 # Start the `step-ca` service.
-$ systemctl start smallstep
+$ systemctl start step-ca
 ```
 
 ## Configure Your Environment

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -209,8 +209,8 @@ Consider adding a service user that will only be used by `systemctl` to manage
 the service.
 
 ```
-$ useradd step
-$ passwd -l step
+$ useradd smallstep
+$ passwd -l smallstep
 ```
 
 Use the following example as a base for your `systemctl` service file:


### PR DESCRIPTION
### Description
In `ExecStart` the user used us `smallstep` so the same user should be defined in `useradd`.

