### PR TITLE
Check for admins in both emails and groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - go 1.17 to github action test matrix
 - Support for CloudKMS RSA-PSS signers without using templates.
 - Add flags to support individual passwords for the intermediate and SSH keys.
-- Support for group admins in OIDC provisioners for X509 certificates.
+- Global support for group admins in the OIDC provisioner.
 ### Changed
 - Using go 1.17 for binaries
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - go 1.17 to github action test matrix
 - Support for CloudKMS RSA-PSS signers without using templates.
 - Add flags to support individual passwords for the intermediate and SSH keys.
+- Support for group admins in OIDC provisioners for X509 certificates.
 ### Changed
 - Using go 1.17 for binaries
 ### Deprecated


### PR DESCRIPTION
### Description
This PR makes sure that admins are always checked on emails and groups. In the previous implementation, the groups were only checked on the SSH flow to decide the template to use.