### PR TITLE
Add authority.WithX509SignerFunc

### DIFF
--- a/authority/options.go
+++ b/authority/options.go
@@ -163,6 +163,22 @@ func WithX509Signer(crt *x509.Certificate, s crypto.Signer) Option {
 	}
 }
 
+// WithX509SignerFunc defines the function used to get the chain of certificates
+// and signer used when we sign X.509 certificates.
+func WithX509SignerFunc(fn func() ([]*x509.Certificate, crypto.Signer, error)) Option {
+	return func(a *Authority) error {
+		srv, err := cas.New(context.Background(), casapi.Options{
+			Type:              casapi.SoftCAS,
+			CertificateSigner: fn,
+		})
+		if err != nil {
+			return err
+		}
+		a.x509CAService = srv
+		return nil
+	}
+}
+
 // WithSSHUserSigner defines the signer used to sign SSH user certificates.
 func WithSSHUserSigner(s crypto.Signer) Option {
 	return func(a *Authority) error {

--- a/cas/apiv1/options.go
+++ b/cas/apiv1/options.go
@@ -31,12 +31,17 @@ type Options struct {
 	// https://cloud.google.com/docs/authentication.
 	CredentialsFile string `json:"credentialsFile,omitempty"`
 
-	// Certificate and signer are the issuer certificate, along with any other
-	// bundled certificates to be returned in the chain for consumers, and
+	// CertificateChain and Signer are the issuer certificate, along with any
+	// other bundled certificates to be returned in the chain for consumers, and
 	// signer used in SoftCAS. They are configured in ca.json crt and key
 	// properties.
 	CertificateChain []*x509.Certificate `json:"-"`
 	Signer           crypto.Signer       `json:"-"`
+
+	// CertificateSigner combines CertificateChain and Signer in a callback that
+	// returns the chain of certificate and signer used to sign X.509
+	// certificates in SoftCAS.
+	CertificateSigner func() ([]*x509.Certificate, crypto.Signer, error) `json:"-"`
 
 	// IsCreator is set to true when we're creating a certificate authority. It
 	// is used to skip some validations when initializing a

--- a/cas/apiv1/options.go
+++ b/cas/apiv1/options.go
@@ -31,12 +31,15 @@ type Options struct {
 	// https://cloud.google.com/docs/authentication.
 	CredentialsFile string `json:"credentialsFile,omitempty"`
 
-	// CertificateChain and Signer are the issuer certificate, along with any
-	// other bundled certificates to be returned in the chain for consumers, and
-	// signer used in SoftCAS. They are configured in ca.json crt and key
-	// properties.
+	// CertificateChain contains the issuer certificate, along with any other
+	// bundled certificates to be returned in the chain for consumers. It is
+	// used used in SoftCAS, and is configured in the crt property of the
+	// ca.json.
 	CertificateChain []*x509.Certificate `json:"-"`
-	Signer           crypto.Signer       `json:"-"`
+
+	// Signer is the private key or a KMS signer for the issuer certificate. It is used in
+	// SoftCAS and it is configured in the key property of the ca.json.
+	Signer crypto.Signer `json:"-"`
 
 	// CertificateSigner combines CertificateChain and Signer in a callback that
 	// returns the chain of certificate and signer used to sign X.509

--- a/cas/softcas/softcas.go
+++ b/cas/softcas/softcas.go
@@ -24,9 +24,10 @@ var now = time.Now
 // SoftCAS implements a Certificate Authority Service using Golang or KMS
 // crypto. This is the default CAS used in step-ca.
 type SoftCAS struct {
-	CertificateChain []*x509.Certificate
-	Signer           crypto.Signer
-	KeyManager       kms.KeyManager
+	CertificateChain  []*x509.Certificate
+	Signer            crypto.Signer
+	CertificateSigner func() ([]*x509.Certificate, crypto.Signer, error)
+	KeyManager        kms.KeyManager
 }
 
 // New creates a new CertificateAuthorityService implementation using Golang or KMS
@@ -34,16 +35,17 @@ type SoftCAS struct {
 func New(ctx context.Context, opts apiv1.Options) (*SoftCAS, error) {
 	if !opts.IsCreator {
 		switch {
-		case len(opts.CertificateChain) == 0:
+		case len(opts.CertificateChain) == 0 && opts.CertificateSigner == nil:
 			return nil, errors.New("softCAS 'CertificateChain' cannot be nil")
-		case opts.Signer == nil:
+		case opts.Signer == nil && opts.CertificateSigner == nil:
 			return nil, errors.New("softCAS 'signer' cannot be nil")
 		}
 	}
 	return &SoftCAS{
-		CertificateChain: opts.CertificateChain,
-		Signer:           opts.Signer,
-		KeyManager:       opts.KeyManager,
+		CertificateChain:  opts.CertificateChain,
+		Signer:            opts.Signer,
+		CertificateSigner: opts.CertificateSigner,
+		KeyManager:        opts.KeyManager,
 	}, nil
 }
 
@@ -57,6 +59,7 @@ func (c *SoftCAS) CreateCertificate(req *apiv1.CreateCertificateRequest) (*apiv1
 	}
 
 	t := now()
+
 	// Provisioners can also set specific values.
 	if req.Template.NotBefore.IsZero() {
 		req.Template.NotBefore = t.Add(-1 * req.Backdate)
@@ -64,16 +67,21 @@ func (c *SoftCAS) CreateCertificate(req *apiv1.CreateCertificateRequest) (*apiv1
 	if req.Template.NotAfter.IsZero() {
 		req.Template.NotAfter = t.Add(req.Lifetime)
 	}
-	req.Template.Issuer = c.CertificateChain[0].Subject
 
-	cert, err := createCertificate(req.Template, c.CertificateChain[0], req.Template.PublicKey, c.Signer)
+	chain, signer, err := c.getCertSigner()
+	if err != nil {
+		return nil, err
+	}
+	req.Template.Issuer = chain[0].Subject
+
+	cert, err := createCertificate(req.Template, chain[0], req.Template.PublicKey, signer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &apiv1.CreateCertificateResponse{
 		Certificate:      cert,
-		CertificateChain: c.CertificateChain,
+		CertificateChain: chain,
 	}, nil
 }
 
@@ -89,16 +97,21 @@ func (c *SoftCAS) RenewCertificate(req *apiv1.RenewCertificateRequest) (*apiv1.R
 	t := now()
 	req.Template.NotBefore = t.Add(-1 * req.Backdate)
 	req.Template.NotAfter = t.Add(req.Lifetime)
-	req.Template.Issuer = c.CertificateChain[0].Subject
 
-	cert, err := createCertificate(req.Template, c.CertificateChain[0], req.Template.PublicKey, c.Signer)
+	chain, signer, err := c.getCertSigner()
+	if err != nil {
+		return nil, err
+	}
+	req.Template.Issuer = chain[0].Subject
+
+	cert, err := createCertificate(req.Template, chain[0], req.Template.PublicKey, signer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &apiv1.RenewCertificateResponse{
 		Certificate:      cert,
-		CertificateChain: c.CertificateChain,
+		CertificateChain: chain,
 	}, nil
 }
 
@@ -106,9 +119,13 @@ func (c *SoftCAS) RenewCertificate(req *apiv1.RenewCertificateRequest) (*apiv1.R
 // operation is a no-op as the actual revoke will happen when we store the entry
 // in the db.
 func (c *SoftCAS) RevokeCertificate(req *apiv1.RevokeCertificateRequest) (*apiv1.RevokeCertificateResponse, error) {
+	chain, _, err := c.getCertSigner()
+	if err != nil {
+		return nil, err
+	}
 	return &apiv1.RevokeCertificateResponse{
 		Certificate:      req.Certificate,
-		CertificateChain: c.CertificateChain,
+		CertificateChain: chain,
 	}, nil
 }
 
@@ -179,7 +196,7 @@ func (c *SoftCAS) CreateCertificateAuthority(req *apiv1.CreateCertificateAuthori
 	}, nil
 }
 
-// initializeKeyManager initiazes the default key manager if was not given.
+// initializeKeyManager initializes the default key manager if was not given.
 func (c *SoftCAS) initializeKeyManager() (err error) {
 	if c.KeyManager == nil {
 		c.KeyManager, err = kms.New(context.Background(), kmsapi.Options{
@@ -187,6 +204,15 @@ func (c *SoftCAS) initializeKeyManager() (err error) {
 		})
 	}
 	return
+}
+
+// getCertSigner returns the certificate chain and signer to use.
+func (c *SoftCAS) getCertSigner() ([]*x509.Certificate, crypto.Signer, error) {
+	if c.CertificateSigner != nil {
+		return c.CertificateSigner()
+	}
+	return c.CertificateChain, c.Signer, nil
+
 }
 
 // createKey uses the configured kms to create a key.


### PR DESCRIPTION
### Description

This change adds a new authority option that allows passing a callback that returns the certificate chain and signer used to sign X.509 certificates.

This option will be used by Caddy, they renew the intermediate certificate weekly and there's no other way to replace it without re-creating the embedded CA.

Fixes #874