### PR TITLE
Converts group and subgroup to lowercase for comparison.

### DIFF
--- a/authority/provisioner/sign_ssh_options.go
+++ b/authority/provisioner/sign_ssh_options.go
@@ -454,20 +454,12 @@ func containsAllMembers(group, subgroup []string) bool {
 	if lsg > lg || (lg > 0 && lsg == 0) {
 		return false
 	}
-	groupLower := []string{}
-	subgroupLower := []string{}
-	for _, s := range group {
-		groupLower = append(groupLower, strings.ToLower(s))
-	}
-	for _, s := range subgroup {
-		subgroupLower = append(subgroupLower, strings.ToLower(s))
-	}
 	visit := make(map[string]struct{}, lg)
 	for i := 0; i < lg; i++ {
-		visit[groupLower[i]] = struct{}{}
+		visit[strings.ToLower(group[i])] = struct{}{}
 	}
 	for i := 0; i < lsg; i++ {
-		if _, ok := visit[subgroupLower[i]]; !ok {
+		if _, ok := visit[strings.ToLower(subgroup[i])]; !ok {
 			return false
 		}
 	}

--- a/authority/provisioner/sign_ssh_options.go
+++ b/authority/provisioner/sign_ssh_options.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -453,12 +454,20 @@ func containsAllMembers(group, subgroup []string) bool {
 	if lsg > lg || (lg > 0 && lsg == 0) {
 		return false
 	}
+	groupLower := []string{}
+	subgroupLower := []string{}
+	for _, s := range group {
+		groupLower = append(groupLower, strings.ToLower(s))
+	}
+	for _, s := range subgroup {
+		subgroupLower = append(subgroupLower, strings.ToLower(s))
+	}
 	visit := make(map[string]struct{}, lg)
 	for i := 0; i < lg; i++ {
-		visit[group[i]] = struct{}{}
+		visit[groupLower[i]] = struct{}{}
 	}
 	for i := 0; i < lsg; i++ {
-		if _, ok := visit[subgroup[i]]; !ok {
+		if _, ok := visit[subgroupLower[i]]; !ok {
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes #679

### Description
This should fix the above issue by converting the ssh principals to lower case for group comparison.
Please note I'm not sure what needs to be done with adding a test for this so any guidance would be appreciated. 

Thank you!
