### PR TITLE
Report SSH provisioner

### DIFF
--- a/authority/authorize_test.go
+++ b/authority/authorize_test.go
@@ -1034,7 +1034,7 @@ func TestAuthority_authorizeSSHSign(t *testing.T) {
 				}
 			} else {
 				if assert.Nil(t, tc.err) {
-					assert.Len(t, 8, got) // number of provisioner.SignOptions returned
+					assert.Len(t, 9, got) // number of provisioner.SignOptions returned
 				}
 			}
 		})

--- a/authority/linkedca.go
+++ b/authority/linkedca.go
@@ -289,7 +289,7 @@ func (c *linkedCaClient) StoreRenewedCertificate(parent *x509.Certificate, fullc
 		PemCertificateChain:  serializeCertificateChain(fullchain[1:]...),
 		PemParentCertificate: serializeCertificateChain(parent),
 	})
-	return errors.Wrap(err, "error posting certificate")
+	return errors.Wrap(err, "error posting renewed certificate")
 }
 
 func (c *linkedCaClient) StoreSSHCertificate(prov provisioner.Interface, crt *ssh.Certificate) error {
@@ -309,7 +309,7 @@ func (c *linkedCaClient) StoreRenewedSSHCertificate(parent, crt *ssh.Certificate
 		Certificate:       string(ssh.MarshalAuthorizedKey(crt)),
 		ParentCertificate: string(ssh.MarshalAuthorizedKey(parent)),
 	})
-	return errors.Wrap(err, "error posting ssh certificate")
+	return errors.Wrap(err, "error posting renewed ssh certificate")
 }
 
 func (c *linkedCaClient) Revoke(crt *x509.Certificate, rci *db.RevokedCertificateInfo) error {

--- a/authority/linkedca.go
+++ b/authority/linkedca.go
@@ -292,11 +292,22 @@ func (c *linkedCaClient) StoreRenewedCertificate(parent *x509.Certificate, fullc
 	return errors.Wrap(err, "error posting certificate")
 }
 
-func (c *linkedCaClient) StoreSSHCertificate(crt *ssh.Certificate) error {
+func (c *linkedCaClient) StoreSSHCertificate(prov provisioner.Interface, crt *ssh.Certificate) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	_, err := c.client.PostSSHCertificate(ctx, &linkedca.SSHCertificateRequest{
 		Certificate: string(ssh.MarshalAuthorizedKey(crt)),
+		Provisioner: createProvisionerIdentity(prov),
+	})
+	return errors.Wrap(err, "error posting ssh certificate")
+}
+
+func (c *linkedCaClient) StoreRenewedSSHCertificate(parent, crt *ssh.Certificate) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, err := c.client.PostSSHCertificate(ctx, &linkedca.SSHCertificateRequest{
+		Certificate:       string(ssh.MarshalAuthorizedKey(crt)),
+		ParentCertificate: string(ssh.MarshalAuthorizedKey(parent)),
 	})
 	return errors.Wrap(err, "error posting ssh certificate")
 }

--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -747,6 +747,7 @@ func (p *AWS) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	signOptions = append(signOptions, templateOptions)
 
 	return append(signOptions,
+		p,
 		// Validate user SignSSHOptions.
 		sshCertOptionsValidator(defaults),
 		// Set the validity bounds if not set.

--- a/authority/provisioner/aws_test.go
+++ b/authority/provisioner/aws_test.go
@@ -813,7 +813,6 @@ func TestAWS_AuthorizeSSHSign(t *testing.T) {
 			} else if assert.NotNil(t, got) {
 				cert, err := signSSHCertificate(tt.args.key, tt.args.sshOpts, got, signer.Key.(crypto.Signer))
 				if (err != nil) != tt.wantSignErr {
-
 					t.Errorf("SignSSH error = %v, wantSignErr %v", err, tt.wantSignErr)
 				} else {
 					if tt.wantSignErr {

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -418,6 +418,7 @@ func (p *Azure) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOptio
 	signOptions = append(signOptions, templateOptions)
 
 	return append(signOptions,
+		p,
 		// Validate user SignSSHOptions.
 		sshCertOptionsValidator(defaults),
 		// Set the validity bounds if not set.

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -425,6 +425,7 @@ func (p *GCP) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	signOptions = append(signOptions, templateOptions)
 
 	return append(signOptions,
+		p,
 		// Validate user SignSSHOptions.
 		sshCertOptionsValidator(defaults),
 		// Set the validity bounds if not set.

--- a/authority/provisioner/jwk.go
+++ b/authority/provisioner/jwk.go
@@ -257,6 +257,7 @@ func (p *JWK) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	}
 
 	return append(signOptions,
+		p,
 		// Set the validity bounds if not set.
 		&sshDefaultDuration{p.ctl.Claimer},
 		// Validate public key

--- a/authority/provisioner/k8sSA.go
+++ b/authority/provisioner/k8sSA.go
@@ -275,6 +275,7 @@ func (p *K8sSA) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOptio
 	signOptions := []SignOption{templateOptions}
 
 	return append(signOptions,
+		p,
 		// Require type, key-id and principals in the SignSSHOptions.
 		&sshCertOptionsRequireValidator{CertType: true, KeyID: true, Principals: true},
 		// Set the validity bounds if not set.

--- a/authority/provisioner/k8sSA_test.go
+++ b/authority/provisioner/k8sSA_test.go
@@ -368,9 +368,10 @@ func TestK8sSA_AuthorizeSSHSign(t *testing.T) {
 			} else {
 				if assert.Nil(t, tc.err) {
 					if assert.NotNil(t, opts) {
-						assert.Len(t, 7, opts)
+						assert.Len(t, 8, opts)
 						for _, o := range opts {
 							switch v := o.(type) {
+							case Interface:
 							case sshCertificateOptionsFunc:
 							case *sshCertOptionsRequireValidator:
 								assert.Equals(t, v, &sshCertOptionsRequireValidator{CertType: true, KeyID: true, Principals: true})

--- a/authority/provisioner/nebula.go
+++ b/authority/provisioner/nebula.go
@@ -250,6 +250,7 @@ func (p *Nebula) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOpti
 	}
 
 	return append(signOptions,
+		p,
 		templateOptions,
 		// Checks the validity bounds, and set the validity if has not been set.
 		&sshLimitDuration{p.ctl.Claimer, crt.Details.NotAfter},

--- a/authority/provisioner/noop.go
+++ b/authority/provisioner/noop.go
@@ -50,7 +50,7 @@ func (p *noop) AuthorizeRevoke(ctx context.Context, token string) error {
 }
 
 func (p *noop) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption, error) {
-	return []SignOption{}, nil
+	return []SignOption{p}, nil
 }
 
 func (p *noop) AuthorizeSSHRenew(ctx context.Context, token string) (*ssh.Certificate, error) {

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -434,6 +434,7 @@ func (o *OIDC) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption
 	}
 
 	return append(signOptions,
+		o,
 		// Set the validity bounds if not set.
 		&sshDefaultDuration{o.ctl.Claimer},
 		// Validate public key

--- a/authority/provisioner/ssh_test.go
+++ b/authority/provisioner/ssh_test.go
@@ -53,6 +53,7 @@ func signSSHCertificate(key crypto.PublicKey, opts SignSSHOptions, signOpts []Si
 
 	for _, op := range signOpts {
 		switch o := op.(type) {
+		case Interface:
 		// add options to NewCertificate
 		case SSHCertificateOptions:
 			certOptions = append(certOptions, o.Options(opts)...)

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -312,6 +312,7 @@ func (p *X5C) AuthorizeSSHSign(ctx context.Context, token string) ([]SignOption,
 	}
 
 	return append(signOptions,
+		p,
 		// Checks the validity bounds, and set the validity if has not been set.
 		&sshLimitDuration{p.ctl.Claimer, claims.chains[0][0].NotAfter},
 		// Validate public key.

--- a/authority/provisioner/x5c_test.go
+++ b/authority/provisioner/x5c_test.go
@@ -769,6 +769,7 @@ func TestX5C_AuthorizeSSHSign(t *testing.T) {
 						nw := now()
 						for _, o := range opts {
 							switch v := o.(type) {
+							case Interface:
 							case sshCertOptionsValidator:
 								tc.claims.Step.SSH.ValidAfter.t = time.Time{}
 								tc.claims.Step.SSH.ValidBefore.t = time.Time{}
@@ -799,9 +800,9 @@ func TestX5C_AuthorizeSSHSign(t *testing.T) {
 							tot++
 						}
 						if len(tc.claims.Step.SSH.CertType) > 0 {
-							assert.Equals(t, tot, 10)
+							assert.Equals(t, tot, 11)
 						} else {
-							assert.Equals(t, tot, 8)
+							assert.Equals(t, tot, 9)
 						}
 					}
 				}

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -370,6 +370,7 @@ func TestBootstrapClient(t *testing.T) {
 }
 
 func TestBootstrapClientServerRotation(t *testing.T) {
+	t.Skipf("skip until we fix https://github.com/smallstep/certificates/issues/873")
 	reset := setMinCertDuration(1 * time.Second)
 	defer reset()
 

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -370,7 +371,9 @@ func TestBootstrapClient(t *testing.T) {
 }
 
 func TestBootstrapClientServerRotation(t *testing.T) {
-	t.Skipf("skip until we fix https://github.com/smallstep/certificates/issues/873")
+	if os.Getenv("CI") == "true" {
+		t.Skipf("skip until we fix https://github.com/smallstep/certificates/issues/873")
+	}
 	reset := setMinCertDuration(1 * time.Second)
 	defer reset()
 

--- a/db/db.go
+++ b/db/db.go
@@ -50,12 +50,17 @@ type AuthDB interface {
 	Revoke(rci *RevokedCertificateInfo) error
 	RevokeSSH(rci *RevokedCertificateInfo) error
 	GetCertificate(serialNumber string) (*x509.Certificate, error)
-	StoreCertificate(crt *x509.Certificate) error
 	UseToken(id, tok string) (bool, error)
 	IsSSHHost(name string) (bool, error)
-	StoreSSHCertificate(crt *ssh.Certificate) error
 	GetSSHHostPrincipals() ([]string, error)
 	Shutdown() error
+}
+
+// CertificateStorer is an extension of AuthDB that allows to store
+// certificates.
+type CertificateStorer interface {
+	StoreCertificate(crt *x509.Certificate) error
+	StoreSSHCertificate(crt *ssh.Certificate) error
 }
 
 // DB is a wrapper over the nosql.DB interface.

--- a/db/simple.go
+++ b/db/simple.go
@@ -20,7 +20,7 @@ type SimpleDB struct {
 	usedTokens *sync.Map
 }
 
-func newSimpleDB(c *Config) (AuthDB, error) {
+func newSimpleDB(c *Config) (*SimpleDB, error) {
 	db := &SimpleDB{}
 	db.usedTokens = new(sync.Map)
 	return db, nil


### PR DESCRIPTION
### Description

This PR allows reporting the provisioner used to sign an SSH certificate to linkedca, on a previous PR, the reporting of provisioners for X509 certificates was implemented.

As a pending task, we can add a new table in the nosql to store this.