### PR TITLE
Add experimental support for a TLS over TLS tunnel.

### DIFF
--- a/ca/client.go
+++ b/ca/client.go
@@ -56,10 +56,7 @@ func newClient(transport http.RoundTripper) *uaClient {
 func newInsecureClient() *uaClient {
 	return &uaClient{
 		Client: &http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			Transport: getDefaultTransport(&tls.Config{InsecureSkipVerify: true}),
 		},
 	}
 }
@@ -292,7 +289,7 @@ func getTransportFromFile(filename string) (http.RoundTripper, error) {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		RootCAs:                  pool,
-	})
+	}), nil
 }
 
 func getTransportFromSHA256(endpoint, sum string) (http.RoundTripper, error) {
@@ -311,7 +308,7 @@ func getTransportFromSHA256(endpoint, sum string) (http.RoundTripper, error) {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		RootCAs:                  pool,
-	})
+	}), nil
 }
 
 func getTransportFromCABundle(bundle []byte) (http.RoundTripper, error) {
@@ -323,7 +320,7 @@ func getTransportFromCABundle(bundle []byte) (http.RoundTripper, error) {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		RootCAs:                  pool,
-	})
+	}), nil
 }
 
 // parseEndpoint parses and validates the given endpoint. It supports general

--- a/ca/client.go
+++ b/ca/client.go
@@ -99,12 +99,13 @@ type RetryFunc func(code int) bool
 type ClientOption func(o *clientOptions) error
 
 type clientOptions struct {
-	transport    http.RoundTripper
-	rootSHA256   string
-	rootFilename string
-	rootBundle   []byte
-	certificate  tls.Certificate
-	retryFunc    RetryFunc
+	transport            http.RoundTripper
+	rootSHA256           string
+	rootFilename         string
+	rootBundle           []byte
+	certificate          tls.Certificate
+	getClientCertificate func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+	retryFunc            RetryFunc
 }
 
 func (o *clientOptions) apply(opts []ClientOption) (err error) {
@@ -139,6 +140,7 @@ func (o *clientOptions) applyDefaultIdentity() error {
 		return nil
 	}
 	o.certificate = crt
+	o.getClientCertificate = i.GetClientCertificateFunc()
 	return nil
 }
 
@@ -193,6 +195,7 @@ func (o *clientOptions) getTransport(endpoint string) (tr http.RoundTripper, err
 			}
 			if len(tr.TLSClientConfig.Certificates) == 0 && tr.TLSClientConfig.GetClientCertificate == nil {
 				tr.TLSClientConfig.Certificates = []tls.Certificate{o.certificate}
+				tr.TLSClientConfig.GetClientCertificate = o.getClientCertificate
 			}
 		case *http2.Transport:
 			if tr.TLSClientConfig == nil {
@@ -200,6 +203,7 @@ func (o *clientOptions) getTransport(endpoint string) (tr http.RoundTripper, err
 			}
 			if len(tr.TLSClientConfig.Certificates) == 0 && tr.TLSClientConfig.GetClientCertificate == nil {
 				tr.TLSClientConfig.Certificates = []tls.Certificate{o.certificate}
+				tr.TLSClientConfig.GetClientCertificate = o.getClientCertificate
 			}
 		default:
 			return nil, errors.Errorf("unsupported transport type %T", tr)

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -186,7 +186,7 @@ func (i *Identity) Validate() error {
 		return fileExists(i.Key)
 	case TunnelTLS:
 		if i.Host == "" {
-			return errors.New("tunnel.crt cannot be empty")
+			return errors.New("tunnel.host cannot be empty")
 		}
 		if i.Certificate != "" {
 			if err := fileExists(i.Certificate); err != nil {

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -26,8 +26,15 @@ type Type string
 // Disabled represents a disabled identity type
 const Disabled Type = ""
 
-// MutualTLS represents the identity using mTLS
+// MutualTLS represents the identity using mTLS.
 const MutualTLS Type = "mTLS"
+
+// TunnelTLS represents an identity using a (m)TLS tunnel.
+//
+// TunnelTLS can be optionally configured with client certificates and a root
+// file with the CAs to trust. By default it will use the system truststore
+// instead of the CA truststore.
+const TunnelTLS Type = "tTLS"
 
 // DefaultLeeway is the duration for matching not before claims.
 const DefaultLeeway = 1 * time.Minute
@@ -44,19 +51,30 @@ type Identity struct {
 	Type        string `json:"type"`
 	Certificate string `json:"crt"`
 	Key         string `json:"key"`
+
+	// Host is the tunnel host for a TunnelTLS (tTLS) identity.
+	Host string `json:"host,omitempty"`
+	// Root is the CA bundle of root CAs used in TunnelTLS to trust the
+	// certificate of the host.
+	Root string `json:"root,omitempty"`
+}
+
+// LoadIdentity loads an identity present in the given filename.
+func LoadIdentity(filename string) (*Identity, error) {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading %s", filename)
+	}
+	identity := new(Identity)
+	if err := json.Unmarshal(b, &identity); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshaling %s", filename)
+	}
+	return identity, nil
 }
 
 // LoadDefaultIdentity loads the default identity.
 func LoadDefaultIdentity() (*Identity, error) {
-	b, err := ioutil.ReadFile(IdentityFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading %s", IdentityFile)
-	}
-	identity := new(Identity)
-	if err := json.Unmarshal(b, &identity); err != nil {
-		return nil, errors.Wrapf(err, "error unmarshaling %s", IdentityFile)
-	}
-	return identity, nil
+	return LoadIdentity(IdentityFile)
 }
 
 // configDir and identityDir are used in WriteDefaultIdentity for testing
@@ -81,7 +99,7 @@ func WriteDefaultIdentity(certChain []api.Certificate, key crypto.PrivateKey) er
 	keyFilename := filepath.Join(identityDir, "identity_key")
 
 	// Write certificate
-	if err := WriteIdentityCertificate(certChain); err != nil {
+	if err := writeCertificate(certFilename, certChain); err != nil {
 		return err
 	}
 
@@ -116,22 +134,21 @@ func WriteDefaultIdentity(certChain []api.Certificate, key crypto.PrivateKey) er
 	return nil
 }
 
-// WriteIdentityCertificate writes the identity certificate in disk.
-func WriteIdentityCertificate(certChain []api.Certificate) error {
+// writeCertificate writes the given certificate on disk.
+func writeCertificate(filename string, certChain []api.Certificate) error {
 	buf := new(bytes.Buffer)
-	certFilename := filepath.Join(identityDir, "identity.crt")
 	for _, crt := range certChain {
 		block := &pem.Block{
 			Type:  "CERTIFICATE",
 			Bytes: crt.Raw,
 		}
 		if err := pem.Encode(buf, block); err != nil {
-			return errors.Wrap(err, "error encoding identity certificate")
+			return errors.Wrap(err, "error encoding certificate")
 		}
 	}
 
-	if err := ioutil.WriteFile(certFilename, buf.Bytes(), 0600); err != nil {
-		return errors.Wrap(err, "error writing identity certificate")
+	if err := ioutil.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+		return errors.Wrap(err, "error writing certificate")
 	}
 
 	return nil
@@ -144,6 +161,8 @@ func (i *Identity) Kind() Type {
 		return Disabled
 	case "mtls":
 		return MutualTLS
+	case "ttls":
+		return TunnelTLS
 	default:
 		return Type(i.Type)
 	}
@@ -164,8 +183,26 @@ func (i *Identity) Validate() error {
 		if err := fileExists(i.Certificate); err != nil {
 			return err
 		}
-		if err := fileExists(i.Key); err != nil {
-			return err
+		return fileExists(i.Key)
+	case TunnelTLS:
+		if i.Host == "" {
+			return errors.New("tunnel.crt cannot be empty")
+		}
+		if i.Certificate != "" {
+			if err := fileExists(i.Certificate); err != nil {
+				return err
+			}
+			if i.Key == "" {
+				return errors.New("tunnel.key cannot be empty")
+			}
+			if err := fileExists(i.Key); err != nil {
+				return err
+			}
+		}
+		if i.Root != "" {
+			if err := fileExists(i.Root); err != nil {
+				return err
+			}
 		}
 		return nil
 	default:
@@ -179,7 +216,7 @@ func (i *Identity) TLSCertificate() (tls.Certificate, error) {
 	switch i.Kind() {
 	case Disabled:
 		return tls.Certificate{}, nil
-	case MutualTLS:
+	case MutualTLS, TunnelTLS:
 		crt, err := tls.LoadX509KeyPair(i.Certificate, i.Key)
 		if err != nil {
 			return fail(errors.Wrap(err, "error creating identity certificate"))
@@ -215,6 +252,22 @@ func (i *Identity) GetClientCertificateFunc() func(*tls.CertificateRequestInfo) 
 	}
 }
 
+// GetCertPool returns a x509.CertPool if the identity defines a custom root.
+func (i *Identity) GetCertPool() (*x509.CertPool, error) {
+	if i.Root == "" {
+		return nil, nil
+	}
+	b, err := ioutil.ReadFile(i.Root)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading identity root")
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(b) {
+		return nil, errors.Errorf("error pasing identity root: %s does not contain any certificate", i.Root)
+	}
+	return pool, nil
+}
+
 // Renewer is that interface that a renew client must implement.
 type Renewer interface {
 	GetRootCAs() *x509.CertPool
@@ -227,7 +280,7 @@ func (i *Identity) Renew(client Renewer) error {
 	switch i.Kind() {
 	case Disabled:
 		return nil
-	case MutualTLS:
+	case MutualTLS, TunnelTLS:
 		cert, err := i.TLSCertificate()
 		if err != nil {
 			return err

--- a/ca/identity/testdata/config/tunnel.json
+++ b/ca/identity/testdata/config/tunnel.json
@@ -1,0 +1,7 @@
+{
+    "type": "mTLS",
+    "crt": "testdata/identity/identity.crt",
+    "key": "testdata/identity/identity_key",
+    "host": "tunnel:443",
+    "root": "testdata/certs/root_ca.crt"
+}

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -23,10 +23,10 @@ import (
 var mTLSDialContext func() func(ctx context.Context, network, address string) (net.Conn, error)
 
 func init() {
-	// STEP_TLS_TUNNEL is an environment that can be set to do an TLS over
-	// (m)TLS tunnel to step-ca using identity-like credentials. The value is a
-	// path to a json file with the tunnel host, certificate, key and root used
-	// to create the (m)TLS tunnel.
+	// STEP_TLS_TUNNEL is an environment variable that can be set to do an TLS
+	// over (m)TLS tunnel to step-ca using identity-like credentials. The value
+	// is a path to a json file with the tunnel host, certificate, key and root
+	// used to create the (m)TLS tunnel.
 	//
 	// The configuration should look like:
 	//  {

--- a/ca/tls_test.go
+++ b/ca/tls_test.go
@@ -181,13 +181,8 @@ func TestClient_GetServerTLSConfig_http(t *testing.T) {
 				t.Errorf("Client.GetClientTLSConfig() error = %v", err)
 				return nil
 			}
-			tr, err := getDefaultTransport(tlsConfig)
-			if err != nil {
-				t.Errorf("getDefaultTransport() error = %v", err)
-				return nil
-			}
 			return &http.Client{
-				Transport: tr,
+				Transport: getDefaultTransport(tlsConfig),
 			}
 		}, map[string]bool{srvTLS.URL: false, srvMTLS.URL: false}},
 		{"with no ClientCert", func(t *testing.T, client *Client, sr *api.SignResponse, pk crypto.PrivateKey) *http.Client {
@@ -199,14 +194,8 @@ func TestClient_GetServerTLSConfig_http(t *testing.T) {
 			tlsConfig := getDefaultTLSConfig(sr)
 			tlsConfig.RootCAs = x509.NewCertPool()
 			tlsConfig.RootCAs.AddCert(root)
-
-			tr, err := getDefaultTransport(tlsConfig)
-			if err != nil {
-				t.Errorf("getDefaultTransport() error = %v", err)
-				return nil
-			}
 			return &http.Client{
-				Transport: tr,
+				Transport: getDefaultTransport(tlsConfig),
 			}
 		}, map[string]bool{srvTLS.URL + "/no-cert": false, srvMTLS.URL + "/no-cert": true}},
 		{"fail with default", func(t *testing.T, client *Client, sr *api.SignResponse, pk crypto.PrivateKey) *http.Client {
@@ -288,10 +277,7 @@ func TestClient_GetServerTLSConfig_renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Client.GetClientTLSConfig() error = %v", err)
 	}
-	tr2, err := getDefaultTransport(tlsConfig)
-	if err != nil {
-		t.Fatalf("getDefaultTransport() error = %v", err)
-	}
+	tr2 := getDefaultTransport(tlsConfig)
 	// No client cert
 	root, err := RootCertificate(sr)
 	if err != nil {
@@ -300,10 +286,7 @@ func TestClient_GetServerTLSConfig_renew(t *testing.T) {
 	tlsConfig = getDefaultTLSConfig(sr)
 	tlsConfig.RootCAs = x509.NewCertPool()
 	tlsConfig.RootCAs.AddCert(root)
-	tr3, err := getDefaultTransport(tlsConfig)
-	if err != nil {
-		t.Fatalf("getDefaultTransport() error = %v", err)
-	}
+	tr3 := getDefaultTransport(tlsConfig)
 
 	// Disable keep alives to force TLS handshake
 	tr1.DisableKeepAlives = true

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -313,7 +313,7 @@ func getSlotAndName(name string) (piv.Slot, string, error) {
 
 	s, ok := slotMapping[slotID]
 	if !ok {
-		return piv.Slot{}, "", errors.Errorf("usupported slot-id '%s'", name)
+		return piv.Slot{}, "", errors.Errorf("unsupported slot-id '%s'", name)
 	}
 
 	name = "yubikey:slot-id=" + url.QueryEscape(slotID)


### PR DESCRIPTION
### Description
This PR adds experimental support for TLS over (m)TLS tunnel, this can be useful in configurations like:

```
step-ca (ra-mode) <--> ghostunnel server <--> step-ca
```

If the RA is started with the environment variable `STEP_TLS_TUNNEL=ghostunnel:9000` it will connect to ghostunnel server using as client certificate the identity certificates if available. And then it will talk HTTPS over that connection.

How to test it:
1. Start CA (ca.smallstep.com):
```sh
step-ca /etc/step-ca/ca.json
```
2. Create a certificate for ghostunnel:
```sh
step ca certificate ghostunnel.smallstep.com gt.crt gt.key
```
3. Start ghostunnel server (ghostunnel.smallstep.com)
```sh
ghostunnel server --cert gt.crt --key gt.key --cacert root_ca.crt \
  --listen :9000 --target ca.smallstep.com:9000 --allow-cn ra.smallstep.com
```
4. Create the certificate for the RA:
```sh
step ca certificate ra.smallstep.com ra.crt ra.key
```
5. Create the configuration for the tunnel:
```sh
$ cat $(step path)/config/tunnel.json
{
    "type": "tTLS",
    "host": "ghostunnel.smallstep.com:9000",
    "crt": "ra.crt",
    "key": "ra.key",
    "root": "root_ca.crt"
}
```
6. Start RA (ra.smallstep.com):
```
STEP_TLS_TUNNEL=$(step path)/config/tunnel.json step-ca /etc/step-ca/ra.json
```
7. Test:
```
step ca certificate --ca-url https://ra.smallstep.com:9000 jane@doe.com jane.crt jane.key
```

**Notes**:
* Currently the RA identity certificate (if available) is read on every client connection to ghostunnel, basically every time the RA needs to sign a certificate.