### PR TITLE
Make the X5C leaf certificate available to the templates.

### DIFF
--- a/authority/provisioner/nebula.go
+++ b/authority/provisioner/nebula.go
@@ -139,9 +139,9 @@ func (p *Nebula) AuthorizeSign(ctx context.Context, token string) ([]SignOption,
 		data.SetToken(v)
 	}
 
-	// The Nebula certificate will be available using the template variable Crt.
-	// For example {{ .AuthorizationCrt.Details.Groups }} can be used to get all
-	// the groups.
+	// The Nebula certificate will be available using the template variable
+	// AuthorizationCrt. For example {{ .AuthorizationCrt.Details.Groups }} can
+	// be used to get all the groups.
 	data.SetAuthorizationCertificate(crt)
 
 	templateOptions, err := TemplateOptions(p.Options, data)

--- a/authority/provisioner/nebula.go
+++ b/authority/provisioner/nebula.go
@@ -140,7 +140,8 @@ func (p *Nebula) AuthorizeSign(ctx context.Context, token string) ([]SignOption,
 	}
 
 	// The Nebula certificate will be available using the template variable Crt.
-	// For example {{ .Crt.Details.Groups }} can be used to get all the groups.
+	// For example {{ .AuthorizationCrt.Details.Groups }} can be used to get all
+	// the groups.
 	data.SetAuthorizationCertificate(crt)
 
 	templateOptions, err := TemplateOptions(p.Options, data)

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -213,6 +213,11 @@ func (p *X5C) AuthorizeSign(ctx context.Context, token string) ([]SignOption, er
 		data.SetToken(v)
 	}
 
+	// The X509 certificate will be available using the template variable Crt.
+	// For example {{ .AuthorizationCrt.DNSNames }} can be used to get all the
+	// domains.
+	data.SetAuthorizationCertificate(claims.chains[0][0])
+
 	templateOptions, err := TemplateOptions(p.Options, data)
 	if err != nil {
 		return nil, errs.Wrap(http.StatusInternalServerError, err, "jwk.AuthorizeSign")
@@ -286,6 +291,11 @@ func (p *X5C) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	if v, err := unsafeParseSigned(token); err == nil {
 		data.SetToken(v)
 	}
+
+	// The X509 certificate will be available using the template variable Crt.
+	// For example {{ .AuthorizationCrt.DNSNames }} can be used to get all the
+	// domains.
+	data.SetAuthorizationCertificate(claims.chains[0][0])
 
 	templateOptions, err := TemplateSSHOptions(p.Options, data)
 	if err != nil {

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -213,9 +213,9 @@ func (p *X5C) AuthorizeSign(ctx context.Context, token string) ([]SignOption, er
 		data.SetToken(v)
 	}
 
-	// The X509 certificate will be available using the template variable Crt.
-	// For example {{ .AuthorizationCrt.DNSNames }} can be used to get all the
-	// domains.
+	// The X509 certificate will be available using the template variable
+	// AuthorizationCrt. For example {{ .AuthorizationCrt.DNSNames }} can be
+	// used to get all the domains.
 	data.SetAuthorizationCertificate(claims.chains[0][0])
 
 	templateOptions, err := TemplateOptions(p.Options, data)
@@ -292,9 +292,9 @@ func (p *X5C) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 		data.SetToken(v)
 	}
 
-	// The X509 certificate will be available using the template variable Crt.
-	// For example {{ .AuthorizationCrt.DNSNames }} can be used to get all the
-	// domains.
+	// The X509 certificate will be available using the template variable
+	// AuthorizationCrt. For example {{ .AuthorizationCrt.DNSNames }} can be
+	// used to get all the domains.
 	data.SetAuthorizationCertificate(claims.chains[0][0])
 
 	templateOptions, err := TemplateSSHOptions(p.Options, data)


### PR DESCRIPTION
### Description

This PR makes the X5C leaf certificate available in the templates.

X509 and SSH templates of the X5C provisioner will have now access to the leaf certificate used to sign the token using the template variable `.AuthorizationCrt`.

Fixes #433
