### PR TITLE
Azure OIDC

### DIFF
--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/assert"
@@ -82,6 +83,10 @@ func testAuthority(t *testing.T, opts ...Option) *Authority {
 	}
 	a, err := New(c, opts...)
 	assert.FatalError(t, err)
+	// Avoid errors when test tokens are created before the test authority. This
+	// happens in some tests where we re-create the same authority to test
+	// special cases without re-creating the token.
+	a.startTime = a.startTime.Add(-1 * time.Minute)
 	return a
 }
 


### PR DESCRIPTION
### Description

This PR adds an extra way to distinguish Azure and Azure OIDC tokens.

We used to distinguish these tokens using the `azp` claim, but this claim does not appear on new azure oidc tokens, at least on some configurations.

This change will attempt to load by the audience (client id) if the token contains an email, required for OIDC