### PR TITLE
Log certificate's serial number as stringified decimal number

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -400,7 +400,7 @@ func logOtt(w http.ResponseWriter, token string) {
 func LogCertificate(w http.ResponseWriter, cert *x509.Certificate) {
 	if rl, ok := w.(logging.ResponseLogger); ok {
 		m := map[string]interface{}{
-			"serial":      cert.SerialNumber,
+			"serial":      cert.SerialNumber.String(),
 			"subject":     cert.Subject.CommonName,
 			"issuer":      cert.Issuer.CommonName,
 			"valid-from":  cert.NotBefore.Format(time.RFC3339),


### PR DESCRIPTION
Using a JSON string fixes a common issue with JSON parsers that
deserialize all numbers to a 64-bit IEEE-754 floats. (Certificate
serial numbers are usually 128 bit values.)

This change is consistent with existing log entries for revocation
requests.

See also: #630, #631

### Description
Please describe your pull request.

💔Thank you!
