### PR TITLE
Go 1.17 compatibility

### DIFF
--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -1395,7 +1395,7 @@ func TestTLSALPN01Validate(t *testing.T) {
 						assert.Equals(t, updch.Type, ch.Type)
 						assert.Equals(t, updch.Value, ch.Value)
 
-						err := NewError(ErrorConnectionType, "error doing TLS dial for %v:443: tls: DialWithDialer timed out", ch.Value)
+						err := NewError(ErrorConnectionType, "error doing TLS dial for %v:443:", ch.Value)
 
 						assert.HasPrefix(t, updch.Error.Err.Error(), err.Err.Error())
 						assert.Equals(t, updch.Error.Type, err.Type)

--- a/kms/uri/uri.go
+++ b/kms/uri/uri.go
@@ -59,7 +59,9 @@ func Parse(rawuri string) (*URI, error) {
 	if u.Scheme == "" {
 		return nil, errors.Errorf("error parsing %s: scheme is missing", rawuri)
 	}
-	v, err := url.ParseQuery(u.Opaque)
+	// Starting with Go 1.17 url.ParseQuery returns an error using semicolon as
+	// separator.
+	v, err := url.ParseQuery(strings.ReplaceAll(u.Opaque, ";", "&"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing %s", rawuri)
 	}

--- a/kms/uri/uri_test.go
+++ b/kms/uri/uri_test.go
@@ -274,3 +274,28 @@ func TestURI_Pin(t *testing.T) {
 		})
 	}
 }
+
+func TestURI_String(t *testing.T) {
+	mustParse := func(s string) *URI {
+		u, err := Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+	tests := []struct {
+		name string
+		uri  *URI
+		want string
+	}{
+		{"ok new", New("yubikey", url.Values{"slot-id": []string{"9a"}, "foo": []string{"bar"}}), "yubikey:foo=bar;slot-id=9a"},
+		{"ok parse", mustParse("yubikey:slot-id=9a;foo=bar?bar=zar"), "yubikey:slot-id=9a;foo=bar?bar=zar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.uri.String(); got != tt.want {
+				t.Errorf("URI.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR fixes step-ca compatibility issues with Go 1.17. Compatibility changes are:
* Go 1.17 introduces a change in the net/url package disallowing the use of a semicolon (;) in URL queries. We used `url.ParseQuery` to decode the opaque string that is semicolon-separated. Now before decoding the opaque string we replace the semicolon with an ampersand. See https://golang.org/doc/go1.17#semicolons
* In Go 1.17 `tls.Dial` will fail if client and server configured protocols do not overlap. See https://golang.org/doc/go1.17#ALPN. The ALPN challenge tests that check that the negotiated protocol is `acme-tls/1` were failing because of this.  This change detects the error `no_application_protocol (120)` and fails as it was failing before.
* There's a change in the error message on one test case, with Go 1.17 the error returned is context exceeded instead of the one in the test.
