### PR TITLE
Fixes #344; also gets docker buildx working on both darwin & linux

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -1,11 +1,18 @@
+FROM golang:alpine AS builder
+
+RUN mkdir /src
+ADD . /src
+
+RUN apk add --no-cache make git curl && \
+    cd /src && \
+    make V=1 bin/step-ca 
+
 FROM smallstep/step-cli:latest
 
-ARG BINPATH="bin/step-ca"
+COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 
 ENV CONFIGPATH="/home/step/config/ca.json"
 ENV PWDPATH="/home/step/secrets/password"
-
-COPY $BINPATH "/usr/local/bin/step-ca"
 
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca


### PR DESCRIPTION
Our `Dockerfile` was copying `bin/step-ca` into the container instead of building the binary within the container. For multi-platform Docker support via `docker buildx`, the Dockerfile now builds the binary within the container.

This PR also gets `make docker-*` working on Darwin, which does not seem to require QEMU.
