### PR TITLE
Note that libpcsclite is required to build from source

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,7 @@ to manage issues, etc.
 
 ## Building From Source
 
-The only prerequisites are [`go`](https://golang.org/) and make.
+The only prerequisites are [`go`](https://golang.org/), `make` and `libpcsclite` for YubiKey support.
 
 To build from source:
 


### PR DESCRIPTION
### Description

If this package is not available `make` will fail with this error

```
ERRO Running error: buildir: failed to load package piv: could not load
export data: no export data for "github.com/go-piv/piv-go/piv"
```