### PR TITLE
Pin golangci-lint to v1.43.0 and fix issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.15', '1.16', '1.17' ]
+        go: [ '1.16', '1.17' ]
     steps:
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: 'latest'
+          version: 'v1.43.0'
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,9 +73,3 @@ issues:
     - error strings should not be capitalized or end with punctuation or a newline
     - Wrapf call needs 1 arg but has 2 args
     - cs.NegotiatedProtocolIsMutual is deprecated
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.19.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/acme/api/account_test.go
+++ b/acme/api/account_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -263,7 +263,7 @@ func TestHandler_GetOrdersByAccountID(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -468,7 +468,7 @@ func TestHandler_NewAccount(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -668,7 +668,7 @@ func TestHandler_GetOrUpdateAccount(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 

--- a/acme/api/handler.go
+++ b/acme/api/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 func link(url, typ string) string {
-	return fmt.Sprintf("<%s>;rel=\"%s\"", url, typ)
+	return fmt.Sprintf("<%s>;rel=%q", url, typ)
 }
 
 // Clock that returns time in UTC rounded to seconds.

--- a/acme/api/handler_test.go
+++ b/acme/api/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,7 +89,7 @@ func TestHandler_GetDirectory(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -261,7 +261,7 @@ func TestHandler_GetAuthorization(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -404,7 +404,7 @@ func TestHandler_GetCertificate(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -660,7 +660,7 @@ func TestHandler_GetChallenge(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 

--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -118,7 +118,7 @@ func (h *Handler) verifyContentType(next nextHTTP) nextHTTP {
 // parseJWS is a middleware that parses a request body into a JSONWebSignature struct.
 func (h *Handler) parseJWS(next nextHTTP) nextHTTP {
 	return func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			api.WriteError(w, acme.WrapErrorISE(err, "failed to read request body"))
 			return
@@ -378,7 +378,7 @@ func (h *Handler) verifyAndExtractJWSPayload(next nextHTTP) nextHTTP {
 		}
 		ctx = context.WithValue(ctx, payloadContextKey, &payloadInfo{
 			value:       payload,
-			isPostAsGet: string(payload) == "",
+			isPostAsGet: len(payload) == 0,
 			isEmptyJSON: string(payload) == "{}",
 		})
 		next(w, r.WithContext(ctx))

--- a/acme/api/middleware_test.go
+++ b/acme/api/middleware_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -148,7 +147,7 @@ func TestHandler_addNonce(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -205,7 +204,7 @@ func TestHandler_addDirLink(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -332,7 +331,7 @@ func TestHandler_verifyContentType(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -400,7 +399,7 @@ func TestHandler_isPostAsGet(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -490,7 +489,7 @@ func TestHandler_parseJWS(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -689,7 +688,7 @@ func TestHandler_verifyAndExtractJWSPayload(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -891,7 +890,7 @@ func TestHandler_lookupJWK(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -1087,7 +1086,7 @@ func TestHandler_extractJWK(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -1454,7 +1453,7 @@ func TestHandler_validateJWS(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 

--- a/acme/api/order_test.go
+++ b/acme/api/order_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -430,7 +430,7 @@ func TestHandler_GetOrder(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -1343,7 +1343,7 @@ func TestHandler_NewOrder(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 
@@ -1633,7 +1633,7 @@ func TestHandler_FinalizeOrder(t *testing.T) {
 
 			assert.Equals(t, res.StatusCode, tc.statusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 

--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,7 +89,7 @@ func http01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSONWeb
 			"error doing http GET for url %s with status code %d", u, resp.StatusCode))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return WrapErrorISE(err, "error reading "+
 			"response body for url %s", u)

--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -707,7 +706,7 @@ func TestHTTP01Validate(t *testing.T) {
 				vo: &ValidateChallengeOptions{
 					HTTPGet: func(url string) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewBufferString("foo")),
+							Body: io.NopCloser(bytes.NewBufferString("foo")),
 						}, nil
 					},
 				},
@@ -733,7 +732,7 @@ func TestHTTP01Validate(t *testing.T) {
 				vo: &ValidateChallengeOptions{
 					HTTPGet: func(url string) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewBufferString("foo")),
+							Body: io.NopCloser(bytes.NewBufferString("foo")),
 						}, nil
 					},
 				},
@@ -775,7 +774,7 @@ func TestHTTP01Validate(t *testing.T) {
 				vo: &ValidateChallengeOptions{
 					HTTPGet: func(url string) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewBufferString("foo")),
+							Body: io.NopCloser(bytes.NewBufferString("foo")),
 						}, nil
 					},
 				},
@@ -818,7 +817,7 @@ func TestHTTP01Validate(t *testing.T) {
 				vo: &ValidateChallengeOptions{
 					HTTPGet: func(url string) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewBufferString(expKeyAuth)),
+							Body: io.NopCloser(bytes.NewBufferString(expKeyAuth)),
 						}, nil
 					},
 				},
@@ -860,7 +859,7 @@ func TestHTTP01Validate(t *testing.T) {
 				vo: &ValidateChallengeOptions{
 					HTTPGet: func(url string) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewBufferString(expKeyAuth)),
+							Body: io.NopCloser(bytes.NewBufferString(expKeyAuth)),
 						}, nil
 					},
 				},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -788,7 +788,7 @@ func Test_caHandler_Health(t *testing.T) {
 		t.Errorf("caHandler.Health StatusCode = %d, wants 200", res.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		t.Errorf("caHandler.Health unexpected error = %v", err)
@@ -829,7 +829,7 @@ func Test_caHandler_Root(t *testing.T) {
 				t.Errorf("caHandler.Root StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Root unexpected error = %v", err)
@@ -902,7 +902,7 @@ func Test_caHandler_Sign(t *testing.T) {
 				t.Errorf("caHandler.Root StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Root unexpected error = %v", err)
@@ -954,7 +954,7 @@ func Test_caHandler_Renew(t *testing.T) {
 				t.Errorf("caHandler.Renew StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Renew unexpected error = %v", err)
@@ -1015,7 +1015,7 @@ func Test_caHandler_Rekey(t *testing.T) {
 				t.Errorf("caHandler.Rekey StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Rekey unexpected error = %v", err)
@@ -1038,12 +1038,12 @@ func Test_caHandler_Provisioners(t *testing.T) {
 		r *http.Request
 	}
 
-	req, err := http.NewRequest("GET", "http://example.com/provisioners?cursor=foo&limit=20", nil)
+	req, err := http.NewRequest("GET", "http://example.com/provisioners?cursor=foo&limit=20", http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	reqLimitFail, err := http.NewRequest("GET", "http://example.com/provisioners?limit=abc", nil)
+	reqLimitFail, err := http.NewRequest("GET", "http://example.com/provisioners?limit=abc", http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1105,7 +1105,7 @@ func Test_caHandler_Provisioners(t *testing.T) {
 			if res.StatusCode != tt.statusCode {
 				t.Errorf("caHandler.Provisioners StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Provisioners unexpected error = %v", err)
@@ -1175,7 +1175,7 @@ func Test_caHandler_ProvisionerKey(t *testing.T) {
 			if res.StatusCode != tt.statusCode {
 				t.Errorf("caHandler.Provisioners StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Provisioners unexpected error = %v", err)
@@ -1225,7 +1225,7 @@ func Test_caHandler_Roots(t *testing.T) {
 				t.Errorf("caHandler.Roots StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Roots unexpected error = %v", err)
@@ -1271,7 +1271,7 @@ func Test_caHandler_Federation(t *testing.T) {
 				t.Errorf("caHandler.Federation StatusCode = %d, wants %d", res.StatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("caHandler.Federation unexpected error = %v", err)

--- a/api/revoke_test.go
+++ b/api/revoke_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -233,7 +233,7 @@ func Test_caHandler_Revoke(t *testing.T) {
 
 			assert.Equals(t, tc.statusCode, res.StatusCode)
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			assert.FatalError(t, err)
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -102,7 +101,7 @@ func ReadJSON(r io.Reader, v interface{}) error {
 // ReadProtoJSON reads JSON from the request body and stores it in the value
 // pointed by v.
 func ReadProtoJSON(r io.Reader, m proto.Message) error {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return errs.Wrap(http.StatusBadRequest, err, "error reading request body")
 	}

--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -7,8 +7,8 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -195,7 +195,7 @@ func TestAuthority_GetDatabase(t *testing.T) {
 }
 
 func TestNewEmbedded(t *testing.T) {
-	caPEM, err := ioutil.ReadFile("testdata/certs/root_ca.crt")
+	caPEM, err := os.ReadFile("testdata/certs/root_ca.crt")
 	assert.FatalError(t, err)
 
 	crt, err := pemutil.ReadCertificate("testdata/certs/intermediate_ca.crt")
@@ -268,7 +268,7 @@ func TestNewEmbedded(t *testing.T) {
 }
 
 func TestNewEmbedded_Sign(t *testing.T) {
-	caPEM, err := ioutil.ReadFile("testdata/certs/root_ca.crt")
+	caPEM, err := os.ReadFile("testdata/certs/root_ca.crt")
 	assert.FatalError(t, err)
 
 	crt, err := pemutil.ReadCertificate("testdata/certs/intermediate_ca.crt")
@@ -294,7 +294,7 @@ func TestNewEmbedded_Sign(t *testing.T) {
 }
 
 func TestNewEmbedded_GetTLSCertificate(t *testing.T) {
-	caPEM, err := ioutil.ReadFile("testdata/certs/root_ca.crt")
+	caPEM, err := os.ReadFile("testdata/certs/root_ca.crt")
 	assert.FatalError(t, err)
 
 	crt, err := pemutil.ReadCertificate("testdata/certs/intermediate_ca.crt")

--- a/authority/export.go
+++ b/authority/export.go
@@ -2,8 +2,8 @@ package authority
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -257,7 +257,7 @@ func mustReadFileOrURI(fn string, m map[string][]byte) string {
 		panic(err)
 	}
 	if ok {
-		b, err := ioutil.ReadFile(config.StepAbs(fn))
+		b, err := os.ReadFile(config.StepAbs(fn))
 		if err != nil {
 			panic(errors.Wrapf(err, "error reading %s", fn))
 		}

--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -9,9 +9,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -165,7 +166,7 @@ func newAWSConfig(certPath string) (*awsConfig, error) {
 	if certPath == "" {
 		certBytes = []byte(awsCertificate)
 	} else {
-		if b, err := ioutil.ReadFile(certPath); err == nil {
+		if b, err := os.ReadFile(certPath); err == nil {
 			certBytes = b
 		} else {
 			return nil, errors.Wrapf(err, "error reading %s", certPath)
@@ -569,7 +570,7 @@ func (p *AWS) readURLv2(url string) (*http.Response, error) {
 	client := http.Client{}
 
 	// first get the token
-	req, err := http.NewRequest(http.MethodPut, p.config.tokenURL, nil)
+	req, err := http.NewRequest(http.MethodPut, p.config.tokenURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -582,7 +583,7 @@ func (p *AWS) readURLv2(url string) (*http.Response, error) {
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("Request for API token returned non-successful status code %d", resp.StatusCode)
 	}
-	token, err := ioutil.ReadAll(resp.Body)
+	token, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +603,7 @@ func (p *AWS) readURLv2(url string) (*http.Response, error) {
 
 func (p *AWS) readResponseBody(resp *http.Response) ([]byte, error) {
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -173,7 +173,7 @@ func (p *Azure) GetIdentityToken(subject, caURL string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "error reading identity token response")
 	}

--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -107,7 +107,7 @@ func TestAzure_GetIdentityToken(t *testing.T) {
 			w.Write([]byte(t1))
 		default:
 			w.Header().Add("Content-Type", "application/json")
-			w.Write([]byte(fmt.Sprintf(`{"access_token":"%s"}`, t1)))
+			fmt.Fprintf(w, `{"access_token":"%s"}`, t1)
 		}
 	}))
 	defer srv.Close()

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -183,7 +183,7 @@ func (p *GCP) GetIdentityToken(subject, caURL string) (string, error) {
 		return "", errors.Wrap(err, "error doing identity request, are you in a GCP VM?")
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "error on identity request")
 	}

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -10,9 +10,9 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"time"
 
@@ -188,7 +188,7 @@ func generateJWK() (*JWK, error) {
 }
 
 func generateK8sSA(inputPubKey interface{}) (*K8sSA, error) {
-	fooPubB, err := ioutil.ReadFile("./testdata/certs/foo.pub")
+	fooPubB, err := os.ReadFile("./testdata/certs/foo.pub")
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func generateK8sSA(inputPubKey interface{}) (*K8sSA, error) {
 	if err != nil {
 		return nil, err
 	}
-	barPubB, err := ioutil.ReadFile("./testdata/certs/bar.pub")
+	barPubB, err := os.ReadFile("./testdata/certs/bar.pub")
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func generateSSHPOP() (*SSHPOP, error) {
 		return nil, err
 	}
 
-	userB, err := ioutil.ReadFile("./testdata/certs/ssh_user_ca_key.pub")
+	userB, err := os.ReadFile("./testdata/certs/ssh_user_ca_key.pub")
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func generateSSHPOP() (*SSHPOP, error) {
 	if err != nil {
 		return nil, err
 	}
-	hostB, err := ioutil.ReadFile("./testdata/certs/ssh_host_ca_key.pub")
+	hostB, err := os.ReadFile("./testdata/certs/ssh_host_ca_key.pub")
 	if err != nil {
 		return nil, err
 	}

--- a/authority/provisioners.go
+++ b/authority/provisioners.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/authority/admin"
@@ -524,7 +524,7 @@ func provisionerOptionsToLinkedca(p *provisioner.Options) (*linkedca.Template, *
 			x509Template.Template = []byte(p.SSH.Template)
 		} else if p.X509.TemplateFile != "" {
 			filename := step.StepAbs(p.X509.TemplateFile)
-			if x509Template.Template, err = ioutil.ReadFile(filename); err != nil {
+			if x509Template.Template, err = os.ReadFile(filename); err != nil {
 				return nil, nil, errors.Wrap(err, "error reading x509 template")
 			}
 		}
@@ -540,7 +540,7 @@ func provisionerOptionsToLinkedca(p *provisioner.Options) (*linkedca.Template, *
 			sshTemplate.Template = []byte(p.SSH.Template)
 		} else if p.SSH.TemplateFile != "" {
 			filename := step.StepAbs(p.SSH.TemplateFile)
-			if sshTemplate.Template, err = ioutil.ReadFile(filename); err != nil {
+			if sshTemplate.Template, err = os.ReadFile(filename); err != nil {
 				return nil, nil, errors.Wrap(err, "error reading ssh template")
 			}
 		}

--- a/authority/tls_test.go
+++ b/authority/tls_test.go
@@ -538,15 +538,15 @@ ZYtQ9Ot36qc=
 					if tc.csr.Subject.CommonName == "" {
 						assert.Equals(t, leaf.Subject, pkix.Name{})
 					} else {
-						assert.Equals(t, fmt.Sprintf("%v", leaf.Subject),
-							fmt.Sprintf("%v", &pkix.Name{
+						assert.Equals(t, leaf.Subject.String(),
+							pkix.Name{
 								Country:       []string{tmplt.Country},
 								Organization:  []string{tmplt.Organization},
 								Locality:      []string{tmplt.Locality},
 								StreetAddress: []string{tmplt.StreetAddress},
 								Province:      []string{tmplt.Province},
 								CommonName:    "smallstep test",
-							}))
+							}.String())
 						assert.Equals(t, leaf.DNSNames, []string{"test.smallstep.com"})
 					}
 					assert.Equals(t, leaf.Issuer, intermediate.Subject)
@@ -718,15 +718,15 @@ func TestAuthority_Renew(t *testing.T) {
 					assert.True(t, leaf.NotAfter.Before(expiry.Add(time.Minute)))
 
 					tmplt := a.config.AuthorityConfig.Template
-					assert.Equals(t, fmt.Sprintf("%v", leaf.Subject),
-						fmt.Sprintf("%v", &pkix.Name{
+					assert.Equals(t, leaf.Subject.String(),
+						pkix.Name{
 							Country:       []string{tmplt.Country},
 							Organization:  []string{tmplt.Organization},
 							Locality:      []string{tmplt.Locality},
 							StreetAddress: []string{tmplt.StreetAddress},
 							Province:      []string{tmplt.Province},
 							CommonName:    tmplt.CommonName,
-						}))
+						}.String())
 					assert.Equals(t, leaf.Issuer, intermediate.Subject)
 
 					assert.Equals(t, leaf.SignatureAlgorithm, x509.ECDSAWithSHA256)
@@ -925,15 +925,15 @@ func TestAuthority_Rekey(t *testing.T) {
 					assert.True(t, leaf.NotAfter.Before(expiry.Add(time.Minute)))
 
 					tmplt := a.config.AuthorityConfig.Template
-					assert.Equals(t, fmt.Sprintf("%v", leaf.Subject),
-						fmt.Sprintf("%v", &pkix.Name{
+					assert.Equals(t, leaf.Subject.String(),
+						pkix.Name{
 							Country:       []string{tmplt.Country},
 							Organization:  []string{tmplt.Organization},
 							Locality:      []string{tmplt.Locality},
 							StreetAddress: []string{tmplt.StreetAddress},
 							Province:      []string{tmplt.Province},
 							CommonName:    tmplt.CommonName,
-						}))
+						}.String())
 					assert.Equals(t, leaf.Issuer, intermediate.Subject)
 
 					assert.Equals(t, leaf.SignatureAlgorithm, x509.ECDSAWithSHA256)

--- a/ca/acmeClient.go
+++ b/ca/acmeClient.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -292,7 +291,7 @@ func (c *ACMEClient) GetCertificate(url string) (*x509.Certificate, []*x509.Cert
 		return nil, nil, readACMEError(resp.Body)
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error reading GET certificate response")
 	}
@@ -338,7 +337,7 @@ func (c *ACMEClient) GetAccountOrders() ([]string, error) {
 
 func readACMEError(r io.ReadCloser) error {
 	defer r.Close()
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrap(err, "error reading from body")
 	}

--- a/ca/acmeClient_test.go
+++ b/ca/acmeClient_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -317,7 +317,7 @@ func TestACMEClient_post(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -455,7 +455,7 @@ func TestACMEClient_NewOrder(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -575,7 +575,7 @@ func TestACMEClient_GetOrder(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -695,7 +695,7 @@ func TestACMEClient_GetAuthz(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -815,7 +815,7 @@ func TestACMEClient_GetChallenge(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -936,7 +936,7 @@ func TestACMEClient_ValidateChallenge(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -1061,7 +1061,7 @@ func TestACMEClient_FinalizeOrder(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -1188,7 +1188,7 @@ func TestACMEClient_GetAccountOrders(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)
@@ -1317,7 +1317,7 @@ func TestACMEClient_GetCertificate(t *testing.T) {
 				}
 
 				// validate jws request protected headers and body
-				body, err := ioutil.ReadAll(req.Body)
+				body, err := io.ReadAll(req.Body)
 				assert.FatalError(t, err)
 				jws, err := jose.ParseJWS(string(body))
 				assert.FatalError(t, err)

--- a/ca/adminClient.go
+++ b/ca/adminClient.go
@@ -197,7 +197,7 @@ func (c *AdminClient) GetAdminsPaginate(opts ...AdminOption) (*adminAPI.GetAdmin
 	if err != nil {
 		return nil, errors.Wrapf(err, "error generating admin token")
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrapf(err, "create GET %s request failed", u)
 	}
@@ -284,7 +284,7 @@ func (c *AdminClient) RemoveAdmin(id string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error generating admin token")
 	}
-	req, err := http.NewRequest("DELETE", u.String(), nil)
+	req, err := http.NewRequest("DELETE", u.String(), http.NoBody)
 	if err != nil {
 		return errors.Wrapf(err, "create DELETE %s request failed", u)
 	}
@@ -363,7 +363,7 @@ func (c *AdminClient) GetProvisioner(opts ...ProvisionerOption) (*linkedca.Provi
 	if err != nil {
 		return nil, errors.Wrapf(err, "error generating admin token")
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrapf(err, "create PUT %s request failed", u)
 	}
@@ -402,7 +402,7 @@ func (c *AdminClient) GetProvisionersPaginate(opts ...ProvisionerOption) (*admin
 	if err != nil {
 		return nil, errors.Wrapf(err, "error generating admin token")
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrapf(err, "create PUT %s request failed", u)
 	}
@@ -472,7 +472,7 @@ func (c *AdminClient) RemoveProvisioner(opts ...ProvisionerOption) error {
 	if err != nil {
 		return errors.Wrapf(err, "error generating admin token")
 	}
-	req, err := http.NewRequest("DELETE", u.String(), nil)
+	req, err := http.NewRequest("DELETE", u.String(), http.NoBody)
 	if err != nil {
 		return errors.Wrapf(err, "create DELETE %s request failed", u)
 	}

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -3,7 +3,7 @@ package ca
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -382,7 +382,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 			return errors.Wrapf(err, "client.Get(%s) failed", srvURL)
 		}
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrap(err, "client.Get() error reading response")
 		}
@@ -499,7 +499,7 @@ func TestBootstrapClientServerFederation(t *testing.T) {
 			return errors.Wrapf(err, "client.Get(%s) failed", srvURL)
 		}
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrap(err, "client.Get() error reading response")
 		}
@@ -589,9 +589,9 @@ func TestBootstrapListener(t *testing.T) {
 				return
 			}
 			defer resp.Body.Close()
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			if err != nil {
-				t.Errorf("ioutil.ReadAll() error = %v", err)
+				t.Errorf("io.ReadAll() error = %v", err)
 				return
 			}
 			if string(b) != "ok" {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -294,15 +294,15 @@ ZEp7knvU2psWRw==
 					assert.Equals(t, leaf.NotBefore, now.Truncate(time.Second))
 					assert.Equals(t, leaf.NotAfter, leafExpiry.Truncate(time.Second))
 
-					assert.Equals(t, fmt.Sprintf("%v", leaf.Subject),
-						fmt.Sprintf("%v", &pkix.Name{
+					assert.Equals(t, leaf.Subject.String(),
+						pkix.Name{
 							Country:       []string{asn1dn.Country},
 							Organization:  []string{asn1dn.Organization},
 							Locality:      []string{asn1dn.Locality},
 							StreetAddress: []string{asn1dn.StreetAddress},
 							Province:      []string{asn1dn.Province},
 							CommonName:    asn1dn.CommonName,
-						}))
+						}.String())
 					assert.Equals(t, leaf.Issuer, intermediate.Subject)
 
 					assert.Equals(t, leaf.SignatureAlgorithm, x509.ECDSAWithSHA256)
@@ -641,10 +641,10 @@ func TestCARenew(t *testing.T) {
 					assert.Equals(t, leaf.NotBefore, now.Truncate(time.Second))
 					assert.Equals(t, leaf.NotAfter, leafExpiry.Truncate(time.Second))
 
-					assert.Equals(t, fmt.Sprintf("%v", leaf.Subject),
-						fmt.Sprintf("%v", &pkix.Name{
+					assert.Equals(t, leaf.Subject.String(),
+						pkix.Name{
 							CommonName: asn1dn.CommonName,
-						}))
+						}.String())
 					assert.Equals(t, leaf.Issuer, intermediate.Subject)
 
 					assert.Equals(t, leaf.SignatureAlgorithm, x509.ECDSAWithSHA256)

--- a/ca/client.go
+++ b/ca/client.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -75,7 +74,7 @@ func (c *uaClient) SetTransport(tr http.RoundTripper) {
 }
 
 func (c *uaClient) Get(u string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest("GET", u, http.NoBody)
 	if err != nil {
 		return nil, errors.Wrapf(err, "new request GET %s failed", u)
 	}
@@ -350,7 +349,7 @@ func WithRetryFunc(fn RetryFunc) ClientOption {
 }
 
 func getTransportFromFile(filename string) (http.RoundTripper, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s", filename)
 	}
@@ -1305,7 +1304,7 @@ func readJSON(r io.ReadCloser, v interface{}) error {
 
 func readProtoJSON(r io.ReadCloser, m proto.Message) error {
 	defer r.Close()
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/ca/identity/client.go
+++ b/ca/identity/client.go
@@ -5,9 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -27,7 +27,7 @@ func (c *Client) ResolveReference(ref *url.URL) *url.URL {
 // $STEPPATH/config/defaults.json and the identity defined in
 // $STEPPATH/config/identity.json
 func LoadClient() (*Client, error) {
-	b, err := ioutil.ReadFile(DefaultsFile)
+	b, err := os.ReadFile(DefaultsFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s", DefaultsFile)
 	}
@@ -65,7 +65,7 @@ func LoadClient() (*Client, error) {
 	}
 
 	// RootCAs
-	b, err = ioutil.ReadFile(defaults.Root)
+	b, err = os.ReadFile(defaults.Root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error loading %s", defaults.Root)
 	}

--- a/ca/identity/client_test.go
+++ b/ca/identity/client_test.go
@@ -3,10 +3,10 @@ package identity
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -40,7 +40,7 @@ func TestClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile("testdata/certs/root_ca.crt")
+	b, err := os.ReadFile("testdata/certs/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestLoadClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile("testdata/certs/root_ca.crt")
+	b, err := os.ReadFile("testdata/certs/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -61,7 +60,7 @@ type Identity struct {
 
 // LoadIdentity loads an identity present in the given filename.
 func LoadIdentity(filename string) (*Identity, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s", filename)
 	}
@@ -112,7 +111,7 @@ func WriteDefaultIdentity(certChain []api.Certificate, key crypto.PrivateKey) er
 	if err := pem.Encode(buf, block); err != nil {
 		return errors.Wrap(err, "error encoding identity key")
 	}
-	if err := ioutil.WriteFile(keyFilename, buf.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(keyFilename, buf.Bytes(), 0600); err != nil {
 		return errors.Wrap(err, "error writing identity certificate")
 	}
 
@@ -127,7 +126,7 @@ func WriteDefaultIdentity(certChain []api.Certificate, key crypto.PrivateKey) er
 	}); err != nil {
 		return errors.Wrap(err, "error writing identity json")
 	}
-	if err := ioutil.WriteFile(IdentityFile, buf.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(IdentityFile, buf.Bytes(), 0600); err != nil {
 		return errors.Wrap(err, "error writing identity certificate")
 	}
 
@@ -153,7 +152,7 @@ func writeCertificate(filename string, certChain []api.Certificate) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
 		return errors.Wrap(err, "error writing certificate")
 	}
 
@@ -263,7 +262,7 @@ func (i *Identity) GetCertPool() (*x509.CertPool, error) {
 	if i.Root == "" {
 		return nil, nil
 	}
-	b, err := ioutil.ReadFile(i.Root)
+	b, err := os.ReadFile(i.Root)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading identity root")
 	}
@@ -320,7 +319,7 @@ func (i *Identity) Renew(client Renewer) error {
 			}
 		}
 		certFilename := filepath.Join(identityDir, "identity.crt")
-		if err := ioutil.WriteFile(certFilename, buf.Bytes(), 0600); err != nil {
+		if err := os.WriteFile(certFilename, buf.Bytes(), 0600); err != nil {
 			return errors.Wrap(err, "error writing identity certificate")
 		}
 

--- a/ca/provisioner_test.go
+++ b/ca/provisioner_test.go
@@ -1,8 +1,8 @@
 package ca
 
 import (
-	"io/ioutil"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -45,7 +45,7 @@ func TestNewProvisioner(t *testing.T) {
 	defer ca.Close()
 	want := getTestProvisioner(t, ca.URL)
 
-	caBundle, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	caBundle, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ca/tls_options_test.go
+++ b/ca/tls_options_test.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -202,7 +202,7 @@ func TestAddRootsToRootCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestAddRootsToClientCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,12 +310,12 @@ func TestAddFederationToRootCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	federated, err := ioutil.ReadFile("testdata/secrets/federated_ca.crt")
+	federated, err := os.ReadFile("testdata/secrets/federated_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,12 +374,12 @@ func TestAddFederationToClientCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	federated, err := ioutil.ReadFile("testdata/secrets/federated_ca.crt")
+	federated, err := os.ReadFile("testdata/secrets/federated_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -438,7 +438,7 @@ func TestAddRootsToCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,12 +492,12 @@ func TestAddFederationToCAs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	root, err := ioutil.ReadFile("testdata/secrets/root_ca.crt")
+	root, err := os.ReadFile("testdata/secrets/root_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	federated, err := ioutil.ReadFile("testdata/secrets/federated_ca.crt")
+	federated, err := os.ReadFile("testdata/secrets/federated_ca.crt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ca/tls_test.go
+++ b/ca/tls_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -221,7 +221,7 @@ func TestClient_GetServerTLSConfig_http(t *testing.T) {
 						return
 					}
 					defer resp.Body.Close()
-					b, err := ioutil.ReadAll(resp.Body)
+					b, err := io.ReadAll(resp.Body)
 					if err != nil {
 						t.Fatalf("ioutil.RealAdd() error = %v", err)
 					}
@@ -335,7 +335,7 @@ func TestClient_GetServerTLSConfig_renew(t *testing.T) {
 					}
 
 					defer resp.Body.Close()
-					b, err := ioutil.ReadAll(resp.Body)
+					b, err := io.ReadAll(resp.Body)
 					if err != nil {
 						t.Errorf("ioutil.RealAdd() error = %v", err)
 						return
@@ -374,9 +374,9 @@ func TestClient_GetServerTLSConfig_renew(t *testing.T) {
 					}
 
 					defer resp.Body.Close()
-					b, err := ioutil.ReadAll(resp.Body)
+					b, err := io.ReadAll(resp.Body)
 					if err != nil {
-						t.Errorf("ioutil.RealAdd() error = %v", err)
+						t.Errorf("io.ReadAll() error = %v", err)
 						return
 					}
 					if !bytes.Equal(b, []byte("ok")) {

--- a/cas/stepcas/stepcas_test.go
+++ b/cas/stepcas/stepcas_test.go
@@ -91,7 +91,7 @@ func mustSerializeCrt(filename string, certs ...*x509.Certificate) {
 			panic(err)
 		}
 	}
-	if err := ioutil.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
 		panic(err)
 	}
 }
@@ -105,7 +105,7 @@ func mustSerializeKey(filename string, key crypto.Signer) {
 		Type:  "PRIVATE KEY",
 		Bytes: b,
 	})
-	if err := ioutil.WriteFile(filename, b, 0600); err != nil {
+	if err := os.WriteFile(filename, b, 0600); err != nil {
 		panic(err)
 	}
 }

--- a/commands/app.go
+++ b/commands/app.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -98,7 +97,7 @@ To get a linked authority token:
 
 	var password []byte
 	if passFile != "" {
-		if password, err = ioutil.ReadFile(passFile); err != nil {
+		if password, err = os.ReadFile(passFile); err != nil {
 			fatal(errors.Wrapf(err, "error reading %s", passFile))
 		}
 		password = bytes.TrimRightFunc(password, unicode.IsSpace)
@@ -106,7 +105,7 @@ To get a linked authority token:
 
 	var sshHostPassword []byte
 	if sshHostPassFile != "" {
-		if sshHostPassword, err = ioutil.ReadFile(sshHostPassFile); err != nil {
+		if sshHostPassword, err = os.ReadFile(sshHostPassFile); err != nil {
 			fatal(errors.Wrapf(err, "error reading %s", sshHostPassFile))
 		}
 		sshHostPassword = bytes.TrimRightFunc(sshHostPassword, unicode.IsSpace)
@@ -114,7 +113,7 @@ To get a linked authority token:
 
 	var sshUserPassword []byte
 	if sshUserPassFile != "" {
-		if sshUserPassword, err = ioutil.ReadFile(sshUserPassFile); err != nil {
+		if sshUserPassword, err = os.ReadFile(sshUserPassFile); err != nil {
 			fatal(errors.Wrapf(err, "error reading %s", sshUserPassFile))
 		}
 		sshUserPassword = bytes.TrimRightFunc(sshUserPassword, unicode.IsSpace)
@@ -122,7 +121,7 @@ To get a linked authority token:
 
 	var issuerPassword []byte
 	if issuerPassFile != "" {
-		if issuerPassword, err = ioutil.ReadFile(issuerPassFile); err != nil {
+		if issuerPassword, err = os.ReadFile(issuerPassFile); err != nil {
 			fatal(errors.Wrapf(err, "error reading %s", issuerPassFile))
 		}
 		issuerPassword = bytes.TrimRightFunc(issuerPassword, unicode.IsSpace)

--- a/commands/export.go
+++ b/commands/export.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"unicode"
 
 	"github.com/pkg/errors"
@@ -72,14 +72,14 @@ func exportAction(ctx *cli.Context) error {
 	}
 
 	if passwordFile != "" {
-		b, err := ioutil.ReadFile(passwordFile)
+		b, err := os.ReadFile(passwordFile)
 		if err != nil {
 			return errors.Wrapf(err, "error reading %s", passwordFile)
 		}
 		cfg.Password = string(bytes.TrimRightFunc(b, unicode.IsSpace))
 	}
 	if issuerPasswordFile != "" {
-		b, err := ioutil.ReadFile(issuerPasswordFile)
+		b, err := os.ReadFile(issuerPasswordFile)
 		if err != nil {
 			return errors.Wrapf(err, "error reading %s", issuerPasswordFile)
 		}

--- a/examples/basic-federation/client/main.go
+++ b/examples/basic-federation/client/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -32,7 +32,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			panic(err)

--- a/examples/bootstrap-client/client.go
+++ b/examples/bootstrap-client/client.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -32,7 +32,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smallstep/certificates
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.83.0

--- a/go.sum
+++ b/go.sum
@@ -367,10 +367,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -956,7 +954,6 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/kms/cloudkms/cloudkms_test.go
+++ b/kms/cloudkms/cloudkms_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -165,7 +165,7 @@ func TestCloudKMS_Close(t *testing.T) {
 
 func TestCloudKMS_CreateSigner(t *testing.T) {
 	keyName := "projects/p/locations/l/keyRings/k/cryptoKeys/c/cryptoKeyVersions/1"
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestCloudKMS_CreateKey(t *testing.T) {
 	testError := fmt.Errorf("an error")
 	alreadyExists := status.Error(codes.AlreadyExists, "already exists")
 
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +389,7 @@ func TestCloudKMS_GetPublicKey(t *testing.T) {
 	keyName := "projects/p/locations/l/keyRings/k/cryptoKeys/c/cryptoKeyVersions/1"
 	testError := fmt.Errorf("an error")
 
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kms/cloudkms/signer_test.go
+++ b/kms/cloudkms/signer_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_newSigner(t *testing.T) {
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func Test_newSigner(t *testing.T) {
 }
 
 func Test_signer_Public(t *testing.T) {
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func Test_signer_Sign(t *testing.T) {
 }
 
 func TestSigner_SignatureAlgorithm(t *testing.T) {
-	pemBytes, err := ioutil.ReadFile("testdata/pub.pem")
+	pemBytes, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kms/softkms/softkms_test.go
+++ b/kms/softkms/softkms_test.go
@@ -11,7 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -78,7 +78,7 @@ func TestSoftKMS_CreateSigner(t *testing.T) {
 	}
 
 	// Read and decode file using standard packages
-	b, err := ioutil.ReadFile("testdata/priv.pem")
+	b, err := os.ReadFile("testdata/priv.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestSoftKMS_CreateKey(t *testing.T) {
 }
 
 func TestSoftKMS_GetPublicKey(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/pub.pem")
+	b, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestSoftKMS_CreateDecrypter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadFile("testdata/rsa.priv.pem")
+	b, err := os.ReadFile("testdata/rsa.priv.pem")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kms/sshagentkms/sshagentkms_test.go
+++ b/kms/sshagentkms/sshagentkms_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -202,7 +201,7 @@ func TestNew(t *testing.T) {
 	})
 
 	// Load ssh test fixtures
-	b, err := ioutil.ReadFile("testdata/ssh")
+	b, err := os.ReadFile("testdata/ssh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +289,7 @@ func TestSSHAgentKMS_CreateSigner(t *testing.T) {
 	}
 
 	// Read and decode file using standard packages
-	b, err := ioutil.ReadFile("testdata/priv.pem")
+	b, err := os.ReadFile("testdata/priv.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +314,7 @@ func TestSSHAgentKMS_CreateSigner(t *testing.T) {
 	})
 
 	// Load ssh test fixtures
-	sshPubKeyStr, err := ioutil.ReadFile("testdata/ssh.pub")
+	sshPubKeyStr, err := os.ReadFile("testdata/ssh.pub")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +322,7 @@ func TestSSHAgentKMS_CreateSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err = ioutil.ReadFile("testdata/ssh")
+	b, err = os.ReadFile("testdata/ssh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -499,7 +498,7 @@ func TestSSHAgentKMS_CreateKey(t *testing.T) {
 */
 
 func TestSSHAgentKMS_GetPublicKey(t *testing.T) {
-	b, err := ioutil.ReadFile("testdata/pub.pem")
+	b, err := os.ReadFile("testdata/pub.pem")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +509,7 @@ func TestSSHAgentKMS_GetPublicKey(t *testing.T) {
 	}
 
 	// Load ssh test fixtures
-	b, err = ioutil.ReadFile("testdata/ssh.pub")
+	b, err = os.ReadFile("testdata/ssh.pub")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +517,7 @@ func TestSSHAgentKMS_GetPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err = ioutil.ReadFile("testdata/ssh")
+	b, err = os.ReadFile("testdata/ssh")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kms/uri/uri.go
+++ b/kms/uri/uri.go
@@ -3,8 +3,8 @@ package uri
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"unicode"
 
@@ -140,7 +140,7 @@ func readFile(path string) ([]byte, error) {
 	if err == nil && (u.Scheme == "" || u.Scheme == "file") && u.Path != "" {
 		path = u.Path
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s", path)
 	}

--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -167,7 +166,7 @@ func decodeSCEPRequest(r *http.Request) (SCEPRequest, error) {
 			return SCEPRequest{}, errors.Errorf("unsupported operation: %s", operation)
 		}
 	case http.MethodPost:
-		body, err := ioutil.ReadAll(io.LimitReader(r.Body, maxPayloadSize))
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadSize))
 		if err != nil {
 			return SCEPRequest{}, err
 		}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -2,7 +2,6 @@ package templates
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +166,7 @@ func (t *Template) Load() error {
 		switch {
 		case t.TemplatePath != "":
 			filename := config.StepAbs(t.TemplatePath)
-			b, err := ioutil.ReadFile(filename)
+			b, err := os.ReadFile(filename)
 			if err != nil {
 				return errors.Wrapf(err, "error reading %s", filename)
 			}


### PR DESCRIPTION
Fixes #740.

The golangci-lint version to use should be updated periodically. 