### PR TITLE
Normalize IPv6 hostname addresses

### DIFF
--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -270,28 +270,36 @@ func (c *Config) GetAudiences() provisioner.Audiences {
 
 	for _, name := range c.DNSNames {
 		audiences.Sign = append(audiences.Sign,
-			fmt.Sprintf("https://%s/1.0/sign", name),
-			fmt.Sprintf("https://%s/sign", name),
-			fmt.Sprintf("https://%s/1.0/ssh/sign", name),
-			fmt.Sprintf("https://%s/ssh/sign", name))
+			fmt.Sprintf("https://%s/1.0/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/1.0/ssh/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/ssh/sign", toHostname(name)))
 		audiences.Revoke = append(audiences.Revoke,
-			fmt.Sprintf("https://%s/1.0/revoke", name),
-			fmt.Sprintf("https://%s/revoke", name))
+			fmt.Sprintf("https://%s/1.0/revoke", toHostname(name)),
+			fmt.Sprintf("https://%s/revoke", toHostname(name)))
 		audiences.SSHSign = append(audiences.SSHSign,
-			fmt.Sprintf("https://%s/1.0/ssh/sign", name),
-			fmt.Sprintf("https://%s/ssh/sign", name),
-			fmt.Sprintf("https://%s/1.0/sign", name),
-			fmt.Sprintf("https://%s/sign", name))
+			fmt.Sprintf("https://%s/1.0/ssh/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/ssh/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/1.0/sign", toHostname(name)),
+			fmt.Sprintf("https://%s/sign", toHostname(name)))
 		audiences.SSHRevoke = append(audiences.SSHRevoke,
-			fmt.Sprintf("https://%s/1.0/ssh/revoke", name),
-			fmt.Sprintf("https://%s/ssh/revoke", name))
+			fmt.Sprintf("https://%s/1.0/ssh/revoke", toHostname(name)),
+			fmt.Sprintf("https://%s/ssh/revoke", toHostname(name)))
 		audiences.SSHRenew = append(audiences.SSHRenew,
-			fmt.Sprintf("https://%s/1.0/ssh/renew", name),
-			fmt.Sprintf("https://%s/ssh/renew", name))
+			fmt.Sprintf("https://%s/1.0/ssh/renew", toHostname(name)),
+			fmt.Sprintf("https://%s/ssh/renew", toHostname(name)))
 		audiences.SSHRekey = append(audiences.SSHRekey,
-			fmt.Sprintf("https://%s/1.0/ssh/rekey", name),
-			fmt.Sprintf("https://%s/ssh/rekey", name))
+			fmt.Sprintf("https://%s/1.0/ssh/rekey", toHostname(name)),
+			fmt.Sprintf("https://%s/ssh/rekey", toHostname(name)))
 	}
 
 	return audiences
+}
+
+func toHostname(name string) string {
+	// ensure an IPv6 address is represented with square brackets when used as hostname
+	if ip := net.ParseIP(name); ip != nil && ip.To4() == nil {
+		name = "[" + name + "]"
+	}
+	return name
 }

--- a/authority/config/config_test.go
+++ b/authority/config/config_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smallstep/assert"
 	"github.com/smallstep/certificates/authority/provisioner"
-	"go.step.sm/crypto/jose"
-
 	_ "github.com/smallstep/certificates/cas"
+	"go.step.sm/crypto/jose"
 )
 
 func TestConfigValidate(t *testing.T) {
@@ -294,6 +293,26 @@ func TestAuthConfigValidate(t *testing.T) {
 				if assert.Nil(t, tc.err, fmt.Sprintf("expected error: %s, but got <nil>", tc.err)) {
 					assert.Equals(t, *tc.ac.Template, tc.asn1dn)
 				}
+			}
+		})
+	}
+}
+
+func Test_toHostname(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "localhost", want: "localhost"},
+		{name: "ca.smallstep.com", want: "ca.smallstep.com"},
+		{name: "127.0.0.1", want: "127.0.0.1"},
+		{name: "::1", want: "[::1]"},
+		{name: "[::1]", want: "[::1]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toHostname(tt.name); got != tt.want {
+				t.Errorf("toHostname() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR ensures that IPv6 addresses the CA is configured for will contain square brackets when used as a hostname. This is at least the case for token audiences.

With these changes and the ones from the CLI in https://github.com/smallstep/cli/pull/610 the CA will have a cert for an IP SAN (instead of DNS) for serving its API, will respond to requests to its IPv6 address (i.e. `https://[::1]:8443`) and allows operations that are authorized by a JWT with that same hostname in it.