### PR TITLE
feat: add health checks to ensure DB availability

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,7 @@ type Authority interface {
 	GetRoots() ([]*x509.Certificate, error)
 	GetFederation() ([]*x509.Certificate, error)
 	Version() authority.Version
+	Health() error
 }
 
 // TimeDuration is an alias of provisioner.TimeDuration
@@ -293,7 +294,12 @@ func (h *caHandler) Version(w http.ResponseWriter, r *http.Request) {
 
 // Health is an HTTP handler that returns the status of the server.
 func (h *caHandler) Health(w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, HealthResponse{Status: "ok"})
+	err := h.Authority.Health()
+	if err == nil {
+		render.JSON(w, HealthResponse{Status: "ok"})
+	} else {
+		render.JSONStatus(w, HealthResponse{Status: "error"}, http.StatusServiceUnavailable)
+	}
 }
 
 // Root is an HTTP handler that using the SHA256 from the URL, returns the root

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -201,6 +201,10 @@ type mockAuthority struct {
 	version                      func() authority.Version
 }
 
+func (m *mockAuthority) Health() error {
+	return nil
+}
+
 // TODO: remove once Authorize is deprecated.
 func (m *mockAuthority) Authorize(ctx context.Context, ott string) ([]provisioner.SignOption, error) {
 	return m.AuthorizeSign(ott)

--- a/authority/authority.go
+++ b/authority/authority.go
@@ -159,6 +159,11 @@ func NewEmbedded(opts ...Option) (*Authority, error) {
 	return a, nil
 }
 
+// Health checks if the authority is stil alive.
+func (a *Authority) Health() error {
+	return a.db.Ping()
+}
+
 // reloadAdminResources reloads admins and provisioners from the DB.
 func (a *Authority) reloadAdminResources(ctx context.Context) error {
 	var (

--- a/db/db.go
+++ b/db/db.go
@@ -56,6 +56,7 @@ type AuthDB interface {
 	StoreSSHCertificate(crt *ssh.Certificate) error
 	GetSSHHostPrincipals() ([]string, error)
 	Shutdown() error
+	Ping() error
 }
 
 // DB is a wrapper over the nosql.DB interface.
@@ -369,6 +370,11 @@ type MockAuthDB struct {
 	MShutdown             func() error
 }
 
+// Ping mock
+func (m *MockAuthDB) Ping() error {
+	return nil
+}
+
 // IsRevoked mock.
 func (m *MockAuthDB) IsRevoked(sn string) (bool, error) {
 	if m.MIsRevoked != nil {
@@ -485,6 +491,11 @@ type MockNoSQLDB struct {
 	MList        func(bucket []byte) ([]*database.Entry, error)
 	MUpdate      func(tx *database.Tx) error
 	MCmpAndSwap  func(bucket, key, old, newval []byte) ([]byte, bool, error)
+}
+
+// Ping mock
+func (m *MockNoSQLDB) Ping() error {
+	return nil
 }
 
 // CmpAndSwap mock

--- a/db/simple.go
+++ b/db/simple.go
@@ -26,6 +26,11 @@ func newSimpleDB(c *Config) (AuthDB, error) {
 	return db, nil
 }
 
+// Ping noop
+func (s *SimpleDB) Ping() error {
+	return nil
+}
+
 // IsRevoked noop
 func (s *SimpleDB) IsRevoked(sn string) (bool, error) {
 	return false, nil

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-// replace github.com/smallstep/nosql => ../nosql
+replace github.com/smallstep/nosql => github.com/hm-edu/nosql v0.4.1-0.20220510094234-1fbe0ffbb194
+
 // replace go.step.sm/crypto => ../crypto
 // replace go.step.sm/cli-utils => ../cli-utils
 // replace go.step.sm/linkedca => ../linkedca

--- a/go.sum
+++ b/go.sum
@@ -453,6 +453,8 @@ github.com/hashicorp/vault/sdk v0.3.0 h1:kR3dpxNkhh/wr6ycaJYqp6AFT/i2xaftbfnwZdu
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hm-edu/nosql v0.4.1-0.20220510094234-1fbe0ffbb194 h1:4wA73z2RPNS7+b/Jqq1XArLfgavlCYqXr6imJZD9LnM=
+github.com/hm-edu/nosql v0.4.1-0.20220510094234-1fbe0ffbb194/go.mod h1:yKZT5h7cdIVm6wEKM9+jN5dgK80Hljpuy8HNsnI7Gzo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
@@ -733,8 +735,6 @@ github.com/slackhq/nebula v1.5.2/go.mod h1:xaCM6wqbFk/NRmmUe1bv88fWBm3a1UioXJVIp
 github.com/smallstep/assert v0.0.0-20180720014142-de77670473b5/go.mod h1:TC9A4+RjIOS+HyTH7wG17/gSqVv95uDw2J64dQZx7RE=
 github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262 h1:unQFBIznI+VYD1/1fApl1A+9VcBk+9dcqGfnePY87LY=
 github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262/go.mod h1:MyOHs9Po2fbM1LHej6sBUT8ozbxmMOFG+E+rx/GSGuc=
-github.com/smallstep/nosql v0.4.0 h1:Go3WYwttUuvwqMtFiiU4g7kBIlY+hR0bIZAqVdakQ3M=
-github.com/smallstep/nosql v0.4.0/go.mod h1:yKZT5h7cdIVm6wEKM9+jN5dgK80Hljpuy8HNsnI7Gzo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -815,8 +815,6 @@ go.step.sm/cli-utils v0.7.0/go.mod h1:Ur6bqA/yl636kCUJbp30J7Unv5JJ226eW2KqXPDwF/
 go.step.sm/crypto v0.9.0/go.mod h1:+CYG05Mek1YDqi5WK0ERc6cOpKly2i/a5aZmU1sfGj0=
 go.step.sm/crypto v0.16.1 h1:4mnZk21cSxyMGxsEpJwZKKvJvDu1PN09UVrWWFNUBdk=
 go.step.sm/crypto v0.16.1/go.mod h1:3G0yQr5lQqfEG0CMYz8apC/qMtjLRQlzflL2AxkcN+g=
-go.step.sm/linkedca v0.16.0 h1:9xdE150lRTEoBq1gJl+prePpSmNqXRXsez3qzRs3Lic=
-go.step.sm/linkedca v0.16.0/go.mod h1:W59ucS4vFpuR0g4PtkGbbtXAwxbDEnNCg+ovkej1ANM=
 go.step.sm/linkedca v0.16.1 h1:CdbMV5SjnlRsgeYTXaaZmQCkYIgJq8BOzpewri57M2k=
 go.step.sm/linkedca v0.16.1/go.mod h1:W59ucS4vFpuR0g4PtkGbbtXAwxbDEnNCg+ovkej1ANM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: 

Extend health to ensure database availability

#### Pain or issue this feature alleviates:

Lost connections to the database are only recognized on user/client requests and not before. Using the health endpoint and the liveness checks provided by docker/k8s this detected earlier.

#### Why is this important to the project (if not answered above):

Ensure availability of service. 

#### Is there documentation on how to use this feature? If so, where?

Enable health checks in docker containers/configure liveness probes in k8s

#### In what environments or workflows is this feature supported?

All. Especially k8s and docker environments.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

None

#### Supporting links/other PRs/issues:

https://github.com/smallstep/nosql/pull/23

(Side note: At the moment I replace the nosql repo ... that should be fixed as soon as the PR is merged 😉)

💔Thank you!
