### PR TITLE
Use new methods in nosql to enable querying for Certificates.

### DIFF
--- a/acme/db/nosql/nosql.go
+++ b/acme/db/nosql/nosql.go
@@ -29,13 +29,19 @@ type DB struct {
 // New configures and returns a new ACME DB backend implemented using a nosql DB.
 func New(db nosqlDB.DB) (*DB, error) {
 	tables := [][]byte{accountTable, accountByKeyIDTable, authzTable,
-		challengeTable, nonceTable, orderTable, ordersByAccountIDTable, certTable}
+		challengeTable, nonceTable, orderTable, ordersByAccountIDTable}
 	for _, b := range tables {
 		if err := db.CreateTable(b); err != nil {
 			return nil, errors.Wrapf(err, "error creating table %s",
 				string(b))
 		}
 	}
+	// Separate schema for Certs Table so that queries on these tables can be done in the future.
+	if err := db.CreateX509CertificateTable(certTable); err != nil {
+		return nil, errors.Wrapf(err, "error creating table %s",
+			string(certTable))
+	}
+
 	return &DB{db}, nil
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -80,7 +80,7 @@ func New(c *Config) (AuthDB, error) {
 	}
 
 	tables := [][]byte{
-		revokedCertsTable, certsTable, usedOTTTable,
+		revokedCertsTable, usedOTTTable,
 		sshCertsTable, sshHostsTable, sshHostPrincipalsTable, sshUsersTable,
 		revokedSSHCertsTable,
 	}
@@ -89,6 +89,11 @@ func New(c *Config) (AuthDB, error) {
 			return nil, errors.Wrapf(err, "error creating table %s",
 				string(b))
 		}
+	}
+	// Separate schema for Certs Table so that queries on these tables can be done in the future.
+	if err := db.CreateX509CertificateTable(certsTable); err != nil {
+		return nil, errors.Wrapf(err, "error creating table %s",
+			string(certsTable))
 	}
 
 	return &DB{db, true}, nil
@@ -203,7 +208,7 @@ func (db *DB) GetCertificate(serialNumber string) (*x509.Certificate, error) {
 
 // StoreCertificate stores a certificate PEM.
 func (db *DB) StoreCertificate(crt *x509.Certificate) error {
-	if err := db.Set(certsTable, []byte(crt.SerialNumber.String()), crt.Raw); err != nil {
+	if err := db.SetX509Certificate(certsTable, []byte(crt.SerialNumber.String()), crt.Raw, crt.NotBefore, crt.NotAfter, crt.Subject.Province, crt.Subject.Locality, crt.Subject.Country, crt.Subject.Organization, crt.Subject.OrganizationalUnit, crt.Subject.CommonName, crt.Issuer.String()); err != nil {
 		return errors.Wrap(err, "database Set error")
 	}
 	return nil
@@ -404,18 +409,20 @@ func (m *MockAuthDB) Shutdown() error {
 
 // MockNoSQLDB //
 type MockNoSQLDB struct {
-	Err          error
-	Ret1, Ret2   interface{}
-	MGet         func(bucket, key []byte) ([]byte, error)
-	MSet         func(bucket, key, value []byte) error
-	MOpen        func(dataSourceName string, opt ...database.Option) error
-	MClose       func() error
-	MCreateTable func(bucket []byte) error
-	MDeleteTable func(bucket []byte) error
-	MDel         func(bucket, key []byte) error
-	MList        func(bucket []byte) ([]*database.Entry, error)
-	MUpdate      func(tx *database.Tx) error
-	MCmpAndSwap  func(bucket, key, old, newval []byte) ([]byte, bool, error)
+	Err                         error
+	Ret1, Ret2                  interface{}
+	MGet                        func(bucket, key []byte) ([]byte, error)
+	MSet                        func(bucket, key, value []byte) error
+	MSetX509Certificate         func(bucket, key, value []byte, notBefore time.Time, notAfter time.Time, province []string, locality []string, country []string, organization []string, organizationalUnit []string, commonName string, issuer string) error
+	MOpen                       func(dataSourceName string, opt ...database.Option) error
+	MClose                      func() error
+	MCreateX509CertificateTable func(bucket []byte) error
+	MCreateTable                func(bucket []byte) error
+	MDeleteTable                func(bucket []byte) error
+	MDel                        func(bucket, key []byte) error
+	MList                       func(bucket []byte) ([]*database.Entry, error)
+	MUpdate                     func(tx *database.Tx) error
+	MCmpAndSwap                 func(bucket, key, old, newval []byte) ([]byte, bool, error)
 }
 
 // CmpAndSwap mock
@@ -448,6 +455,14 @@ func (m *MockNoSQLDB) Set(bucket, key, value []byte) error {
 	return m.Err
 }
 
+// SetX509Certificate mock
+func (m *MockNoSQLDB) SetX509Certificate(bucket, key, value []byte, notBefore time.Time, notAfter time.Time, province []string, locality []string, country []string, organization []string, organizationalUnit []string, commonName string, issuer string) error {
+	if m.MSetX509Certificate != nil {
+		return m.MSetX509Certificate(bucket, key, value, notBefore, notAfter, province, locality, country, organization, organizationalUnit, commonName, issuer)
+	}
+	return m.Err
+}
+
 // Open mock
 func (m *MockNoSQLDB) Open(dataSourceName string, opt ...database.Option) error {
 	if m.MOpen != nil {
@@ -468,6 +483,14 @@ func (m *MockNoSQLDB) Close() error {
 func (m *MockNoSQLDB) CreateTable(bucket []byte) error {
 	if m.MCreateTable != nil {
 		return m.MCreateTable(bucket)
+	}
+	return m.Err
+}
+
+// CreateX509CertificateTable mock
+func (m *MockNoSQLDB) CreateX509CertificateTable(bucket []byte) error {
+	if m.MCreateX509CertificateTable != nil {
+		return m.MCreateX509CertificateTable(bucket)
 	}
 	return m.Err
 }

--- a/db/simple.go
+++ b/db/simple.go
@@ -143,6 +143,11 @@ func (s *SimpleDB) CreateTable(bucket []byte) error {
 	return ErrNotImplemented
 }
 
+// CreateX509CertificateTable creates a table or a bucket in the database.
+func (s *SimpleDB) CreateX509CertificateTable(bucket []byte) error {
+	return ErrNotImplemented
+}
+
 // DeleteTable deletes a table or a bucket in the database.
 func (s *SimpleDB) DeleteTable(bucket []byte) error {
 	return ErrNotImplemented


### PR DESCRIPTION
### Description
This resolves https://github.com/smallstep/certificates/issues/688 and enables users to perform a normal upgrade of smallstep, and the new schema will be migrated to. At which point users can begin to query for certificates the application has signed on a go forward basis. This is reliant on https://github.com/smallstep/nosql/pull/15, and then updating the version of the dependency used in this project.
