### PR TITLE
avoid using yubikey attestation cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/aws/aws-sdk-go v1.30.29
 	github.com/go-chi/chi v4.0.2+incompatible
-	github.com/go-piv/piv-go v1.5.0
+	github.com/go-piv/piv-go v1.6.0
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
 	github.com/lunixbochs/vtclean v1.0.0 // indirect

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -141,7 +141,7 @@ func (k *YubiKey) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 	}
 
 	priv, err := k.yk.PrivateKey(slot, cert.PublicKey, piv.KeyAuth{
-		PIN: k.pin,
+		PIN:       k.pin,
 		PINPolicy: piv.PINPolicyAlways,
 	})
 	if err != nil {

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -142,7 +142,7 @@ func (k *YubiKey) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 
 	priv, err := k.yk.PrivateKey(slot, cert.PublicKey, piv.KeyAuth{
 		PIN: k.pin,
-		PINPolicy:   piv.PINPolicyAlways,
+		PINPolicy: piv.PINPolicyAlways,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving private key")

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -142,6 +142,7 @@ func (k *YubiKey) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 
 	priv, err := k.yk.PrivateKey(slot, cert.PublicKey, piv.KeyAuth{
 		PIN: k.pin,
+		PINPolicy:   piv.PINPolicyAlways,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving private key")


### PR DESCRIPTION
With piv-go 1.5.0, the lib tries to use the yubikey attestation certificate to guess the PIN policy, which seems quite crazy.
Attestation certificate can be found on yubikey only in the case of yubikey-self-generated private key. In our use case we do have an external-generated key we want to back up and carefully import on the yubikey, so we don't have the attestation certificate.

This PR transmits the PINPolicy "always" to the piv-go pkg to make it clear we have the PIN and don't want the lib to guess the PINPolicy value. This option is introduced in piv-go 1.6.0.

It solves the use of the Yubikey key storage with externally generated keys.

See : https://github.com/go-piv/piv-go/blob/b3946de126a897b5129fef09d836e425cf1fc721/piv/key.go#L687

- transmits the PINPolicy "always" to the piv-go pkg
- bump piv-go version to 1.6.0
