### PR TITLE
Permit linting and testing without CGO support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_script:
   - make bootstrap
 script:
-  - make
+  - make travis
   - make artifacts
 after_success:
   - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" || echo "Codecov did

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: lint test build
 
 travis: lintcgo testcgo build
 
-.PHONY: all
+.PHONY: all travis
 
 #########################################
 # Bootstrapping

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ OUTPUT_ROOT=output/
 
 all: lint test build
 
+travis: lintcgo testcgo build
+
 .PHONY: all
 
 #########################################
@@ -119,9 +121,12 @@ generate:
 # Test
 #########################################
 test:
+	$Q $(GOFLAGS) go test -short -coverprofile=coverage.out ./...
+
+testcgo:
 	$Q go test -short -coverprofile=coverage.out ./...
 
-.PHONY: test
+.PHONY: test testcgo
 
 integrate: integration
 
@@ -138,9 +143,12 @@ fmt:
 	$Q gofmt -l -w $(SRC)
 
 lint:
+	$Q $(GOFLAGS) LOG_LEVEL=error golangci-lint run --timeout=30m
+
+lintcgo:
 	$Q LOG_LEVEL=error golangci-lint run --timeout=30m
 
-.PHONY: lint fmt
+.PHONY: fmt lint lintcgo
 
 #########################################
 # Install

--- a/kms/pkcs11/other_test.go
+++ b/kms/pkcs11/other_test.go
@@ -1,4 +1,4 @@
-// +build !softhsm2,!yubihsm2,!opensc
+// +build cgo,!softhsm2,!yubihsm2,!opensc
 
 package pkcs11
 

--- a/kms/pkcs11/softhsm2_test.go
+++ b/kms/pkcs11/softhsm2_test.go
@@ -1,4 +1,4 @@
-// +build softhsm2
+// +build cgo,softhsm2
 
 package pkcs11
 

--- a/kms/pkcs11/yubihsm2_test.go
+++ b/kms/pkcs11/yubihsm2_test.go
@@ -1,4 +1,4 @@
-// +build yubihsm2
+// +build cgo,yubihsm2
 
 package pkcs11
 


### PR DESCRIPTION
### Description

Do not require CGO (and dependencies like libpcsclite) when doing `make`, but require CGO for testing and linting in travis.
Fixes #471
