### PR TITLE
Bump go-piv to v1.7.0 for x32 overflow fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/aws/aws-sdk-go v1.30.29
 	github.com/go-chi/chi v4.0.2+incompatible
-	github.com/go-piv/piv-go v1.6.0
+	github.com/go-piv/piv-go v1.7.0
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gax-go/v2 v2.0.5


### PR DESCRIPTION
### Description
While attempting to compile step-ca for my Raspberry Pi 3+ (armv7l, 32bit), I kept running into this error when compiling with `CGO_ENABLED=1` in the Makefile and env vars: `GOOS=linux`, `GOARCH=arm`:
```sh
$ make build GOFLAGS=""
github.com/go-piv/piv-go/piv
# github.com/go-piv/piv-go/piv
../../go/pkg/mod/github.com/go-piv/piv-go@v1.6.0/piv/pcsc_linux.go:29:12: constant 2148532270 overflows _Ctype_long
Makefile:83: recipe for target 'bin/step-ca' failed
make: *** [bin/step-ca] Error 2
```

Some quick Googling led me to [the pull request that fixes this](https://github.com/go-piv/piv-go/pull/81) and I saw that it was released in [v1.7.0](https://github.com/go-piv/piv-go/releases/tag/v1.7.0)

I'm a Golang newbie but it looks like simply bumping the `go-piv` dependency might be all that is required to get this fix into the next release of step-ca. After doing so locally I got past the compilation error 😄 