### PR TITLE
SSH host or SSH user only CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for CloudKMS RSA-PSS signers without using templates.
 - Add flags to support individual passwords for the intermediate and SSH keys.
 - Global support for group admins in the OIDC provisioner.
+- Support host-only or user-only SSH CA.
 ### Changed
 - Using go 1.17 for binaries
 ### Deprecated


### PR DESCRIPTION
### Description

This PR allows configuring `step-ca` as an SSH Host or SSH User CA, just configuring one of them.

In previous versions, if the host or user CA is not configured, the start of step-ca was crashing with a nil pointer dereference. This allows configuring a user-only or host-only ssh ca.

https://github.com/smallstep/certificates/blob/28bd2ef6c16b31df7f6d289c914a2b06b85329c2/authority/authority.go#L412-L418
