### PR TITLE
WIP: Support Azure tokens generated by managed identities

### DIFF
--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -30,7 +30,7 @@ const azureDefaultAudience = "https://management.azure.com/"
 
 // azureXMSMirIDRegExp is the regular expression used to parse the xms_mirid claim.
 // Using case insensitive as resourceGroups appears as resourcegroups.
-var azureXMSMirIDRegExp = regexp.MustCompile(`(?i)^/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft.Compute/virtualMachines/([^/]+)$`)
+var azureXMSMirIDRegExp = regexp.MustCompile(`(?i)^/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft.(Compute/virtualMachines|ManagedIdentity/userAssignedIdentities)/([^/]+)$`)
 
 type azureConfig struct {
 	oidcDiscoveryURL string
@@ -263,11 +263,19 @@ func (p *Azure) authorizeToken(token string) (*azurePayload, string, string, str
 	}
 
 	re := azureXMSMirIDRegExp.FindStringSubmatch(claims.XMSMirID)
-	if len(re) != 4 {
+	if len(re) != 5 {
 		return nil, "", "", "", "", errs.Unauthorized("azure.authorizeToken; error parsing xms_mirid claim - %s", claims.XMSMirID)
 	}
+
+	var subscription, group, name string
 	identityObjectID := claims.ObjectID
-	subscription, group, name := re[1], re[2], re[3]
+
+	if strings.Contains(claims.XMSMirID, "virtualMachines") {
+		subscription, group, name = re[1], re[2], re[4]
+	} else {
+		// This is not a VM resource ID so we don't have the VM name so set that to the empty string
+		subscription, group, name = re[1], re[2], ""
+	}
 	return &claims, name, group, subscription, identityObjectID, nil
 }
 

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -269,13 +269,8 @@ func (p *Azure) authorizeToken(token string) (*azurePayload, string, string, str
 
 	var subscription, group, name string
 	identityObjectID := claims.ObjectID
+	subscription, group, name = re[1], re[2], re[4]
 
-	if strings.Contains(claims.XMSMirID, "virtualMachines") {
-		subscription, group, name = re[1], re[2], re[4]
-	} else {
-		// This is not a VM resource ID so we don't have the VM name so set that to the empty string
-		subscription, group, name = re[1], re[2], ""
-	}
 	return &claims, name, group, subscription, identityObjectID, nil
 }
 

--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -95,7 +95,7 @@ func TestAzure_GetIdentityToken(t *testing.T) {
 	assert.FatalError(t, err)
 
 	t1, err := generateAzureToken("subject", p1.oidcConfig.Issuer, azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now(), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 
@@ -237,7 +237,7 @@ func TestAzure_authorizeToken(t *testing.T) {
 			jwk, err := jose.GenerateJWK("EC", "P-256", "ES256", "sig", "", 0)
 			assert.FatalError(t, err)
 			tok, err := generateAzureToken("subject", p.oidcConfig.Issuer, azureDefaultAudience,
-				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 				time.Now(), jwk)
 			assert.FatalError(t, err)
 			return test{
@@ -252,7 +252,7 @@ func TestAzure_authorizeToken(t *testing.T) {
 			assert.FatalError(t, err)
 			defer srv.Close()
 			tok, err := generateAzureToken("subject", "bad-issuer", azureDefaultAudience,
-				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 				time.Now(), &p.keyStore.keySet.Keys[0])
 			assert.FatalError(t, err)
 			return test{
@@ -267,7 +267,7 @@ func TestAzure_authorizeToken(t *testing.T) {
 			assert.FatalError(t, err)
 			defer srv.Close()
 			tok, err := generateAzureToken("subject", p.oidcConfig.Issuer, azureDefaultAudience,
-				"foo", "subscriptionID", "resourceGroup", "virtualMachine",
+				"foo", "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 				time.Now(), &p.keyStore.keySet.Keys[0])
 			assert.FatalError(t, err)
 			return test{
@@ -321,7 +321,7 @@ func TestAzure_authorizeToken(t *testing.T) {
 			assert.FatalError(t, err)
 			defer srv.Close()
 			tok, err := generateAzureToken("subject", p.oidcConfig.Issuer, azureDefaultAudience,
-				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+				p.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 				time.Now(), &p.keyStore.keySet.Keys[0])
 			assert.FatalError(t, err)
 			return test{
@@ -437,28 +437,28 @@ func TestAzure_AuthorizeSign(t *testing.T) {
 	assert.FatalError(t, err)
 
 	t11, err := generateAzureToken("subject", p1.oidcConfig.Issuer, azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now(), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 
 	failIssuer, err := generateAzureToken("subject", "bad-issuer", azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now(), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 	failAudience, err := generateAzureToken("subject", p1.oidcConfig.Issuer, "bad-audience",
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now(), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 	failExp, err := generateAzureToken("subject", p1.oidcConfig.Issuer, azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now().Add(-360*time.Second), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 	failNbf, err := generateAzureToken("subject", p1.oidcConfig.Issuer, azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now().Add(360*time.Second), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 	failKey, err := generateAzureToken("subject", p1.oidcConfig.Issuer, azureDefaultAudience,
-		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine",
+		p1.TenantID, "subscriptionID", "resourceGroup", "virtualMachine", "vm",
 		time.Now(), badKey)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -1009,7 +1009,7 @@ func generateAWSToken(p *AWS, sub, iss, aud, accountID, instanceID, privateIP, r
 	return jose.Signed(sig).Claims(claims).CompactSerialize()
 }
 
-func generateAzureToken(sub, iss, aud, tenantID, subscriptionID, resourceGroup, resourceName string, resourceType string, iat time.Time, jwk *jose.JSONWebKey) (string, error) {
+func generateAzureToken(sub, iss, aud, tenantID, subscriptionID, resourceGroup, resourceName, resourceType string, iat time.Time, jwk *jose.JSONWebKey) (string, error) {
 	sig, err := jose.NewSigner(
 		jose.SigningKey{Algorithm: jose.ES256, Key: jwk.Key},
 		new(jose.SignerOptions).WithType("JWT").WithHeader("kid", jwk.KeyID),


### PR DESCRIPTION
I  know that its expected that users utilise either the ACME provisioner or I guess the K8sSA provisioner on Kubernetes. However, I think it would still be nice if it were possible to use step cli in container on Kubernetes, specifically on Azure Kubernetes Service (AKS).                                                                 
                                                                                                                                                                        
At the moment it's not possible because the value in the `xms_mirid` claim is expected to match the regular expression:                                                 
                                                                                                                                                                        
```go                                                                                                                                                                   
var azureXMSMirIDRegExp = regexp.MustCompile(`(?i)^/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft.Compute/virtualMachines/([^/]+)$`)                 
```                                                                                                                                                                     
                                                                                                                                                                        
However, on AKS you can use [Azure AD Pod Identity](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) the purpose of this is to allow you to use a managed identity to access Azure resources from within workloads running on AKS. When you use this the token you obtain from the IMDS has an `xms_mirid` claim that looks like this:                                                                                                                                                             
                                                                                                                                                                        
```                                                                                                                                                                     
var azureXMSMirIDRegExp = regexp.MustCompile(`(?i)^/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft.ManagedIdentity/userAssignedIdentities/([^/]+)$`)  
```                                                                                                                                                                     
                                                                                                                                                                        
Note the `xms_mirid` claim looks like this for VM Scale Sets as well.                                                                                                   
                                                                                                                                                                        
The net result is that today if you try to run                                                                                                                          
                                                                                                                                                                        
```                                                                                                                                                                     
step ca certificate <somedomain> mycert.crt mykey.key --provisioner "Azure"                                                                                             
```                                                                                                                                                                     
                                                                                                                                                                        
You receive the error `token is not supported`.                                                                                                                         
                                                                                                                                                                        
The regular expression is used in `authority/provisioner/azure.go` in [authorizeToken](https://github.com/smallstep/certificates/blob/master/authority/provisioner/azure.go#L265) and in [parseResponse](https://github.com/smallstep/cli/blob/master/token/parse.go#L174) in the step cli. Furthermore, in `parseResponse` the virtual machine name is extracted from this `xms_mirid` claim as it is used as a default SAN in [CreateSignRequest](https://github.com/smallstep/cli/blob/master/utils/cautils/certificate_flow.go#L274). 

This PR changes the regular expression used for the `xms_mirid` claim so it can accept both types of resource identifiers. However, there is a side effect that the virtual machine name is used as the default SAN - in particular when DisableCustomSANs is true, the IP address and the VM name are added as SANs. But when the resource type is Microsoft.ManagedIdentity we won't have a real VM name so I have assumed in this case that the virtual machine name should just be the empty string.                
                                                                                                                                                                        
I think it also means that if custom SANs are disabled then it won't issue certs/authorize the token when the resource type is Managed.Identity.

Please let me know if people think we should support this scenario in a different way (or indeed if the feeling is either the ACME or K8sSA provisioner should be used instead). I've marked it as WIP because I think I'd probably need to add new tests but I wanted to see if the project is open to making a change like this. 

This is the associated [PR](https://github.com/smallstep/cli/pull/646) for the cli repo.