### PR TITLE
Add step-awskms-init to the binary releases.

### DIFF
--- a/make/bundle.sh
+++ b/make/bundle.sh
@@ -9,6 +9,7 @@ STEP_PLATFORM=$4
 STEP_ARCH=$5
 STEP_EXEC_NAME=$6
 STEP_CLOUDKMS_EXEC_NAME=$7
+STEP_AWSKMS_EXEC_NAME=$8
 
 BUNDLE_DIR=${OUTPUT_DIR}/bundle
 
@@ -22,6 +23,7 @@ mkdir -p "$newdir/bin"
 
 cp "$OUTPUT_DIR/bin/${STEP_EXEC_NAME}" "$newdir/bin/${STEP_EXEC_NAME}"
 cp "$OUTPUT_DIR/bin/${STEP_CLOUDKMS_EXEC_NAME}" "$newdir/bin/${STEP_CLOUDKMS_EXEC_NAME}"
+cp "$OUTPUT_DIR/bin/${STEP_AWSKMS_EXEC_NAME}" "$newdir/bin/${STEP_AWSKMS_EXEC_NAME}"
 
 cp README.md "$newdir"
 NEW_BUNDLE="${RELEASE_DIR}/step-certificates_${STEP_PLATFORM}_${STEP_VERSION}_${STEP_ARCH}.tar.gz"


### PR DESCRIPTION
### Description

This PR adds the missing step to add `step-awskms-init` to binary releases.

Fixes #332