### PR TITLE
Dockerfile for HSM-enabled Step CA

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -3,15 +3,15 @@ FROM golang:alpine AS builder
 WORKDIR /src
 COPY . .
 
-RUN apk add --no-cache \
-   curl \
-   git \
-   make && \
-   make V=1 bin/step-ca
+RUN apk add --no-cache curl git make
+RUN make V=1 bin/step-ca bin/step-awskms-init bin/step-cloudkms-init
+
 
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
+COPY --from=builder /src/bin/step-awskms-init /usr/local/bin/step-awskms-init
+COPY --from=builder /src/bin/step-cloudkms-init /usr/local/bin/step-cloudkms-init
 
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -1,0 +1,33 @@
+FROM golang:alpine AS builder
+
+WORKDIR /src
+COPY . .
+
+RUN apk add --no-cache curl git make
+RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
+RUN make V=1 GOFLAGS="" build
+
+FROM smallstep/step-cli:latest
+
+COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
+COPY --from=builder /src/bin/step-awskms-init /usr/local/bin/step-awskms-init
+COPY --from=builder /src/bin/step-cloudkms-init /usr/local/bin/step-cloudkms-init
+COPY --from=builder /src/bin/step-pkcs11-init /usr/local/bin/step-pkcs11-init
+COPY --from=builder /src/bin/step-yubikey-init /usr/local/bin/step-yubikey-init
+
+USER root
+RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
+RUN apk add --no-cache pcsc-lite-libs
+USER step
+
+ENV CONFIGPATH="/home/step/config/ca.json"
+ENV PWDPATH="/home/step/secrets/password"
+
+VOLUME ["/home/step"]
+STOPSIGNAL SIGTERM
+HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
+
+COPY docker/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -17,7 +17,7 @@ COPY --from=builder /src/bin/step-yubikey-init /usr/local/bin/step-yubikey-init
 
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
-RUN apk add --no-cache pcsc-lite-libs
+RUN apk add --no-cache pcsc-lite pcsc-lite-libs
 USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -7,6 +7,7 @@ RUN apk add --no-cache curl git make
 RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
 RUN make V=1 GOFLAGS="" build
 
+
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,6 +53,10 @@ function step_ca_init () {
     mv $STEPPATH/password $PWDPATH
 }
 
+if [ -f /usr/sbin/pcscd ]; then
+	/usr/sbin/pcscd
+fi
+
 if [ ! -f "${STEPPATH}/config/ca.json" ]; then
 	init_if_possible
 fi


### PR DESCRIPTION
### Description

- Update existing Dockerfile to include GCP and AWS KMS (does not require CGO)
- Add new Dockerfile to build Step CA with support for PKCS#11 and Yubikey (with CGO and PCSC), not yet included in the build process 
- Start pcscd in entrypoint if installed
