### PR TITLE
Added missing hints for running step-ca on Raspberry Pi

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -101,6 +101,35 @@ HTTPS-proxy has similar options --proxy-cacert and --proxy-insecure.
 It's working but curl complains because the certificate is not signed by an
 accepted certificate authority.
 
+### Notes for running on a Raspberry Pi
+
+When you run step-ca on a Raspberry Pi, you might get the following error in the
+logs of your docker container:
+
+```sh
+step-ca  | badger 2021/05/08 20:13:12 INFO: All 0 tables opened in 0s
+step-ca  | Error opening database of Type badger with source /home/step/db: error opening Badger database: Mmap value log file. Path=/home/step/db/000000.vlog. Error=cannot allocate memory
+```
+
+In that case you need to adjust the `db` configuration in the file `/home/step/config/ca.json`,
+you need to adjust `badgerFileLoadingMode` from being `""` to the value `FileIO`.
+
+```sh
+docker run -it -v step:/home/step smallstep/step-ca sh
+
+~ $ vi config/ca.json
+```
+
+You will end up with something similar like this:
+```json
+    "db": {
+          "type": "badger",
+          "dataSource": "/root/.step/db",
+          "badgerFileLoadingMode": "FileIO",
+    },
+```
+
+
 ## Dev environment bootstrap
 
 To initialize the development environment we need to grab the Root fingerprint


### PR DESCRIPTION
This should add some information for people that want to use **step-ca** on their Raspberry Pi (tested on my Raspberry Pi 4B inside docker running 32bit Raspbian).

Already closed issues regarding to raspberry: #351, #344, #279