### PR TITLE
Fix logging provisioner name as string

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -418,7 +418,7 @@ func LogCertificate(w http.ResponseWriter, cert *x509.Certificate) {
 				if len(val.CredentialID) > 0 {
 					m["provisioner"] = fmt.Sprintf("%s (%s)", val.Name, val.CredentialID)
 				} else {
-					m["provisioner"] = val.Name
+					m["provisioner"] = string(val.Name)
 				}
 				break
 			}


### PR DESCRIPTION
### Description
The provisioner name was printed as a byte slice due to a regression. This PR prints it as a string again when logging a certificate.

💔Thank you!
