### PR TITLE
Add step-ca Windows build & Scoop release to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm
@@ -20,6 +21,9 @@ builds:
       - 386
     goarm:
       - 7
+    ignore:
+     - goos: windows
+       goarch: 386
     flags:
       - -trimpath
     main: ./cmd/step-ca/main.go
@@ -33,6 +37,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm
@@ -40,6 +45,9 @@ builds:
       - 386
     goarm:
       - 7
+    ignore:
+     - goos: windows
+       goarch: 386
     flags:
       - -trimpath
     main: ./cmd/step-cloudkms-init/main.go
@@ -53,6 +61,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm
@@ -60,6 +69,9 @@ builds:
       - 386
     goarm:
       - 7
+    ignore:
+     - goos: windows
+       goarch: 386
     flags:
       - -trimpath
     main: ./cmd/step-awskms-init/main.go
@@ -124,41 +136,41 @@ release:
   #  - glob: ./glob/**/to/**/file/**/*
   #  - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
 
-  #scoop:
-  #  # Template for the url which is determined by the given Token (github or gitlab)
-  #  # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  #  # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
-  #  # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  #  url_template: "http://github.com/smallstep/certificates/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  #
-  #  # Repository to push the app manifest to.
-  #  bucket:
-  #    owner: smallstep
-  #    name: scoop-bucket
-  #
-  #  # Git author used to commit to the repository.
-  #  # Defaults are shown.
-  #  commit_author:
-  #    name: goreleaserbot
-  #    email: goreleaser@smallstep.com
-  #
-  #  # The project name and current git tag are used in the format string.
-  #  commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
-  #
-  #  # Your app's homepage.
-  #  # Default is empty.
-  #  homepage: "https://smallstep.com/docs/step-ca"
-  #
-  #  # Skip uploads for prerelease.
-  #  skip_upload: auto
-  #
-  #  # Your app's description.
-  #  # Default is empty.
-  #  description: "A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH."
-  #
-  #  # Your app's license
-  #  # Default is empty.
-  #  license: "Apache-2.0"
+  scoop:
+    # Template for the url which is determined by the given Token (github or gitlab)
+    # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+    # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "http://github.com/smallstep/certificates/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Repository to push the app manifest to.
+    bucket:
+      owner: smallstep
+      name: scoop-bucket
+
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@smallstep.com
+
+    # The project name and current git tag are used in the format string.
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://smallstep.com/docs/step-ca"
+
+    # Skip uploads for prerelease.
+    skip_upload: auto
+
+    # Your app's description.
+    # Default is empty.
+    description: "A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH."
+
+    # Your app's license
+    # Default is empty.
+    license: "Apache-2.0"
 
   #dockers:
   #  - dockerfile: docker/Dockerfile


### PR DESCRIPTION
This will need a little testing when we cut the next release.
Mariano merged the remaining issue that was making step-ca bork on Windows PowerShell.
