### PR TITLE
Strip base64-url padding from ACME CSR

### DIFF
--- a/acme/api/order_test.go
+++ b/acme/api/order_test.go
@@ -210,6 +210,13 @@ func TestFinalizeRequestValidate(t *testing.T) {
 				},
 			}
 		},
+		"ok/padding": func(t *testing.T) test {
+			return test{
+				fr: &FinalizeRequest{
+					CSR: base64.RawURLEncoding.EncodeToString(csr.Raw) + "==", // add intentional padding
+				},
+			}
+		},
 	}
 	for name, run := range tests {
 		tc := run(t)


### PR DESCRIPTION
This commit strips the padding from a base64-url encoded CSR
submitted by a client that doesn't use raw base64-url encoding.

#### Supporting links/other PRs/issues:

Fixes #939 
