### PR TITLE
scep: remove Interface and the dependency to pkg/errors

### DIFF
--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -1,3 +1,4 @@
+// Package api implements a SCEP HTTP server.
 package api
 
 import (

--- a/scep/scep.go
+++ b/scep/scep.go
@@ -1,3 +1,4 @@
+// Package scep implements Simple Certificate Enrollment Protocol related functionality.
 package scep
 
 import (
@@ -5,9 +6,6 @@ import (
 	"encoding/asn1"
 
 	microscep "github.com/micromdm/scep/v2/scep"
-
-	//"github.com/smallstep/certificates/scep/pkcs7"
-
 	"go.mozilla.org/pkcs7"
 )
 


### PR DESCRIPTION
This PR continues the work of #867 as follows:

- removes `scep.Interface` and refactors the code to use `*scep.Authority` in its place.
- removes scep's dependency to `pkg/errors`
