### PR TITLE
Allow reading pin from kms string

### DIFF
--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -119,19 +119,6 @@ func main() {
 		fatal(err)
 	}
 
-	kmsPin := u.Pin()
-	if c.Pin == "" && kmsPin != "" {
-		c.Pin = kmsPin
-	}
-
-	if c.Pin == "" {
-		pin, err := ui.PromptPassword("What is the PKCS#11 PIN?")
-		if err != nil {
-			fatal(err)
-		}
-		c.Pin = string(pin)
-	}
-
 	k, err := kms.New(context.Background(), apiv1.Options{
 		Type: string(apiv1.PKCS11),
 		URI:  c.KMS,

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -119,6 +119,14 @@ func main() {
 		fatal(err)
 	}
 
+	if c.Pin == "" && u.Get("pin-value") == "" && u.Get("pin-source") == "" {
+		pin, err := ui.PromptPassword("What is the PKCS#11 PIN?")
+		if err != nil {
+			fatal(err)
+		}
+		c.Pin = string(pin)
+	}
+
 	k, err := kms.New(context.Background(), apiv1.Options{
 		Type: string(apiv1.PKCS11),
 		URI:  c.KMS,

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -119,7 +119,7 @@ func main() {
 		fatal(err)
 	}
 
-	if c.Pin == "" && u.Get("pin-value") == "" && u.Get("pin-source") == "" {
+	if u.Get("pin-value") == "" && u.Get("pin-source") == "" && c.Pin == "" {
 		pin, err := ui.PromptPassword("What is the PKCS#11 PIN?")
 		if err != nil {
 			fatal(err)

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -119,7 +119,12 @@ func main() {
 		fatal(err)
 	}
 
-	if u.Pin() == "" && c.Pin == "" {
+	kmsPin := u.Pin()
+	if c.Pin == "" && kmsPin != "" {
+		c.Pin = kmsPin
+	}
+
+	if c.Pin == "" {
 		pin, err := ui.PromptPassword("What is the PKCS#11 PIN?")
 		if err != nil {
 			fatal(err)


### PR DESCRIPTION
Originally `pin-source` would be read twice, once by `u.Pin()` and again inside `kms.New()`. 
This double read is problematic when reading pins from FIFO pipes. 

This PR fixes this by removing the double read. 