### PR TITLE
Authority enforcer option

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -50,6 +50,7 @@ type Authority struct {
 	rootX509CertPool   *x509.CertPool
 	federatedX509Certs []*x509.Certificate
 	certificates       *sync.Map
+	x509Enforcers      []provisioner.CertificateEnforcer
 
 	// SCEP CA
 	scepService *scep.Service

--- a/authority/options.go
+++ b/authority/options.go
@@ -241,6 +241,15 @@ func WithLinkedCAToken(token string) Option {
 	}
 }
 
+// WithX509Enforcers is an option that allows to define custom certificate
+// modifiers that will be processed just before the signing of the certificate.
+func WithX509Enforcers(ces ...provisioner.CertificateEnforcer) Option {
+	return func(a *Authority) error {
+		a.x509Enforcers = ces
+		return nil
+	}
+}
+
 func readCertificateBundle(pemCerts []byte) ([]*x509.Certificate, error) {
 	var block *pem.Block
 	var certs []*x509.Certificate


### PR DESCRIPTION
### Description

Add an authority option that we can use to inject X509 enforcers. These enforcers are used to modify a cert after any validation.