### PR TITLE
Add descriptive provisioner JWK decryption error messages

### DIFF
--- a/ca/provisioner.go
+++ b/ca/provisioner.go
@@ -155,11 +155,11 @@ func (p *Provisioner) SSHToken(certType, keyID string, principals []string) (str
 func decryptProvisionerJWK(encryptedKey string, password []byte) (*jose.JSONWebKey, error) {
 	enc, err := jose.ParseEncrypted(encryptedKey)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error parsing provisioner encrypted key")
 	}
 	data, err := enc.Decrypt(password)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error decrypting provisioner key with provided password")
 	}
 	jwk := new(jose.JSONWebKey)
 	if err := json.Unmarshal(data, jwk); err != nil {


### PR DESCRIPTION
### Description

Wrap other errors in JWK decryption process with more helpful messaging.  This should help users troubleshoot misconfiguration more easily.

Fixes #816
