### PR TITLE
optimized render.JSON

### DIFF
--- a/api/render/render.go
+++ b/api/render/render.go
@@ -36,6 +36,11 @@ func JSONStatus(w http.ResponseWriter, v interface{}, status int) {
 		if errors.As(err, &errUnsupportedValue) {
 			panic(err)
 		}
+
+		var errMarshalError *json.MarshalerError
+		if errors.As(err, &errMarshalError) {
+			panic(err)
+		}
 	}
 
 	log.EnabledResponse(w, v)

--- a/api/render/render_test.go
+++ b/api/render/render_test.go
@@ -36,7 +36,18 @@ func TestJSONPanicsOnUnsupportedValue(t *testing.T) {
 	jsonPanicTest[json.UnsupportedValueError](t, math.NaN())
 }
 
-func jsonPanicTest[T json.UnsupportedTypeError | json.UnsupportedValueError](t *testing.T, v any) {
+func TestJSONPanicsOnMarshalerError(t *testing.T) {
+	var v erroneousJSONMarshaler
+	jsonPanicTest[json.MarshalerError](t, v)
+}
+
+type erroneousJSONMarshaler struct{}
+
+func (erroneousJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, assert.AnError
+}
+
+func jsonPanicTest[T json.UnsupportedTypeError | json.UnsupportedValueError | json.MarshalerError](t *testing.T, v any) {
 	t.Helper()
 
 	defer func() {


### PR DESCRIPTION
This PR optimizes `render.JSON` so that it doesn't use an intermediate buffer.