### PR TITLE
Allow KMS type to be specified in the helm chart values YAML 

### DIFF
--- a/pki/helm.go
+++ b/pki/helm.go
@@ -68,6 +68,10 @@ inject:
         federateRoots: []
         crt: {{ .Intermediate }}
         key: {{ .IntermediateKey }}
+	{{- if .Kms }}
+	kms:
+	  type: {{ lower (.Kms.Type | toString) }}
+	{{- end }}
         {{- if .EnableSSH }}
         ssh:
           hostKey: {{ .Ssh.HostKey }}


### PR DESCRIPTION
#### Name of feature:
Allow KMS type to be inserted into the helm chart values if specified on the command line.

#### Pain or issue this feature alleviates:

Currently if you run something along the lines of:

`step ca init --helm --kms azurekms > values.yaml`

The command will succeed and will even add the reference to the - in this case, Azure Key Vault - for `key` but when you deploy the chart it will fail with an error about the local file azurekms....not existing. This is because when the template values file created it is omitting

```YAML
kms:
  type: <kms type goes here>
```

It took me a minute to realise that this is what was happening.

#### Why is this important to the project (if not answered above):

Make it easier for users to use step ca in Kubernetes when also using a KMS. Currently users may be confused why it doesn't work and requires editing the values YAML file after it has been generated to make it work with a KMS.

#### Is there documentation on how to use this feature? If so, where?

Yes here https://smallstep.com/docs/step-cli/reference/ca/init

#### In what environments or workflows is this feature supported?

When deploying step ca to Kubernetes using the provided helm chart.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

When deploying step ca outside of Kubernetes.

#### Supporting links/other PRs/issues:

I will submit the PR for the cli repo to bump the dependency in go.mod once this is merged and a tag created.


💔Thank you!
