### PR TITLE
New Dockerfile with entrypoint script for easy CA init

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -24,4 +24,7 @@ VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
 HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 
+COPY docker/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,11 +37,6 @@ function generate_password () {
 
 # Initialize a CA if not already initialized
 function step_ca_init () {
-    if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
-        echo -n "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
-    else
-        generate_password > "${STEPPATH}/password"
-    fi
     local -a setup_args=(
         --name "${DOCKER_STEPCA_INIT_NAME}"
 		--dns "${DOCKER_STEPCA_INIT_DNS}"
@@ -49,6 +44,11 @@ function step_ca_init () {
 		--password-file "${STEPPATH}/password"
         --address ":9000"
     )
+    if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
+        echo -n "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
+    else
+        generate_password > "${STEPPATH}/password"
+    fi
     if [ -n "${DOCKER_STEPCA_INIT_SSH}" ]; then
         setup_args=("${setup_args[@]}" --ssh)
     fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,6 +32,7 @@ function init_if_possible () {
 function generate_password () {
     set +o pipefail
     < /dev/urandom tr -dc A-Za-z0-9 | head -c40
+    echo
     set -o pipefail
 }
 
@@ -45,7 +46,7 @@ function step_ca_init () {
         --address ":9000"
     )
     if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
-        echo -n "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
+        echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
     else
         generate_password > "${STEPPATH}/password"
     fi


### PR DESCRIPTION
The goal of this PR is to simplify the CA init process with Docker, using environment variables.
See [this Notion page](https://www.notion.so/smallstep/new-docker-readme-7b2af4d61c324803bb01f2629266af54) for draft documentation.
This paves the way for easier CA deployment in common homelab systems like Unraid and TrueNAS.
To build a test image, go to the repo root and run `docker build -f docker/Dockerfile.step-ca .`
