### PR TITLE
Allow to kms signers to define the SignatureAlgorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased - 0.17.3] - DATE
 ### Added
 - go 1.17 to github action test matrix
+- Support for CloudKMS RSA-PSS signers without using templates.
 ### Changed
 - Using go 1.17 for binaries
 ### Deprecated

--- a/cas/apiv1/services.go
+++ b/cas/apiv1/services.go
@@ -1,6 +1,7 @@
 package apiv1
 
 import (
+	"crypto/x509"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,12 @@ type CertificateAuthorityGetter interface {
 // authority.
 type CertificateAuthorityCreator interface {
 	CreateCertificateAuthority(req *CreateCertificateAuthorityRequest) (*CreateCertificateAuthorityResponse, error)
+}
+
+// SignatureAlgorithmGetter is an optional implementation in a crypto.Signer
+// that returns the SignatureAlgorithm to use.
+type SignatureAlgorithmGetter interface {
+	SignatureAlgorithm() x509.SignatureAlgorithm
 }
 
 // Type represents the CAS type used.

--- a/cas/softcas/softcas.go
+++ b/cas/softcas/softcas.go
@@ -214,8 +214,8 @@ func (c *SoftCAS) createSigner(req *kmsapi.CreateSignerRequest) (crypto.Signer, 
 // createCertificate sets the SignatureAlgorithm of the template if necessary
 // and calls x509util.CreateCertificate.
 func createCertificate(template, parent *x509.Certificate, pub crypto.PublicKey, signer crypto.Signer) (*x509.Certificate, error) {
-	// Signers can specify the signature algorithm. This is specially important
-	// when x509.CreateCertificates attempts to validate a RSAPSS signature.
+	// Signers can specify the signature algorithm. This is especially important
+	// when x509.CreateCertificate attempts to validate a RSAPSS signature.
 	if template.SignatureAlgorithm == 0 {
 		if sa, ok := signer.(apiv1.SignatureAlgorithmGetter); ok {
 			template.SignatureAlgorithm = sa.SignatureAlgorithm()

--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -3,6 +3,7 @@ package cloudkms
 import (
 	"context"
 	"crypto"
+	"crypto/x509"
 	"log"
 	"strings"
 	"time"
@@ -61,6 +62,19 @@ var signatureAlgorithmMapping = map[apiv1.SignatureAlgorithm]interface{}{
 	},
 	apiv1.ECDSAWithSHA256: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
 	apiv1.ECDSAWithSHA384: kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384,
+}
+
+var cryptoKeyVersionMapping = map[kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm]x509.SignatureAlgorithm{
+	kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:        x509.ECDSAWithSHA256,
+	kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384:        x509.ECDSAWithSHA384,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256: x509.SHA256WithRSA,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256: x509.SHA256WithRSA,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256: x509.SHA256WithRSA,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512: x509.SHA512WithRSA,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256:   x509.SHA256WithRSAPSS,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256:   x509.SHA256WithRSAPSS,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256:   x509.SHA256WithRSAPSS,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512:   x509.SHA512WithRSAPSS,
 }
 
 // KeyManagementClient defines the methods on KeyManagementClient that this

--- a/kms/cloudkms/signer_test.go
+++ b/kms/cloudkms/signer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -152,6 +153,82 @@ func Test_signer_Sign(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("signer.Sign() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSigner_SignatureAlgorithm(t *testing.T) {
+	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &MockClient{
+		getPublicKey: func(_ context.Context, req *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+			var algorithm kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm
+			switch req.Name {
+			case "ECDSA-SHA256":
+				algorithm = kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256
+			case "ECDSA-SHA384":
+				algorithm = kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384
+			case "SHA256-RSA-2048":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256
+			case "SHA256-RSA-3072":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256
+			case "SHA256-RSA-4096":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256
+			case "SHA512-RSA-4096":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512
+			case "SHA256-RSAPSS-2048":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256
+			case "SHA256-RSAPSS-3072":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256
+			case "SHA256-RSAPSS-4096":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256
+			case "SHA512-RSAPSS-4096":
+				algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512
+			}
+			return &kmspb.PublicKey{
+				Pem:       string(pemBytes),
+				Algorithm: algorithm,
+			}, nil
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		client     KeyManagementClient
+		signingKey string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   x509.SignatureAlgorithm
+	}{
+		{"ECDSA-SHA256", fields{client, "ECDSA-SHA256"}, x509.ECDSAWithSHA256},
+		{"ECDSA-SHA384", fields{client, "ECDSA-SHA384"}, x509.ECDSAWithSHA384},
+		{"SHA256-RSA-2048", fields{client, "SHA256-RSA-2048"}, x509.SHA256WithRSA},
+		{"SHA256-RSA-3072", fields{client, "SHA256-RSA-3072"}, x509.SHA256WithRSA},
+		{"SHA256-RSA-4096", fields{client, "SHA256-RSA-4096"}, x509.SHA256WithRSA},
+		{"SHA512-RSA-4096", fields{client, "SHA512-RSA-4096"}, x509.SHA512WithRSA},
+		{"SHA256-RSAPSS-2048", fields{client, "SHA256-RSAPSS-2048"}, x509.SHA256WithRSAPSS},
+		{"SHA256-RSAPSS-3072", fields{client, "SHA256-RSAPSS-3072"}, x509.SHA256WithRSAPSS},
+		{"SHA256-RSAPSS-4096", fields{client, "SHA256-RSAPSS-4096"}, x509.SHA256WithRSAPSS},
+		{"SHA512-RSAPSS-4096", fields{client, "SHA512-RSAPSS-4096"}, x509.SHA512WithRSAPSS},
+		{"unknown", fields{client, "UNKNOWN"}, x509.UnknownSignatureAlgorithm},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, err := NewSigner(tt.fields.client, tt.fields.signingKey)
+			if err != nil {
+				t.Errorf("NewSigner() error = %v", err)
+			}
+			if got := signer.SignatureAlgorithm(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Signer.SignatureAlgorithm() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

This PR adds a new interface to CloudKMS Signers to define the signature algorithm.

CloudKMS keys signs data using a specific signature algorithm, in RSA keys, this can be PKCS#1 RSA or RSA-PSS, if the latter is used, x509.CreateCertificate will fail unless the template SignatureCertificate is properly set.

In contrast, AWS KMS RSA keys, are just RSA keys and can sign with PKCS#1 or RSA-PSS schemes, so right now the way to enforce one or the other is to use templates.