### PR TITLE
RA mode improvements

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -23,9 +23,10 @@ import (
 )
 
 type options struct {
-	configFile string
-	password   []byte
-	database   db.AuthDB
+	configFile     string
+	password       []byte
+	issuerPassword []byte
+	database       db.AuthDB
 }
 
 func (o *options) apply(opts []Option) {
@@ -50,6 +51,14 @@ func WithConfigFile(name string) Option {
 func WithPassword(password []byte) Option {
 	return func(o *options) {
 		o.password = password
+	}
+}
+
+// WithIssuer sets the given password as the configured certificate issuer
+// password in the CA options.
+func WithIssuerPassword(password []byte) Option {
+	return func(o *options) {
+		o.issuerPassword = password
 	}
 }
 
@@ -82,8 +91,16 @@ func New(config *authority.Config, opts ...Option) (*CA, error) {
 
 // Init initializes the CA with the given configuration.
 func (ca *CA) Init(config *authority.Config) (*CA, error) {
-	if l := len(ca.opts.password); l > 0 {
+	// Intermediate Password.
+	if len(ca.opts.password) > 0 {
 		ca.config.Password = string(ca.opts.password)
+	}
+
+	// Certificate issuer password for RA mode.
+	if len(ca.opts.issuerPassword) > 0 {
+		if ca.config.AuthorityConfig != nil && ca.config.AuthorityConfig.CertificateIssuer != nil {
+			ca.config.AuthorityConfig.CertificateIssuer.Password = string(ca.opts.issuerPassword)
+		}
 	}
 
 	var opts []authority.Option
@@ -213,6 +230,7 @@ func (ca *CA) Reload() error {
 
 	newCA, err := New(config,
 		WithPassword(ca.opts.password),
+		WithIssuerPassword(ca.opts.issuerPassword),
 		WithConfigFile(ca.opts.configFile),
 		WithDatabase(ca.auth.GetDatabase()),
 	)

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -54,8 +54,8 @@ func WithPassword(password []byte) Option {
 	}
 }
 
-// WithIssuer sets the given password as the configured certificate issuer
-// password in the CA options.
+// WithIssuerPassword sets the given password as the configured certificate
+// issuer password in the CA options.
 func WithIssuerPassword(password []byte) Option {
 	return func(o *options) {
 		o.issuerPassword = password

--- a/cas/stepcas/issuer.go
+++ b/cas/stepcas/issuer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/ca"
 	"github.com/smallstep/certificates/cas/apiv1"
 )
 
@@ -16,7 +17,7 @@ type stepIssuer interface {
 }
 
 // newStepIssuer returns the configured step issuer.
-func newStepIssuer(caURL *url.URL, iss *apiv1.CertificateIssuer) (stepIssuer, error) {
+func newStepIssuer(caURL *url.URL, client *ca.Client, iss *apiv1.CertificateIssuer) (stepIssuer, error) {
 	if err := validateCertificateIssuer(iss); err != nil {
 		return nil, err
 	}
@@ -25,7 +26,7 @@ func newStepIssuer(caURL *url.URL, iss *apiv1.CertificateIssuer) (stepIssuer, er
 	case "x5c":
 		return newX5CIssuer(caURL, iss)
 	case "jwk":
-		return newJWKIssuer(caURL, iss)
+		return newJWKIssuer(caURL, client, iss)
 	default:
 		return nil, errors.Errorf("stepCAS `certificateIssuer.type` %s is not supported", iss.Type)
 	}
@@ -65,11 +66,11 @@ func validateX5CIssuer(iss *apiv1.CertificateIssuer) error {
 	}
 }
 
-// validateJWKIssuer validates the configuration of jwk issuer.
+// validateJWKIssuer validates the configuration of jwk issuer. If the key is
+// not given, then it will download it from the CA. If the password is not given
+// it will be asked.
 func validateJWKIssuer(iss *apiv1.CertificateIssuer) error {
 	switch {
-	case iss.Key == "":
-		return errors.New("stepCAS `certificateIssuer.key` cannot be empty")
 	case iss.Provisioner == "":
 		return errors.New("stepCAS `certificateIssuer.provisioner` cannot be empty")
 	default:

--- a/cas/stepcas/issuer.go
+++ b/cas/stepcas/issuer.go
@@ -67,8 +67,8 @@ func validateX5CIssuer(iss *apiv1.CertificateIssuer) error {
 }
 
 // validateJWKIssuer validates the configuration of jwk issuer. If the key is
-// not given, then it will download it from the CA. If the password is not given
-// it will be asked.
+// not given, then it will download it from the CA. If the password is not set
+// it will be prompted.
 func validateJWKIssuer(iss *apiv1.CertificateIssuer) error {
 	switch {
 	case iss.Provisioner == "":

--- a/cas/stepcas/issuer_test.go
+++ b/cas/stepcas/issuer_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smallstep/certificates/ca"
 	"github.com/smallstep/certificates/cas/apiv1"
+	"go.step.sm/crypto/jose"
 )
 
 type mockErrIssuer struct{}
@@ -23,15 +25,27 @@ func (m mockErrIssuer) Lifetime(d time.Duration) time.Duration {
 	return d
 }
 
+type mockErrSigner struct{}
+
+func (s *mockErrSigner) Sign(payload []byte) (*jose.JSONWebSignature, error) {
+	return nil, apiv1.ErrNotImplemented{}
+}
+
+func (s *mockErrSigner) Options() jose.SignerOptions {
+	return jose.SignerOptions{}
+}
+
 func Test_newStepIssuer(t *testing.T) {
-	caURL, err := url.Parse("https://ca.smallstep.com")
+	caURL, client := testCAHelper(t)
+	signer, err := newJWKSignerFromEncryptedKey(testKeyID, testEncryptedJWKKey, testPassword)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	type args struct {
-		caURL *url.URL
-		iss   *apiv1.CertificateIssuer
+		caURL  *url.URL
+		client *ca.Client
+		iss    *apiv1.CertificateIssuer
 	}
 	tests := []struct {
 		name    string
@@ -39,7 +53,7 @@ func Test_newStepIssuer(t *testing.T) {
 		want    stepIssuer
 		wantErr bool
 	}{
-		{"x5c", args{caURL, &apiv1.CertificateIssuer{
+		{"x5c", args{caURL, client, &apiv1.CertificateIssuer{
 			Type:        "x5c",
 			Provisioner: "X5C",
 			Certificate: testX5CPath,
@@ -50,16 +64,16 @@ func Test_newStepIssuer(t *testing.T) {
 			keyFile:  testX5CKeyPath,
 			issuer:   "X5C",
 		}, false},
-		{"jwk", args{caURL, &apiv1.CertificateIssuer{
+		{"jwk", args{caURL, client, &apiv1.CertificateIssuer{
 			Type:        "jwk",
 			Provisioner: "ra@doe.org",
 			Key:         testX5CKeyPath,
 		}}, &jwkIssuer{
-			caURL:   caURL,
-			keyFile: testX5CKeyPath,
-			issuer:  "ra@doe.org",
+			caURL:  caURL,
+			issuer: "ra@doe.org",
+			signer: signer,
 		}, false},
-		{"fail", args{caURL, &apiv1.CertificateIssuer{
+		{"fail", args{caURL, client, &apiv1.CertificateIssuer{
 			Type:        "unknown",
 			Provisioner: "ra@doe.org",
 			Key:         testX5CKeyPath,
@@ -67,10 +81,13 @@ func Test_newStepIssuer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newStepIssuer(tt.args.caURL, tt.args.iss)
+			got, err := newStepIssuer(tt.args.caURL, tt.args.client, tt.args.iss)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newStepIssuer() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.args.iss.Type == "jwk" && got != nil && tt.want != nil {
+				got.(*jwkIssuer).signer = tt.want.(*jwkIssuer).signer
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newStepIssuer() = %v, want %v", got, tt.want)

--- a/cas/stepcas/jwk_issuer.go
+++ b/cas/stepcas/jwk_issuer.go
@@ -1,33 +1,55 @@
 package stepcas
 
 import (
+	"crypto"
+	"encoding/json"
 	"net/url"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/authority/provisioner"
+	"github.com/smallstep/certificates/ca"
 	"github.com/smallstep/certificates/cas/apiv1"
+	"go.step.sm/cli-utils/ui"
 	"go.step.sm/crypto/jose"
 	"go.step.sm/crypto/randutil"
 )
 
 type jwkIssuer struct {
-	caURL    *url.URL
-	issuer   string
-	keyFile  string
-	password string
+	caURL  *url.URL
+	issuer string
+	signer jose.Signer
 }
 
-func newJWKIssuer(caURL *url.URL, cfg *apiv1.CertificateIssuer) (*jwkIssuer, error) {
-	_, err := newJWKSigner(cfg.Key, cfg.Password)
-	if err != nil {
-		return nil, err
+func newJWKIssuer(caURL *url.URL, client *ca.Client, cfg *apiv1.CertificateIssuer) (*jwkIssuer, error) {
+	var err error
+	var signer jose.Signer
+	// Read the key from the CA if not provided.
+	// Or read it from a PEM file.
+	if cfg.Key == "" {
+		p, err := findProvisioner(client, provisioner.TypeJWK, cfg.Provisioner)
+		if err != nil {
+			return nil, err
+		}
+		kid, key, ok := p.GetEncryptedKey()
+		if !ok {
+			return nil, errors.Errorf("provisioner with name %s does not have an encrypted key", cfg.Provisioner)
+		}
+		signer, err = newJWKSignerFromEncryptedKey(kid, key, cfg.Password)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		signer, err = newJWKSigner(cfg.Key, cfg.Password)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &jwkIssuer{
-		caURL:    caURL,
-		issuer:   cfg.Provisioner,
-		keyFile:  cfg.Key,
-		password: cfg.Password,
+		caURL:  caURL,
+		issuer: cfg.Provisioner,
+		signer: signer,
 	}, nil
 }
 
@@ -50,18 +72,13 @@ func (i *jwkIssuer) Lifetime(d time.Duration) time.Duration {
 }
 
 func (i *jwkIssuer) createToken(aud, sub string, sans []string) (string, error) {
-	signer, err := newJWKSigner(i.keyFile, i.password)
-	if err != nil {
-		return "", err
-	}
-
 	id, err := randutil.Hex(64) // 256 bits
 	if err != nil {
 		return "", err
 	}
 
 	claims := defaultClaims(i.issuer, sub, aud, id)
-	builder := jose.Signed(signer).Claims(claims)
+	builder := jose.Signed(i.signer).Claims(claims)
 	if len(sans) > 0 {
 		builder = builder.Claims(map[string]interface{}{
 			"sans": sans,
@@ -89,4 +106,52 @@ func newJWKSigner(keyFile, password string) (jose.Signer, error) {
 	so.WithType("JWT")
 	so.WithHeader("kid", kid)
 	return newJoseSigner(signer, so)
+}
+
+func newJWKSignerFromEncryptedKey(kid, key, password string) (jose.Signer, error) {
+	var jwk jose.JSONWebKey
+
+	// If the password is empty it will use the password prompter.
+	b, err := jose.Decrypt([]byte(key),
+		jose.WithPassword([]byte(password)),
+		jose.WithPasswordPrompter("Please enter the password to decrypt the provisioner key", func(msg string) ([]byte, error) {
+			return ui.PromptPassword(msg)
+		}))
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt returns the JSON representation of the JWK.
+	if err := json.Unmarshal(b, &jwk); err != nil {
+		return nil, errors.Wrap(err, "error parsing provisioner key")
+	}
+
+	signer, ok := jwk.Key.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("error parsing provisioner key: key is not a crypto.Signer")
+	}
+
+	so := new(jose.SignerOptions)
+	so.WithType("JWT")
+	so.WithHeader("kid", kid)
+	return newJoseSigner(signer, so)
+}
+
+func findProvisioner(client *ca.Client, typ provisioner.Type, name string) (provisioner.Interface, error) {
+	cursor := ""
+	for {
+		ps, err := client.Provisioners(ca.WithProvisionerCursor(cursor))
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range ps.Provisioners {
+			if p.GetType() == typ && p.GetName() == name {
+				return p, nil
+			}
+		}
+		if ps.NextCursor == "" {
+			return nil, errors.Errorf("provisioner with name %s was not found", name)
+		}
+		cursor = ps.NextCursor
+	}
 }

--- a/cas/stepcas/jwk_issuer_test.go
+++ b/cas/stepcas/jwk_issuer_test.go
@@ -14,11 +14,15 @@ func Test_jwkIssuer_SignToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	signer, err := newJWKSignerFromEncryptedKey(testKeyID, testEncryptedJWKKey, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	type fields struct {
-		caURL   *url.URL
-		keyFile string
-		issuer  string
+		caURL  *url.URL
+		issuer string
+		signer jose.Signer
 	}
 	type args struct {
 		subject string
@@ -35,16 +39,15 @@ func Test_jwkIssuer_SignToken(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"ok", fields{caURL, testX5CKeyPath, "ra@doe.org"}, args{"doe", []string{"doe.org"}}, false},
-		{"fail key", fields{caURL, "", "ra@doe.org"}, args{"doe", []string{"doe.org"}}, true},
-		{"fail no signer", fields{caURL, testIssPath, "ra@doe.org"}, args{"doe", []string{"doe.org"}}, true},
+		{"ok", fields{caURL, "ra@doe.org", signer}, args{"doe", []string{"doe.org"}}, false},
+		{"fail", fields{caURL, "ra@doe.org", &mockErrSigner{}}, args{"doe", []string{"doe.org"}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &jwkIssuer{
-				caURL:   tt.fields.caURL,
-				keyFile: tt.fields.keyFile,
-				issuer:  tt.fields.issuer,
+				caURL:  tt.fields.caURL,
+				issuer: tt.fields.issuer,
+				signer: tt.fields.signer,
 			}
 			got, err := i.SignToken(tt.args.subject, tt.args.sans)
 			if (err != nil) != tt.wantErr {
@@ -78,11 +81,15 @@ func Test_jwkIssuer_RevokeToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	signer, err := newJWKSignerFromEncryptedKey(testKeyID, testEncryptedJWKKey, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	type fields struct {
-		caURL   *url.URL
-		keyFile string
-		issuer  string
+		caURL  *url.URL
+		issuer string
+		signer jose.Signer
 	}
 	type args struct {
 		subject string
@@ -98,16 +105,15 @@ func Test_jwkIssuer_RevokeToken(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"ok", fields{caURL, testX5CKeyPath, "ra@smallstep.com"}, args{"doe"}, false},
-		{"fail key", fields{caURL, "", "ra@smallstep.com"}, args{"doe"}, true},
-		{"fail no signer", fields{caURL, testIssPath, "ra@smallstep.com"}, args{"doe"}, true},
+		{"ok", fields{caURL, "ra@doe.org", signer}, args{"doe"}, false},
+		{"ok", fields{caURL, "ra@doe.org", &mockErrSigner{}}, args{"doe"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &jwkIssuer{
-				caURL:   tt.fields.caURL,
-				keyFile: tt.fields.keyFile,
-				issuer:  tt.fields.issuer,
+				caURL:  tt.fields.caURL,
+				issuer: tt.fields.issuer,
+				signer: tt.fields.signer,
 			}
 			got, err := i.RevokeToken(tt.args.subject)
 			if (err != nil) != tt.wantErr {
@@ -140,11 +146,15 @@ func Test_jwkIssuer_Lifetime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	signer, err := newJWKSignerFromEncryptedKey(testKeyID, testEncryptedJWKKey, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	type fields struct {
-		caURL   *url.URL
-		keyFile string
-		issuer  string
+		caURL  *url.URL
+		issuer string
+		signer jose.Signer
 	}
 	type args struct {
 		d time.Duration
@@ -155,17 +165,70 @@ func Test_jwkIssuer_Lifetime(t *testing.T) {
 		args   args
 		want   time.Duration
 	}{
-		{"ok", fields{caURL, testX5CKeyPath, "ra@smallstep.com"}, args{time.Second}, time.Second},
+		{"ok", fields{caURL, "ra@smallstep.com", signer}, args{time.Second}, time.Second},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &jwkIssuer{
-				caURL:   tt.fields.caURL,
-				keyFile: tt.fields.keyFile,
-				issuer:  tt.fields.issuer,
+				caURL:  tt.fields.caURL,
+				issuer: tt.fields.issuer,
+				signer: tt.fields.signer,
 			}
 			if got := i.Lifetime(tt.args.d); got != tt.want {
 				t.Errorf("jwkIssuer.Lifetime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newJWKSignerFromEncryptedKey(t *testing.T) {
+	encrypt := func(plaintext string) string {
+		recipient := jose.Recipient{
+			Algorithm:  jose.PBES2_HS256_A128KW,
+			Key:        testPassword,
+			PBES2Count: jose.PBKDF2Iterations,
+			PBES2Salt:  []byte{0x01, 0x02},
+		}
+
+		opts := new(jose.EncrypterOptions)
+		opts.WithContentType(jose.ContentType("jwk+json"))
+
+		encrypter, err := jose.NewEncrypter(jose.DefaultEncAlgorithm, recipient, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		jwe, err := encrypter.Encrypt([]byte(plaintext))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ret, err := jwe.CompactSerialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ret
+	}
+
+	type args struct {
+		kid      string
+		key      string
+		password string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"ok", args{testKeyID, testEncryptedJWKKey, testPassword}, false},
+		{"fail decrypt", args{testKeyID, testEncryptedJWKKey, "bad-password"}, true},
+		{"fail unmarshal", args{testKeyID, encrypt(`{not a json}`), testPassword}, true},
+		{"fail not signer", args{testKeyID, encrypt(`{"kty":"oct","k":"password"}`), testPassword}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newJWKSignerFromEncryptedKey(tt.args.kid, tt.args.key, tt.args.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newJWKSignerFromEncryptedKey() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/cas/stepcas/stepcas.go
+++ b/cas/stepcas/stepcas.go
@@ -41,14 +41,14 @@ func New(ctx context.Context, opts apiv1.Options) (*StepCAS, error) {
 		return nil, errors.Wrap(err, "stepCAS `certificateAuthority` is not valid")
 	}
 
-	// Create configured issuer
-	iss, err := newStepIssuer(caURL, opts.CertificateIssuer)
+	// Create client.
+	client, err := ca.NewClient(opts.CertificateAuthority, ca.WithRootSHA256(opts.CertificateAuthorityFingerprint))
 	if err != nil {
 		return nil, err
 	}
 
-	// Create client.
-	client, err := ca.NewClient(opts.CertificateAuthority, ca.WithRootSHA256(opts.CertificateAuthorityFingerprint))
+	// Create configured issuer
+	iss, err := newStepIssuer(caURL, client, opts.CertificateIssuer)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -66,6 +66,7 @@ var appHelpTemplate = `## NAME
 | **{{join .Names ", "}}** | {{.Usage}} |{{end}}
 {{end}}{{if .VisibleFlags}}{{end}}
 ## OPTIONS
+
 {{range $index, $option := .VisibleFlags}}{{if $index}}
 {{end}}{{$option}}
 {{end}}{{end}}{{if .Copyright}}{{if len .Authors}}

--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -106,7 +106,7 @@ func main() {
 	app.HelpName = "step-ca"
 	app.Version = config.Version()
 	app.Usage = "an online certificate authority for secure automated certificate management"
-	app.UsageText = `**step-ca** <config> [**--password-file**=<file>] [**--resolver**=<addr>] [**--help**] [**--version**]`
+	app.UsageText = `**step-ca** <config> [**--password-file**=<file>] [**--issuer-password-file**=<file>] [**--resolver**=<addr>] [**--help**] [**--version**]`
 	app.Description = `**step-ca** runs the Step Online Certificate Authority
 (Step CA) using the given configuration.
 See the README.md for more detailed configuration documentation.

--- a/commands/app.go
+++ b/commands/app.go
@@ -22,13 +22,17 @@ var AppCommand = cli.Command{
 	Name:   "start",
 	Action: appAction,
 	UsageText: `**step-ca** <config>
-	[**--password-file**=<file>]
-	[**--resolver**=<addr>]`,
+[**--password-file**=<file>] [**--issuer-password-file**=<file>] [**--resolver**=<addr>]`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "password-file",
 			Usage: `path to the <file> containing the password to decrypt the
 intermediate private key.`,
+		},
+		cli.StringFlag{
+			Name: "issuer-password-file",
+			Usage: `path to the <file> containing the password to decrypt the
+certificate issuer private key used in the RA mode.`,
 		},
 		cli.StringFlag{
 			Name:  "resolver",
@@ -40,6 +44,7 @@ intermediate private key.`,
 // AppAction is the action used when the top command runs.
 func appAction(ctx *cli.Context) error {
 	passFile := ctx.String("password-file")
+	issuerPassFile := ctx.String("issuer-password-file")
 	resolver := ctx.String("resolver")
 
 	// If zero cmd line args show help, if >1 cmd line args show error.
@@ -64,6 +69,14 @@ func appAction(ctx *cli.Context) error {
 		password = bytes.TrimRightFunc(password, unicode.IsSpace)
 	}
 
+	var issuerPassword []byte
+	if issuerPassFile != "" {
+		if issuerPassword, err = ioutil.ReadFile(issuerPassFile); err != nil {
+			fatal(errors.Wrapf(err, "error reading %s", issuerPassFile))
+		}
+		issuerPassword = bytes.TrimRightFunc(issuerPassword, unicode.IsSpace)
+	}
+
 	// replace resolver if requested
 	if resolver != "" {
 		net.DefaultResolver.PreferGo = true
@@ -72,7 +85,10 @@ func appAction(ctx *cli.Context) error {
 		}
 	}
 
-	srv, err := ca.New(config, ca.WithConfigFile(configFile), ca.WithPassword(password))
+	srv, err := ca.New(config,
+		ca.WithConfigFile(configFile),
+		ca.WithPassword(password),
+		ca.WithIssuerPassword(issuerPassword))
 	if err != nil {
 		fatal(err)
 	}


### PR DESCRIPTION
### Description

This PR extends the StepCAS RA mode with the following improvements:
* Allow passing the issuer password using the flag `--issuer-password-file`. 
* Allow getting the JWK provisioner from the CA using  `GET /provisioners`. This way the JWK key is only held in memory.

Using the remote encrypted key one could run the following `ca.json` like `step-ca --issuer-password-file pass.txt ca.json`:
```
{
	"address": ":9100",
	"dnsNames": ["ra.smallstep.com"],
	"db": {
		"type": "badgerV2",
		"dataSource": "/home/step/db"
	},
	"logger": {"format": "text"},
	"authority": {
		"type": "stepcas",
		"certificateAuthority": "https://ca.smallstep.com:9000",
		"certificateAuthorityFingerprint": "b4fc6b547ca4610b69cfcc53c6933e7a37170476dfe134a2c257726f92c403f5",
		"certificateIssuer": {
			"type": "jwk", 
			"provisioner": "ra@doe.org"
		},
		"provisioners": [{
			"type": "ACME",
			"name": "acme"
		}]
	},
	"tls": {
		"cipherSuites": [
			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
		],
		"minVersion": 1.2,
		"maxVersion": 1.3,
		"renegotiation": false
	}
}
```