### PR TITLE
Change go version to 1.17 and 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.15', '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     outputs:
       is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
     steps:
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: 'v1.44.0'
+          version: 'v1.45.0'
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
@@ -106,7 +106,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: APT Install
         id: aptInstall
@@ -159,7 +159,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       -
         name: Install cosign
         uses: sigstore/cosign-installer@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       -
         name: Checkout
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: 'v1.44.0'
+          version: 'v1.45.0'
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
@@ -58,7 +58,7 @@ jobs:
         run: V=1 make ci
       -
         name: Codecov
-        if: matrix.go == '1.17'
+        if: matrix.go == '1.18'
         uses: codecov/codecov-action@v1.2.1
         with:
           file: ./coverage.out # optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for renew after expiry using the claim `allowRenewAfterExpiry`.
 ### Changed
 - Made SCEP CA URL paths dynamic
+- Support two latest versions of golang (1.17, 1.18)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for renew after expiry using the claim `allowRenewAfterExpiry`.
 ### Changed
 - Made SCEP CA URL paths dynamic
-- Support two latest versions of golang (1.17, 1.18)
+- Support two latest versions of Go (1.17, 1.18)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -100,6 +100,7 @@ func (p *X5C) Init(config Config) (err error) {
 	var (
 		block *pem.Block
 		rest  = p.Roots
+		count int
 	)
 	for rest != nil {
 		block, rest = pem.Decode(rest)
@@ -110,11 +111,12 @@ func (p *X5C) Init(config Config) (err error) {
 		if err != nil {
 			return errors.Wrap(err, "error parsing x509 certificate from PEM block")
 		}
+		count++
 		p.rootPool.AddCert(cert)
 	}
 
 	// Verify that at least one root was found.
-	if len(p.rootPool.Subjects()) == 0 {
+	if count == 0 {
 		return errors.Errorf("no x509 certificates found in roots attribute for provisioner '%s'", p.GetName())
 	}
 

--- a/authority/provisioner/x5c_test.go
+++ b/authority/provisioner/x5c_test.go
@@ -118,6 +118,8 @@ M46l92gdOozT
 			return ProvisionerValidateTest{
 				p: p,
 				extraValid: func(p *X5C) error {
+					// nolint:staticcheck // We don't have a different way to
+					// check the number of certificates in the pool.
 					numCerts := len(p.rootPool.Subjects())
 					if numCerts != 2 {
 						return errors.Errorf("unexpected number of certs: want 2, but got %d", numCerts)

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -450,9 +450,6 @@ func (ca *CA) getTLSConfig(auth *authority.Authority) (*tls.Config, error) {
 	tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
 	tlsConfig.ClientCAs = certPool
 
-	// Use server's most preferred ciphersuite
-	tlsConfig.PreferServerCipherSuites = true
-
 	return tlsConfig, nil
 }
 

--- a/ca/identity/identity_test.go
+++ b/ca/identity/identity_test.go
@@ -346,6 +346,8 @@ func TestIdentity_GetCertPool(t *testing.T) {
 				return
 			}
 			if got != nil {
+				// nolint:staticcheck // we don't have a different way to check
+				// the certificates in the pool.
 				subjects := got.Subjects()
 				if !reflect.DeepEqual(subjects, tt.wantSubjects) {
 					t.Errorf("Identity.GetCertPool() = %x, want %x", subjects, tt.wantSubjects)

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -95,7 +95,6 @@ func (c *Client) getClientTLSConfig(ctx context.Context, sign *api.SignResponse,
 	// Note that with GetClientCertificate tlsConfig.Certificates is not used.
 	// Without tlsConfig.Certificates there's not need to use tlsConfig.BuildNameToCertificate()
 	tlsConfig.GetClientCertificate = renewer.GetClientCertificate
-	tlsConfig.PreferServerCipherSuites = true
 
 	// Apply options and initialize mutable tls.Config
 	tlsCtx := newTLSOptionCtx(c, tlsConfig, sign)
@@ -137,7 +136,6 @@ func (c *Client) GetServerTLSConfig(ctx context.Context, sign *api.SignResponse,
 	// Without tlsConfig.Certificates there's not need to use tlsConfig.BuildNameToCertificate()
 	tlsConfig.GetCertificate = renewer.GetCertificate
 	tlsConfig.GetClientCertificate = renewer.GetClientCertificate
-	tlsConfig.PreferServerCipherSuites = true
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 
 	// Apply options and initialize mutable tls.Config

--- a/ca/tls_options_test.go
+++ b/ca/tls_options_test.go
@@ -542,6 +542,7 @@ func TestAddFederationToCAs(t *testing.T) {
 	}
 }
 
+// nolint:staticcheck,gocritic
 func equalPools(a, b *x509.CertPool) bool {
 	if reflect.DeepEqual(a, b) {
 		return true


### PR DESCRIPTION
### Description
This PR changes the supported versions of Go to 1.17 and 1.18, using Go 1.18 for releases.