### PR TITLE
Avoid doing unauthenticated requests on the SDK

### DIFF
--- a/ca/bootstrap.go
+++ b/ca/bootstrap.go
@@ -65,7 +65,7 @@ func BootstrapClient(ctx context.Context, token string, options ...TLSOption) (*
 		return nil, err
 	}
 
-	// Make sure the tlsConfig have all supported roots on RootCAs.
+	// Make sure the tlsConfig has all supported roots on RootCAs.
 	//
 	// The roots request is only supported if identity certificates are not
 	// required. In all cases the current root is also added after applying all
@@ -123,7 +123,7 @@ func BootstrapServer(ctx context.Context, token string, base *http.Server, optio
 		return nil, err
 	}
 
-	// Make sure the tlsConfig have all supported roots on RootCAs.
+	// Make sure the tlsConfig has all supported roots on RootCAs.
 	//
 	// The roots request is only supported if identity certificates are not
 	// required. In all cases the current root is also added after applying all
@@ -171,7 +171,7 @@ func BootstrapListener(ctx context.Context, token string, inner net.Listener, op
 		return nil, err
 	}
 
-	// Make sure the tlsConfig have all supported roots on RootCAs.
+	// Make sure the tlsConfig has all supported roots on RootCAs.
 	//
 	// The roots request is only supported if identity certificates are not
 	// required. In all cases the current root is also added after applying all

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -603,7 +603,7 @@ func TestBootstrapListener(t *testing.T) {
 	mtlsServer.Config.Handler = mTLSMiddleware(next, "/root/", "/sign")
 	defer mtlsServer.Close()
 	mtlsToken := func() string {
-		return generateBootstrapToken(mtlsServer.URL, "subject", "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7")
+		return generateBootstrapToken(mtlsServer.URL, "127.0.0.1", "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7")
 	}
 
 	type args struct {

--- a/ca/tls_options.go
+++ b/ca/tls_options.go
@@ -115,6 +115,7 @@ func AddRootCA(cert *x509.Certificate) TLSOption {
 		if ctx.Config.RootCAs == nil {
 			ctx.Config.RootCAs = x509.NewCertPool()
 		}
+		ctx.hasRootCA = true
 		ctx.Config.RootCAs.AddCert(cert)
 		ctx.mutableConfig.AddImmutableRootCACert(cert)
 		return nil
@@ -129,6 +130,7 @@ func AddClientCA(cert *x509.Certificate) TLSOption {
 		if ctx.Config.ClientCAs == nil {
 			ctx.Config.ClientCAs = x509.NewCertPool()
 		}
+		ctx.hasClientCA = true
 		ctx.Config.ClientCAs.AddCert(cert)
 		ctx.mutableConfig.AddImmutableClientCACert(cert)
 		return nil


### PR DESCRIPTION
### Description

When step-ca runs with mTLS required on some endpoints, the SDK used in autocert will fail to start because the identity certificate is missing. This certificate is only required to retrieve all roots, in most cases, there's only one, and the SDK has access to it.


I've added you @hslatman and @dopey, but I only need one review.