### PR TITLE
Use badgerv2 the default DB in helm

### DIFF
--- a/pki/helm.go
+++ b/pki/helm.go
@@ -79,7 +79,7 @@ inject:
         logger:
           format: json
         db:
-          type: badger
+          type: badgerv2
           dataSource: /home/step/db
         authority:
           provisioners:

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -341,7 +341,9 @@ func New(o apiv1.Options, opts ...Option) (*PKI, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing %s", p.Address)
 		}
-		if port == "443" {
+		// On k8s we usually access through a service, and this is configured on
+		// port 443 by default.
+		if port == "443" || p.options.isHelm {
 			p.Defaults.CaUrl = fmt.Sprintf("https://%s", p.Defaults.CaUrl)
 		} else {
 			p.Defaults.CaUrl = fmt.Sprintf("https://%s:%s", p.Defaults.CaUrl, port)


### PR DESCRIPTION
### Description

This PR changes the default DB for helm charts to badgerv2, this is currently the default in `step ca init`.

We also use port 443 for the default `--ca-url`, as we usually access it through a k8s service. This option can be overridden using the `--with-ca-url` flag in the cli.