### PR TITLE
Getting Started docs fixes

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -224,7 +224,7 @@ After=syslog.target network.target
 
 User=step
 Group=step
-ExecStart=/bin/sh -c '/bin/step-ca /home/step/.step/config/ca.json --password-file=/home/step/.step/pwd >> /var/log/smallstep/output.log 2>&1'
+ExecStart=/bin/sh -c '/bin/step-ca /home/step/.step/config/ca.json --password-file=/home/step/.step/pwd >> /var/log/step-ca/output.log 2>&1'
 Type=simple
 Restart=on-failure
 RestartSec=10

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -222,13 +222,12 @@ After=syslog.target network.target
 
 [Service]
 
-User=smallstep
-Group=smallstep
-ExecStart=/bin/sh -c '/bin/step-ca /home/smallstep/.step/config/ca.json --password-file=/home/smallstep/.step/pwd >>   /var/log/smallstep/output.log 2>&1'
+User=step
+Group=step
+ExecStart=/bin/sh -c '/bin/step-ca /home/step/.step/config/ca.json --password-file=/home/step/.step/pwd >> /var/log/smallstep/output.log 2>&1'
 Type=simple
 Restart=on-failure
 RestartSec=10
-
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -242,7 +242,7 @@ $ systemctl status step-ca
 # Configure the `step-ca` process to startup on reboot automatically
 $ systemctl enable step-ca
 # Start the `step-ca` service.
-$ systemctl start smallstep
+$ systemctl start step-ca
 ```
 
 ## Configure Your Environment


### PR DESCRIPTION
_superseding https://github.com/smallstep/certificates/pull/316_

### Description
1. The user (and optionally the group) should be the same as the one create in line 212 (`$ useradd step`)
2. Since the service unit name is `step-ca` and the program it uses is also called `step-ca`, the directory to store the logs should also be called `step-ca` imo.
3. Fixed the name of the service in line 246 (`$ systemctl start smallstep`): There's no service called `smallstep`.