### PR TITLE
Add configuration for custom path segment on SCEP provisioners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased - 0.18.3] - DATE
 ### Added
 ### Changed
+- Made SCEP CA URL paths dynamic
 ### Deprecated
 ### Removed
 ### Fixed

--- a/authority/provisioner/scep.go
+++ b/authority/provisioner/scep.go
@@ -26,10 +26,18 @@ type SCEP struct {
 	// Numerical identifier for the ContentEncryptionAlgorithm as defined in github.com/mozilla-services/pkcs7
 	// at https://github.com/mozilla-services/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63
 	// Defaults to 0, being DES-CBC
-	EncryptionAlgorithmIdentifier int      `json:"encryptionAlgorithmIdentifier,omitempty"`
-	Options                       *Options `json:"options,omitempty"`
-	Claims                        *Claims  `json:"claims,omitempty"`
-	claimer                       *Claimer
+	EncryptionAlgorithmIdentifier int `json:"encryptionAlgorithmIdentifier,omitempty"`
+	// CustomPath is used to specify a custom path on which the SCEP provisioner will be made
+	// available. By default a SCEP provisioner is available at
+	// https://<address>:<port>/scep/<provisionerName> and requests performed looking similar
+	// to https://<address>:<port>/scep/<provisionerName>?operations=GetCACert. When CustomPath
+	// is set, the SCEP URL will be https://<address>:<port>/scep/<provisionerName>/<customPath>,
+	// resulting in SCEP clients that expect a specific path, such as "/pkiclient.exe", to be
+	// able to interact with the SCEP provisioner.
+	CustomPath string   `json:"customPath,omitempty"`
+	Options    *Options `json:"options,omitempty"`
+	Claims     *Claims  `json:"claims,omitempty"`
+	claimer    *Claimer
 
 	secretChallengePassword string
 	encryptionAlgorithm     int

--- a/authority/provisioner/scep.go
+++ b/authority/provisioner/scep.go
@@ -26,18 +26,10 @@ type SCEP struct {
 	// Numerical identifier for the ContentEncryptionAlgorithm as defined in github.com/mozilla-services/pkcs7
 	// at https://github.com/mozilla-services/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63
 	// Defaults to 0, being DES-CBC
-	EncryptionAlgorithmIdentifier int `json:"encryptionAlgorithmIdentifier,omitempty"`
-	// CustomPath is used to specify a custom path on which the SCEP provisioner will be made
-	// available. By default a SCEP provisioner is available at
-	// https://<address>:<port>/scep/<provisionerName> and requests performed looking similar
-	// to https://<address>:<port>/scep/<provisionerName>?operations=GetCACert. When CustomPath
-	// is set, the SCEP URL will be https://<address>:<port>/scep/<provisionerName>/<customPath>,
-	// resulting in SCEP clients that expect a specific path, such as "/pkiclient.exe", to be
-	// able to interact with the SCEP provisioner.
-	CustomPath string   `json:"customPath,omitempty"`
-	Options    *Options `json:"options,omitempty"`
-	Claims     *Claims  `json:"claims,omitempty"`
-	claimer    *Claimer
+	EncryptionAlgorithmIdentifier int      `json:"encryptionAlgorithmIdentifier,omitempty"`
+	Options                       *Options `json:"options,omitempty"`
+	Claims                        *Claims  `json:"claims,omitempty"`
+	claimer                       *Claimer
 
 	secretChallengePassword string
 	encryptionAlgorithm     int

--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -66,9 +66,9 @@ func New(scepAuth scep.Interface) api.RouterHandler {
 // Route traffic and implement the Router interface.
 func (h *Handler) Route(r api.Router) {
 	getLink := h.Auth.GetLinkExplicit
-	r.MethodFunc(http.MethodGet, getLink("{provisionerName}/{customPath}*", false, nil), h.lookupProvisioner(h.Get))
+	r.MethodFunc(http.MethodGet, getLink("{provisionerName}/*", false, nil), h.lookupProvisioner(h.Get))
 	r.MethodFunc(http.MethodGet, getLink("{provisionerName}", false, nil), h.lookupProvisioner(h.Get))
-	r.MethodFunc(http.MethodPost, getLink("{provisionerName}/{customPath}*", false, nil), h.lookupProvisioner(h.Post))
+	r.MethodFunc(http.MethodPost, getLink("{provisionerName}/*", false, nil), h.lookupProvisioner(h.Post))
 	r.MethodFunc(http.MethodPost, getLink("{provisionerName}", false, nil), h.lookupProvisioner(h.Post))
 }
 
@@ -193,13 +193,6 @@ func (h *Handler) lookupProvisioner(next nextHTTP) nextHTTP {
 			return
 		}
 
-		customPathParam := chi.URLParam(r, "customPath")
-		customPath, err := url.PathUnescape(customPathParam)
-		if err != nil {
-			api.WriteError(w, err)
-			return
-		}
-
 		p, err := h.Auth.LoadProvisionerByName(provisionerName)
 		if err != nil {
 			api.WriteError(w, err)
@@ -209,12 +202,6 @@ func (h *Handler) lookupProvisioner(next nextHTTP) nextHTTP {
 		prov, ok := p.(*provisioner.SCEP)
 		if !ok {
 			api.WriteError(w, errors.New("provisioner must be of type SCEP"))
-			return
-		}
-
-		configuredCustomPath := strings.Trim(prov.CustomPath, "/")
-		if customPath != configuredCustomPath {
-			api.WriteError(w, errors.Errorf("custom path requested '%s' is not the expected path '%s'", customPath, configuredCustomPath))
 			return
 		}
 


### PR DESCRIPTION
To support SCEP clients that expect a specific path segment in a SCEP URL, we now made `step-ca` respond to any request made to an URL path that's prefixed by `http://<host>:<port>/scep/scepca`. The same SCEP provisioner will serve the request, no matter what path segments are provided behind `/scepca`. So e.g. `/scepca` and `/scepca/pkiclient.exe` will work the same. 

This PR closes https://github.com/smallstep/certificates/issues/843. 