### PR TITLE
Small changes to docker/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,9 @@ env:
     - V=1
 before_script:
   - make bootstrap
-jobs:
-  include:
-    - stage: lint
-      script: make lint
-    - script:
-        - make test
-        - make build
-        - make artifacts
+script:
+  - make
+  - make artifacts
 after_success:
   - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did
     not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-dist: bionic
+dist: focal
 services:
 - docker
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+os: linux
 dist: focal
 services:
   - docker
@@ -18,10 +19,10 @@ before_script:
   - make bootstrap
 jobs:
   include:
-    - script: make lint
-    - script: make test
-    - stage: build
-      script:
+    - stage: lint
+      script: make lint
+    - script:
+        - make test
         - make build
         - make artifacts
 after_success:
@@ -31,8 +32,8 @@ notifications:
   email: false
 deploy:
   provider: releases
-  skip_cleanup: true
-  api_key:
+  cleanup: false
+  token:
     secure: EVV43Vkqn67hhKGYn4WhQp2YO6KFmUDSkLXjYXYGX07Fm8p5KjRFBPOz9LV83QrvVmLigvg0CtR8Jqqcnq2SUhus3nhZaN2g19NhMypZLioyOVP0kAkas8ocuvxkwz3YxIK/yMrmTKbQ7JGXtbc8IjAox9ovNo1fFIQmVMAzPfu++OWBJ0j+gUqKtpaNA7gzsSv8UOw3/T3hNm6E1IbpWxl9BPSOzUOE9F/QOThANzifGfdxvqNJFkAgqu5DVPz8zQNbMrz4zH+KwASKxd6hjhzSSMzouKzOEHTA/elDCHEjke0Jos29MkGWHcIydLtCD95DGecqM8BFSC9f2acHDjmUO1rdfoLA3Pt+UiZJuTwyQm/jrHHhRnH8oJpK15G5LvxSqzY9YDWpAk38+jMw/udW6wt7BGAU8FEXLbq0bsFL3yfTepeWjmzT5WS0YXdiBz2SEK+Og9R2bSdtl4owghRzKNio5DNPuYAbqbpi+jqzqQVLj27x7LWoQ0MHvZcz9U+oO00r6M1tDCmFVRdtfgb2H+MIDY69qYGo5qoGMfH1btCWR8bA9wSYB/Z7hW/xZT9r7f/d5/P40k8yKINmTZqyUTQeplrE3y4BPVzKksclczBZa67syIUQ49I35QppnH4GFQHUwlra7r3W9zfZRvaLnp5qOIKAQe3MAIZqtLg=
   file_glob: true
   file: .travis-releases/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+dist: bionic
+services:
+- docker
 go:
 - 1.14.x
 addons:
@@ -8,7 +11,6 @@ addons:
     - fakeroot
     - bash-completion
     - libpcsclite-dev
-    - docker-ce
 env:
   global:
   - V=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,32 @@
 language: go
 dist: focal
 services:
-- docker
+  - docker
 go:
-- 1.14.x
+  - 1.14.x
 addons:
   apt:
     packages:
-    - debhelper
-    - fakeroot
-    - bash-completion
-    - libpcsclite-dev
+      - debhelper
+      - fakeroot
+      - bash-completion
+      - libpcsclite-dev
 env:
   global:
-  - V=1
+    - V=1
 before_script:
-- make bootstrap
-script:
-- make
-- make artifacts
+  - make bootstrap
+jobs:
+  include:
+    - script: make lint
+    - script: make test
+    - stage: build
+      script:
+        - make build
+        - make artifacts
 after_success:
-- bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did
-  not collect coverage reports"
+  - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did
+    not collect coverage reports"
 notifications:
   email: false
 deploy:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-step-certificates (0.8.4-14-ge72f087-dev) unstable; urgency=medium
+step-certificates (0.15.1~rc.1~2~gd073a0a~dev) unstable; urgency=medium
 
   * See https://github.com/smallstep/certificates/releases
 
- -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Wed, 20 Feb 2019 20:44:25 +0000
+ -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Tue, 18 Aug 2020 18:40:32 +0000

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-step-certificates (0.15.1~rc.1~2~gd073a0a~dev) unstable; urgency=medium
+step-certificates (0.8.4-14-ge72f087-dev) unstable; urgency=medium
 
   * See https://github.com/smallstep/certificates/releases
 
- -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Tue, 18 Aug 2020 18:40:32 +0000
+ -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Wed, 20 Feb 2019 20:44:25 +0000

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -21,14 +21,14 @@ DOCKER_IMAGE_NAME = smallstep/step-ca
 docker-prepare:
 	# Ensure, we can build for ARM architecture
 ifeq (linux,$(DOCKER_CLIENT_OS))
-	[ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+	[ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged linuxkit/binfmt:v0.8-amd64
 endif
 
 	# Register buildx builder
 	mkdir -p $$HOME/.docker/cli-plugins
 
 	test -f $$HOME/.docker/cli-plugins/docker-buildx || \
-		(wget -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
+		(wget -q -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
 		chmod +x $$HOME/.docker/cli-plugins/docker-buildx)
 
 	# Called directly instead of via `docker buildx` because

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -57,8 +57,7 @@ define DOCKER_BUILDX
 endef
 
 # For non-master builds don't build the docker containers.
-docker-branch: docker-prepare
-	$(call DOCKER_BUILDX,$(VERSION),)
+docker-branch:
 
 # For master builds don't build the docker containers.
 docker-master:

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -17,9 +17,9 @@ DOCKER_IMAGE_NAME = smallstep/step-ca
 
 docker-prepare:
 	# Ensure, we can build for ARM architecture
-ifeq (linux,$(DOCKER_CLIENT_OS))
-	[ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged linuxkit/binfmt:v0.8-amd64
-endif
+# ifeq (linux,$(DOCKER_CLIENT_OS))
+	# [ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged linuxkit/binfmt:v0.8-amd64
+# endif
 
 	# Register buildx builder
 	mkdir -p $$HOME/.docker/cli-plugins
@@ -28,8 +28,6 @@ endif
 		(wget -q -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
 		chmod +x $$HOME/.docker/cli-plugins/docker-buildx)
 
-	# Called directly instead of via `docker buildx` because
-	# Travis runs a pre-19.03 Docker that doesn't support plugin discovery
 	docker buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
 
 .PHONY: docker-prepare

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -6,9 +6,6 @@
 # binary is copied to a new image that is optimized for size.
 #########################################
 
-# Testing: output images to out/ with -o out, like this:
-# docker buildx build . --progress plain -t step-ca:master  -f docker/Dockerfile --platform linux/amd64,linux/arm/v7,linux/386,linux/arm64 -o out
-
 ifeq (, $(shell which docker))
 	DOCKER_CLIENT_OS := linux
 else
@@ -33,7 +30,7 @@ endif
 
 	# Called directly instead of via `docker buildx` because
 	# Travis runs a pre-19.03 Docker that doesn't support plugin discovery
-	$$HOME/.docker/cli-plugins/docker-buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
+	docker buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
 
 .PHONY: docker-prepare
 
@@ -58,11 +55,12 @@ docker-login:
 define DOCKER_BUILDX
 	# $(1) -- Image Tag
 	# $(2) -- Push (empty is no push | --push will push to dockerhub)
-	$$HOME/.docker/cli-plugins/docker-buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile.step-ca --platform="$(DOCKER_PLATFORMS)" $(2)
+	docker buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile.step-ca --platform="$(DOCKER_PLATFORMS)" $(2)
 endef
 
 # For non-master builds don't build the docker containers.
-docker-branch:
+docker-branch: docker-prepare
+	$(call DOCKER_BUILDX,$(VERSION),)
 
 # For master builds don't build the docker containers.
 docker-master:

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -17,9 +17,9 @@ DOCKER_IMAGE_NAME = smallstep/step-ca
 
 docker-prepare:
 	# Ensure, we can build for ARM architecture
-# ifeq (linux,$(DOCKER_CLIENT_OS))
-	# [ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged linuxkit/binfmt:v0.8-amd64
-# endif
+ifeq (linux,$(DOCKER_CLIENT_OS))
+	[ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged linuxkit/binfmt:v0.8-amd64
+endif
 
 	# Register buildx builder
 	mkdir -p $$HOME/.docker/cli-plugins


### PR DESCRIPTION
Just a couple cleanups here:
- Upgrade Travis VM to Ubuntu 20.04 — which comes with Docker 19.03
- Fix `.travis.yml` based on their linter's recommendations
- `docker/binfmt` is now 'linuxkit/binfmt`
- Docker 19.03: use `docker buildx` subcommand instead of calling `docker-buildx` directly
