### PR TITLE
Always specify a Proxy in all custom transports.

### DIFF
--- a/ca/client.go
+++ b/ca/client.go
@@ -57,6 +57,7 @@ func newInsecureClient() *uaClient {
 	return &uaClient{
 		Client: &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		},


### PR DESCRIPTION
### Description
This PR changes all the custom transports being used to add `Proxy: http.ProxyFromEnvironment`

Fixes #535
