### PR TITLE
git: ignore .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.txt
 output
 vendor
 .idea
+.envrc


### PR DESCRIPTION
This PR includes `.envrc` to `.gitignore` as a convenience to engineers who work on `certificates` while at the same time use a tool like [`direnv`](https://direnv.net/).