### PR TITLE
Create the db directory on step ca init

### DIFF
--- a/pki/pki.go
+++ b/pki/pki.go
@@ -978,6 +978,7 @@ func (p *PKI) Save(opt ...ConfigOption) error {
 		}
 
 		if cfg.DB != nil {
+			os.MkdirAll(cfg.DB.DataSource, 0700)
 			ui.PrintSelected("Database folder", cfg.DB.DataSource)
 		}
 		if cfg.Templates != nil {


### PR DESCRIPTION
The systemd unit has a stanza that requires the db folder to exist, or else it will not start the unit.
But `step ca init` doesn't create the db folder.
This PR makes it possible to run `step ca init` and then `systemctl start step-ca` without needing to manually mkdir the db folder first.

