### PR TITLE
Drop any query string from the admin tokens

### DIFF
--- a/ca/adminClient.go
+++ b/ca/adminClient.go
@@ -90,6 +90,13 @@ func (c *AdminClient) generateAdminToken(aud *url.URL) (string, error) {
 		return "", err
 	}
 
+	// Drop any query string parameter from the token audience
+	aud = &url.URL{
+		Scheme: aud.Scheme,
+		Host:   aud.Host,
+		Path:   aud.Path,
+	}
+
 	now := time.Now()
 	tokOptions := []token.Options{
 		token.WithJWTID(jwtID),


### PR DESCRIPTION
### Description

This PR makes sure the admin token audience is passed without a query string (or any fragment). The audience is checked against a string like `https://host/path`, so URLs like `https://host/path?limit=100` were failing on master if we replace the version of the certificates in the cli with master.
