### PR TITLE
Update provisioners.md

### DIFF
--- a/docs/provisioners.md
+++ b/docs/provisioners.md
@@ -191,7 +191,7 @@ In the ca.json configuration file, a complete JWK provisioner example looks like
 ### OIDC
 
 An OIDC provisioner allows a user to get a certificate after authenticating
-himself with an OAuth OpenID Connect identity provider. The ID token provided
+themself with an OAuth OpenID Connect identity provider. The ID token provided
 will be used on the CA authentication, and by default, the certificate will only
 have the user's email as a Subject Alternative Name (SAN) Extension.
 


### PR DESCRIPTION
"Themself" over "himself" is gender neutral. Not sure that anyone would notice or care, but just want to make it a happy place for everyone. Grammar is not my strong suite, so I won't make a fuss if this doesn't get merged.

### Description
added Gender neutral vernacular though i've gone back and fourth on the grammar (themself vs Themselves). Again, won't be upset if this doesn't get merged.

💔Thank you!
