### PR TITLE
CloudKMS signer with errors

### DIFF
--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -141,6 +141,17 @@ func (k *CloudKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, 
 		return nil, errors.New("signing key cannot be empty")
 	}
 
+	// Validate that the key exists
+	ctx, cancel := defaultContext()
+	defer cancel()
+
+	_, err := k.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
+		Name: req.SigningKey,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "cloudKMS GetPublicKey failed")
+	}
+
 	return NewSigner(k.client, req.SigningKey), nil
 }
 

--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -140,19 +140,7 @@ func (k *CloudKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, 
 	if req.SigningKey == "" {
 		return nil, errors.New("signing key cannot be empty")
 	}
-
-	// Validate that the key exists
-	ctx, cancel := defaultContext()
-	defer cancel()
-
-	_, err := k.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
-		Name: req.SigningKey,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "cloudKMS GetPublicKey failed")
-	}
-
-	return NewSigner(k.client, req.SigningKey), nil
+	return NewSigner(k.client, req.SigningKey)
 }
 
 // CreateKey creates in Google's Cloud KMS a new asymmetric key for signing.


### PR DESCRIPTION
### Description

This PR refactors a little bit the crypto.Signer cloudkms to return an error on the constructor, we preload the public key on the constructor, so we can verify that it exists. We're doing the same thing in the awskms.

Fixes #487