### PR TITLE
Initialize required IMDSVersions for GetIdentityToken

### DIFF
--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -515,6 +515,11 @@ func (p *AWS) readURL(url string) ([]byte, error) {
 	var resp *http.Response
 	var err error
 
+	// Initialize IMDS versions when this is called from the cli.
+	if len(p.IMDSVersions) == 0 {
+		p.IMDSVersions = []string{"v2", "v1"}
+	}
+
 	for _, v := range p.IMDSVersions {
 		switch v {
 		case "v1":

--- a/authority/provisioner/aws_test.go
+++ b/authority/provisioner/aws_test.go
@@ -141,6 +141,12 @@ func TestAWS_GetIdentityToken(t *testing.T) {
 	p7.config.signatureURL = p1.config.signatureURL
 	p7.config.tokenURL = p1.config.tokenURL
 
+	p8, err := generateAWS()
+	assert.FatalError(t, err)
+	p8.IMDSVersions = nil
+	p8.Accounts = p1.Accounts
+	p8.config = p1.config
+
 	caURL := "https://ca.smallstep.com"
 	u, err := url.Parse(caURL)
 	assert.FatalError(t, err)
@@ -156,6 +162,7 @@ func TestAWS_GetIdentityToken(t *testing.T) {
 		wantErr bool
 	}{
 		{"ok", p1, args{"foo.local", caURL}, false},
+		{"ok no imds", p8, args{"foo.local", caURL}, false},
 		{"fail ca url", p1, args{"foo.local", "://ca.smallstep.com"}, true},
 		{"fail identityURL", p2, args{"foo.local", caURL}, true},
 		{"fail signatureURL", p3, args{"foo.local", caURL}, true},


### PR DESCRIPTION
### Description

If the IMDSVersions are not defined in the AWS provisioner the call to GetIdentityToken will panic (see smallstep/cli#465). This PR initializes the versions to the default values.

Fixes smallstep/cli#465