### PR TITLE
PKCS11 Init Pin Flag

### DIFF
--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -119,7 +119,7 @@ func main() {
 		fatal(err)
 	}
 
-	if u.Pin() == "" {
+	if u.Pin() == "" && c.Pin == "" {
 		pin, err := ui.PromptPassword("What is the PKCS#11 PIN?")
 		if err != nil {
 			fatal(err)

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -94,6 +94,7 @@ func main() {
 
 	var c Config
 	flag.StringVar(&c.KMS, "kms", kmsuri, "PKCS #11 URI with the module-path and token to connect to the module.")
+	flag.StringVar(&c.Pin, "pin", "", "PKCS #11 PIN")
 	flag.StringVar(&c.RootObject, "root-cert", "pkcs11:id=7330;object=root-cert", "PKCS #11 URI with object id and label to store the root certificate.")
 	flag.StringVar(&c.RootKeyObject, "root-key", "pkcs11:id=7330;object=root-key", "PKCS #11 URI with object id and label to store the root key.")
 	flag.StringVar(&c.CrtObject, "crt-cert", "pkcs11:id=7331;object=intermediate-cert", "PKCS #11 URI with object id and label to store the intermediate certificate.")


### PR DESCRIPTION
Adds a "pin" flag to cmd/step-pkcs11-init so that it can take it as input from another program
