### PR TITLE
Update Dockerfile.step-ca to match best practices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+README.md
+.gitignore
+bin
+coverage.txt
+*.test
+*.out
+.travis-releases

--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -1,24 +1,27 @@
 FROM golang:alpine AS builder
 
-RUN mkdir /src
-ADD . /src
+WORKDIR /src
+COPY . .
 
-RUN apk add --no-cache make git curl && \
-    cd /src && \
-    make V=1 bin/step-ca 
+RUN apk add --no-cache \
+   curl \
+   git \
+   make && \
+   make V=1 bin/step-ca
 
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 
-ENV CONFIGPATH="/home/step/config/ca.json"
-ENV PWDPATH="/home/step/secrets/password"
-
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
 USER step
 
+ENV CONFIGPATH="/home/step/config/ca.json"
+ENV PWDPATH="/home/step/secrets/password"
+
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
+HEALTHCHECK CMD curl --cacert /home/step/certs/root_ca.crt -sSf https://localhost/health >/dev/null || exit 1
 
 CMD exec /bin/sh -c "/usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH"

--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -22,6 +22,6 @@ ENV PWDPATH="/home/step/secrets/password"
 
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
-HEALTHCHECK CMD curl --cacert /home/step/certs/root_ca.crt -sSf https://localhost/health >/dev/null || exit 1
+HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 
-CMD exec /bin/sh -c "/usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH"
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH


### PR DESCRIPTION
- Use `COPY` instead of `ADD`, because `ADD` does Magical Things that we don't need (like auto-ungzipping)
- Use `WORKDIR` instead of `RUN mkdir`
- Added a `.dockerignore` file to reduce the build context size
- Added a `HEALTHCHECK` for the CA (runs every 30 seconds and reports health status in `docker ps`)
- The `CMD exec` is already a [shell form `CMD`](https://docs.docker.com/engine/reference/builder/#cmd), so it doesn't need `/bin/sh -c` (which ends up being redundant). I tested that `docker kill -s HUP` still works properly.

See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
