### PR TITLE
Use Golang's default keepalive.

### DIFF
--- a/ca/tls.go
+++ b/ca/tls.go
@@ -279,9 +279,9 @@ func getDefaultTLSConfig(sign *api.SignResponse) *tls.Config {
 
 // getDefaultDialer returns a new dialer with the default configuration.
 func getDefaultDialer() *net.Dialer {
+	// With the KeepAlive parameter set to 0, it will be use Golang's default.
 	return &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 }
 

--- a/examples/basic-client/client.go
+++ b/examples/basic-client/client.go
@@ -116,7 +116,6 @@ func main() {
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
 			MaxIdleConns:          100,


### PR DESCRIPTION
### Description

This PR removes the references to both client (`net.Dial`) and server (`net.Listen`) keepalives to use Golang's default of 15s.

Since Go 1.13 a `net.Listen` keep-alive is enabled by default if the protocol and OS support it. The new one is 15s to match
the `net.Dial` default one. Previously `http.Server.ListenAndServe` and `http.Server.ListenAndServeTLS` used to add a wrapper with 3m that we replicated in our server.

See https://github.com/golang/go/issues/31510