### PR TITLE
Add support for setting individual password for ssh and tls keys

### DIFF
--- a/authority/options.go
+++ b/authority/options.go
@@ -38,6 +38,42 @@ func WithConfigFile(filename string) Option {
 	}
 }
 
+// WithPassword set the password to decrypt the intermediate key as well as the
+// ssh host and user keys if they are not overridden by other options.
+func WithPassword(password []byte) Option {
+	return func(a *Authority) (err error) {
+		a.password = password
+		return
+	}
+}
+
+// WithSSHHostPassword set the password to decrypt the key used to sign SSH host
+// certificates.
+func WithSSHHostPassword(password []byte) Option {
+	return func(a *Authority) (err error) {
+		a.sshHostPassword = password
+		return
+	}
+}
+
+// WithSSHUserPassword set the password to decrypt the key used to sign SSH user
+// certificates.
+func WithSSHUserPassword(password []byte) Option {
+	return func(a *Authority) (err error) {
+		a.sshUserPassword = password
+		return
+	}
+}
+
+// WithIssuerPassword set the password to decrypt the certificate issuer private
+// key used in RA mode.
+func WithIssuerPassword(password []byte) Option {
+	return func(a *Authority) (err error) {
+		a.issuerPassword = password
+		return
+	}
+}
+
 // WithDatabase sets an already initialized authority database to a new
 // authority. This option is intended to be use on graceful reloads.
 func WithDatabase(db db.AuthDB) Option {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -29,11 +29,13 @@ import (
 )
 
 type options struct {
-	configFile     string
-	linkedCAToken  string
-	password       []byte
-	issuerPassword []byte
-	database       db.AuthDB
+	configFile      string
+	linkedCAToken   string
+	password        []byte
+	issuerPassword  []byte
+	sshHostPassword []byte
+	sshUserPassword []byte
+	database        db.AuthDB
 }
 
 func (o *options) apply(opts []Option) {
@@ -58,6 +60,22 @@ func WithConfigFile(name string) Option {
 func WithPassword(password []byte) Option {
 	return func(o *options) {
 		o.password = password
+	}
+}
+
+// WithSSHHostPassword sets the given password to decrypt the key used to sign
+// ssh host certificates.
+func WithSSHHostPassword(password []byte) Option {
+	return func(o *options) {
+		o.sshHostPassword = password
+	}
+}
+
+// WithSSHUserPassword sets the given password to decrypt the key used to sign
+// ssh user certificates.
+func WithSSHUserPassword(password []byte) Option {
+	return func(o *options) {
+		o.sshUserPassword = password
 	}
 }
 
@@ -106,19 +124,14 @@ func New(config *config.Config, opts ...Option) (*CA, error) {
 
 // Init initializes the CA with the given configuration.
 func (ca *CA) Init(config *config.Config) (*CA, error) {
-	// Intermediate Password.
-	if len(ca.opts.password) > 0 {
-		ca.config.Password = string(ca.opts.password)
+	// Set password, it's ok to set nil password, the ca will prompt for them if
+	// they are required.
+	opts := []authority.Option{
+		authority.WithPassword(ca.opts.password),
+		authority.WithSSHHostPassword(ca.opts.sshHostPassword),
+		authority.WithSSHUserPassword(ca.opts.sshUserPassword),
+		authority.WithIssuerPassword(ca.opts.issuerPassword),
 	}
-
-	// Certificate issuer password for RA mode.
-	if len(ca.opts.issuerPassword) > 0 {
-		if ca.config.AuthorityConfig != nil && ca.config.AuthorityConfig.CertificateIssuer != nil {
-			ca.config.AuthorityConfig.CertificateIssuer.Password = string(ca.opts.issuerPassword)
-		}
-	}
-
-	var opts []authority.Option
 	if ca.opts.linkedCAToken != "" {
 		opts = append(opts, authority.WithLinkedCAToken(ca.opts.linkedCAToken))
 	}
@@ -337,6 +350,8 @@ func (ca *CA) Reload() error {
 
 	newCA, err := New(config,
 		WithPassword(ca.opts.password),
+		WithSSHHostPassword(ca.opts.sshHostPassword),
+		WithSSHUserPassword(ca.opts.sshUserPassword),
 		WithIssuerPassword(ca.opts.issuerPassword),
 		WithLinkedCAToken(ca.opts.linkedCAToken),
 		WithConfigFile(ca.opts.configFile),

--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -107,7 +107,9 @@ func main() {
 	app.HelpName = "step-ca"
 	app.Version = config.Version()
 	app.Usage = "an online certificate authority for secure automated certificate management"
-	app.UsageText = `**step-ca** <config> [**--password-file**=<file>] [**--issuer-password-file**=<file>] [**--resolver**=<addr>] [**--help**] [**--version**]`
+	app.UsageText = `**step-ca** <config> [**--password-file**=<file>] 
+[**--ssh-host-password-file**=<file>] [**--ssh-user-password-file**=<file>]
+[**--issuer-password-file**=<file>] [**--resolver**=<addr>] [**--help**] [**--version**]`
 	app.Description = `**step-ca** runs the Step Online Certificate Authority
 (Step CA) using the given configuration.
 See the README.md for more detailed configuration documentation.

--- a/commands/app.go
+++ b/commands/app.go
@@ -32,6 +32,18 @@ var AppCommand = cli.Command{
 intermediate private key.`,
 		},
 		cli.StringFlag{
+			Name: "ssh-host-password-file",
+			Usage: `path to the <file> containing the password to decrypt the
+private key used to sign SSH host certificates. If the flag is not passed it
+will default to --password-file.`,
+		},
+		cli.StringFlag{
+			Name: "ssh-user-password-file",
+			Usage: `path to the <file> containing the password to decrypt the
+private key used to sign SSH user certificates. If the flag is not passed it
+will default to --password-file.`,
+		},
+		cli.StringFlag{
 			Name: "issuer-password-file",
 			Usage: `path to the <file> containing the password to decrypt the
 certificate issuer private key used in the RA mode.`,
@@ -51,6 +63,8 @@ certificate issuer private key used in the RA mode.`,
 // AppAction is the action used when the top command runs.
 func appAction(ctx *cli.Context) error {
 	passFile := ctx.String("password-file")
+	sshHostPassFile := ctx.String("ssh-host-password-file")
+	sshUserPassFile := ctx.String("ssh-user-password-file")
 	issuerPassFile := ctx.String("issuer-password-file")
 	resolver := ctx.String("resolver")
 	token := ctx.String("token")
@@ -89,6 +103,22 @@ To get a linked authority token:
 		password = bytes.TrimRightFunc(password, unicode.IsSpace)
 	}
 
+	var sshHostPassword []byte
+	if sshHostPassFile != "" {
+		if sshHostPassword, err = ioutil.ReadFile(sshHostPassFile); err != nil {
+			fatal(errors.Wrapf(err, "error reading %s", sshHostPassFile))
+		}
+		sshHostPassword = bytes.TrimRightFunc(sshHostPassword, unicode.IsSpace)
+	}
+
+	var sshUserPassword []byte
+	if sshUserPassFile != "" {
+		if sshUserPassword, err = ioutil.ReadFile(sshUserPassFile); err != nil {
+			fatal(errors.Wrapf(err, "error reading %s", sshUserPassFile))
+		}
+		sshUserPassword = bytes.TrimRightFunc(sshUserPassword, unicode.IsSpace)
+	}
+
 	var issuerPassword []byte
 	if issuerPassFile != "" {
 		if issuerPassword, err = ioutil.ReadFile(issuerPassFile); err != nil {
@@ -108,6 +138,8 @@ To get a linked authority token:
 	srv, err := ca.New(config,
 		ca.WithConfigFile(configFile),
 		ca.WithPassword(password),
+		ca.WithSSHHostPassword(sshHostPassword),
+		ca.WithSSHUserPassword(sshUserPassword),
 		ca.WithIssuerPassword(issuerPassword),
 		ca.WithLinkedCAToken(token))
 	if err != nil {

--- a/commands/app.go
+++ b/commands/app.go
@@ -23,8 +23,9 @@ import (
 var AppCommand = cli.Command{
 	Name:   "start",
 	Action: appAction,
-	UsageText: `**step-ca** <config>
-[**--password-file**=<file>] [**--issuer-password-file**=<file>] [**--resolver**=<addr>]`,
+	UsageText: `**step-ca** <config> [**--password-file**=<file>]
+[**--ssh-host-password-file**=<file>] [**--ssh-user-password-file**=<file>]	
+[**--issuer-password-file**=<file>] [**--resolver**=<addr>]`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "password-file",


### PR DESCRIPTION
### Description

This PR adds the flags `--ssh-host-password-file` and `--ssh-user-password-file`, if any of them are not set will default to the one passed in --password-file or the one in the ca.json

Fixes #693
