### PR TITLE
Fix systemd renewer script

### DIFF
--- a/systemd/cert-renewer@.service
+++ b/systemd/cert-renewer@.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/step ca renew --force ${CERT_LOCATION} ${KEY_LOCATION}
 
 ; Try to reload or restart the systemd service that relies on this cert-renewer
 ; If the relying service doesn't exist, forge ahead.
-ExecStartPost=/usr/bin/env bash -c "if ! systemctl --quiet is-enabled %i.service ; then exit 0; fi; systemctl try-reload-or-restart %i"
+ExecStartPost=/usr/bin/env sh -c "! systemctl --quiet is-enabled %i.service || systemctl reload-or-try-restart %i.service"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This corrects the systemctl command. Additionally, it simplifies the shell script used and switches to sh, which unlike bash is guaranteed to be available.

See also smallstep/docs#32.