### PR TITLE
all: reformat all go files with the next gofmt (Go 1.19)

### DIFF
--- a/acme/api/eab.go
+++ b/acme/api/eab.go
@@ -107,10 +107,11 @@ func keysAreEqual(x, y *jose.JSONWebKey) bool {
 
 // validateEABJWS verifies the contents of the External Account Binding JWS.
 // The protected header of the JWS MUST meet the following criteria:
-// 	o 	The "alg" field MUST indicate a MAC-based algorithm
-//	o  	The "kid" field MUST contain the key identifier provided by the CA
-//	o  	The "nonce" field MUST NOT be present
-//	o  	The "url" field MUST be set to the same value as the outer JWS
+//
+//   - The "alg" field MUST indicate a MAC-based algorithm
+//   - The "kid" field MUST contain the key identifier provided by the CA
+//   - The "nonce" field MUST NOT be present
+//   - The "url" field MUST be set to the same value as the outer JWS
 func validateEABJWS(ctx context.Context, jws *jose.JSONWebSignature) (string, *acme.Error) {
 	if jws == nil {
 		return "", acme.NewErrorISE("no JWS provided")

--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -119,13 +119,13 @@ func parseJWS(next nextHTTP) nextHTTP {
 // The JWS Unprotected Header [RFC7515] MUST NOT be used
 // The JWS Payload MUST NOT be detached
 // The JWS Protected Header MUST include the following fields:
-//   * “alg” (Algorithm)
-//     * This field MUST NOT contain “none” or a Message Authentication Code
-//       (MAC) algorithm (e.g. one in which the algorithm registry description
-//       mentions MAC/HMAC).
-//   * “nonce” (defined in Section 6.5)
-//   * “url” (defined in Section 6.4)
-//   * Either “jwk” (JSON Web Key) or “kid” (Key ID) as specified below<Paste>
+//   - “alg” (Algorithm).
+//     This field MUST NOT contain “none” or a Message Authentication Code
+//     (MAC) algorithm (e.g. one in which the algorithm registry description
+//     mentions MAC/HMAC).
+//   - “nonce” (defined in Section 6.5)
+//   - “url” (defined in Section 6.4)
+//   - Either “jwk” (JSON Web Key) or “kid” (Key ID) as specified below<Paste>
 func validateJWS(next nextHTTP) nextHTTP {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -51,22 +51,27 @@ const awsMetadataTokenTTLHeader = "X-aws-ec2-metadata-token-ttl-seconds"
 // signature.
 //
 // The first certificate is used in:
-//   ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2
-//   eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3
-//   us-east-1, us-east-2, us-west-1, us-west-2
-//   ca-central-1, sa-east-1
+//
+//	ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2
+//	eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3
+//	us-east-1, us-east-2, us-west-1, us-west-2
+//	ca-central-1, sa-east-1
 //
 // The second certificate is used in:
-//   eu-south-1
+//
+//	eu-south-1
 //
 // The third certificate is used in:
-//   ap-east-1
+//
+//	ap-east-1
 //
 // The fourth certificate is used in:
-//   af-south-1
+//
+//	af-south-1
 //
 // The fifth certificate is used in:
-//   me-south-1
+//
+//	me-south-1
 const awsCertificate = `-----BEGIN CERTIFICATE-----
 MIIDIjCCAougAwIBAgIJAKnL4UEDMN/FMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV
 BAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdTZWF0dGxlMRgw

--- a/ca/bootstrap.go
+++ b/ca/bootstrap.go
@@ -48,17 +48,18 @@ func Bootstrap(token string) (*Client, error) {
 // certificate after 2/3rd of the certificate's lifetime has expired.
 //
 // Usage:
-//   // Default example with certificate rotation.
-//   client, err := ca.BootstrapClient(ctx.Background(), token)
 //
-//   // Example canceling automatic certificate rotation.
-//   ctx, cancel := context.WithCancel(context.Background())
-//   defer cancel()
-//   client, err := ca.BootstrapClient(ctx, token)
-//   if err != nil {
-//     return err
-//   }
-//   resp, err := client.Get("https://internal.smallstep.com")
+//	// Default example with certificate rotation.
+//	client, err := ca.BootstrapClient(ctx.Background(), token)
+//
+//	// Example canceling automatic certificate rotation.
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	client, err := ca.BootstrapClient(ctx, token)
+//	if err != nil {
+//	  return err
+//	}
+//	resp, err := client.Get("https://internal.smallstep.com")
 func BootstrapClient(ctx context.Context, token string, options ...TLSOption) (*http.Client, error) {
 	b, err := createBootstrap(token)
 	if err != nil {
@@ -96,23 +97,24 @@ func BootstrapClient(ctx context.Context, token string, options ...TLSOption) (*
 // ca.AddClientCA(*x509.Certificate).
 //
 // Usage:
-//   // Default example with certificate rotation.
-//   srv, err := ca.BootstrapServer(context.Background(), token, &http.Server{
-//       Addr: ":443",
-//       Handler: handler,
-//   })
 //
-//   // Example canceling automatic certificate rotation.
-//   ctx, cancel := context.WithCancel(context.Background())
-//   defer cancel()
-//   srv, err := ca.BootstrapServer(ctx, token, &http.Server{
-//       Addr: ":443",
-//       Handler: handler,
-//   })
-//   if err != nil {
-//       return err
-//   }
-//   srv.ListenAndServeTLS("", "")
+//	// Default example with certificate rotation.
+//	srv, err := ca.BootstrapServer(context.Background(), token, &http.Server{
+//	    Addr: ":443",
+//	    Handler: handler,
+//	})
+//
+//	// Example canceling automatic certificate rotation.
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	srv, err := ca.BootstrapServer(ctx, token, &http.Server{
+//	    Addr: ":443",
+//	    Handler: handler,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	srv.ListenAndServeTLS("", "")
 func BootstrapServer(ctx context.Context, token string, base *http.Server, options ...TLSOption) (*http.Server, error) {
 	if base.TLSConfig != nil {
 		return nil, errors.New("server TLSConfig is already set")
@@ -152,19 +154,20 @@ func BootstrapServer(ctx context.Context, token string, base *http.Server, optio
 // ca.AddClientCA(*x509.Certificate).
 //
 // Usage:
-//   inner, err := net.Listen("tcp", ":443")
-//   if err != nil {
-//     return nil
-//   }
-//   ctx, cancel := context.WithCancel(context.Background())
-//   defer cancel()
-//   lis, err := ca.BootstrapListener(ctx, token, inner)
-//   if err != nil {
-//       return err
-//   }
-//   srv := grpc.NewServer()
-//   ... // register services
-//   srv.Serve(lis)
+//
+//	inner, err := net.Listen("tcp", ":443")
+//	if err != nil {
+//	  return nil
+//	}
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	lis, err := ca.BootstrapListener(ctx, token, inner)
+//	if err != nil {
+//	    return err
+//	}
+//	srv := grpc.NewServer()
+//	... // register services
+//	srv.Serve(lis)
 func BootstrapListener(ctx context.Context, token string, inner net.Listener, options ...TLSOption) (net.Listener, error) {
 	b, err := createBootstrap(token)
 	if err != nil {

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -523,7 +523,7 @@ func (ca *CA) shouldServeSCEPEndpoints() bool {
 	return ca.auth.GetSCEPService() != nil
 }
 
-//nolint // ignore linters to allow keeping this function around for debugging
+// nolint // ignore linters to allow keeping this function around for debugging
 func dumpRoutes(mux chi.Routes) {
 	// helpful routine for logging all routes //
 	walkFunc := func(method string, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {

--- a/cas/cloudcas/cloudcas.go
+++ b/cas/cloudcas/cloudcas.go
@@ -32,7 +32,9 @@ func init() {
 var now = time.Now
 
 // The actual regular expression that matches a certificate authority is:
-//   ^projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/locations/[a-z0-9-]+/caPools/[a-zA-Z0-9-_]+/certificateAuthorities/[a-zA-Z0-9-_]+$
+//
+//	^projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/locations/[a-z0-9-]+/caPools/[a-zA-Z0-9-_]+/certificateAuthorities/[a-zA-Z0-9-_]+$
+//
 // But we will allow a more flexible one to fail if this changes.
 var caRegexp = regexp.MustCompile("^projects/[^/]+/locations/[^/]+/caPools/[^/]+/certificateAuthorities/[^/]+$")
 

--- a/cas/cloudcas/mock_client_test.go
+++ b/cas/cloudcas/mock_client_test.go
@@ -5,12 +5,13 @@
 package cloudcas
 
 import (
-	privateca "cloud.google.com/go/security/privateca/apiv1"
 	context "context"
+	reflect "reflect"
+
+	privateca "cloud.google.com/go/security/privateca/apiv1"
 	gomock "github.com/golang/mock/gomock"
 	gax "github.com/googleapis/gax-go/v2"
 	privateca0 "google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
-	reflect "reflect"
 )
 
 // MockCertificateAuthorityClient is a mock of CertificateAuthorityClient interface

--- a/cas/cloudcas/mock_operation_server_test.go
+++ b/cas/cloudcas/mock_operation_server_test.go
@@ -6,10 +6,11 @@ package cloudcas
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	longrunning "google.golang.org/genproto/googleapis/longrunning"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	reflect "reflect"
 )
 
 // MockOperationsServer is a mock of OperationsServer interface

--- a/commands/onboard.go
+++ b/commands/onboard.go
@@ -23,7 +23,8 @@ import (
 
 // defaultOnboardingURL is the production onboarding url, to use a development
 // url use:
-//   export STEP_CA_ONBOARDING_URL=http://localhost:3002/onboarding/
+//
+//	export STEP_CA_ONBOARDING_URL=http://localhost:3002/onboarding/
 const defaultOnboardingURL = "https://api.smallstep.com/onboarding/"
 
 type onboardingConfiguration struct {

--- a/kms/azurekms/internal/mock/key_vault_client.go
+++ b/kms/azurekms/internal/mock/key_vault_client.go
@@ -6,9 +6,10 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+
 	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // KeyVaultClient is a mock of KeyVaultClient interface

--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -279,7 +279,8 @@ func (k *CloudKMS) createKeyRingIfNeeded(name string) error {
 
 // GetPublicKey gets from Google's Cloud KMS a public key by name. Key names
 // follow the pattern:
-//   projects/([^/]+)/locations/([a-zA-Z0-9_-]{1,63})/keyRings/([a-zA-Z0-9_-]{1,63})/cryptoKeys/([a-zA-Z0-9_-]{1,63})/cryptoKeyVersions/([a-zA-Z0-9_-]{1,63})
+//
+//	projects/([^/]+)/locations/([a-zA-Z0-9_-]{1,63})/keyRings/([a-zA-Z0-9_-]{1,63})/cryptoKeys/([a-zA-Z0-9_-]{1,63})/cryptoKeyVersions/([a-zA-Z0-9_-]{1,63})
 func (k *CloudKMS) GetPublicKey(req *apiv1.GetPublicKeyRequest) (crypto.PublicKey, error) {
 	if req.Name == "" {
 		return nil, errors.New("createKeyRequest 'name' cannot be empty")

--- a/kms/pkcs11/opensc_test.go
+++ b/kms/pkcs11/opensc_test.go
@@ -14,12 +14,15 @@ var softHSM2Once sync.Once
 
 // mustPKCS11 configures a *PKCS11 KMS to be used with OpenSC, using for example
 // a Nitrokey HSM. To initialize these tests we should run:
-//   sc-hsm-tool --initialize --so-pin 3537363231383830 --pin 123456
-//  Or:
-//   pkcs11-tool --module /usr/local/lib/opensc-pkcs11.so \
-//   --init-token --init-pin \
-//   --so-pin=3537363231383830 --new-pin=123456 --pin=123456 \
-//   --label="pkcs11-test"
+//
+//	sc-hsm-tool --initialize --so-pin 3537363231383830 --pin 123456
+//
+// Or:
+//
+//	pkcs11-tool --module /usr/local/lib/opensc-pkcs11.so \
+//	--init-token --init-pin \
+//	--so-pin=3537363231383830 --new-pin=123456 --pin=123456 \
+//	--label="pkcs11-test"
 func mustPKCS11(t TBTesting) *PKCS11 {
 	t.Helper()
 	testModule = "OpenSC"

--- a/kms/pkcs11/softhsm2_test.go
+++ b/kms/pkcs11/softhsm2_test.go
@@ -14,12 +14,14 @@ var softHSM2Once sync.Once
 
 // mustPKCS11 configures a *PKCS11 KMS to be used with SoftHSM2. To initialize
 // these tests, we should run:
-//   softhsm2-util --init-token --free \
-//   --token pkcs11-test --label pkcs11-test \
-//   --so-pin password --pin password
+//
+//	softhsm2-util --init-token --free \
+//	--token pkcs11-test --label pkcs11-test \
+//	--so-pin password --pin password
 //
 // To delete we should run:
-// 	softhsm2-util --delete-token --token pkcs11-test
+//
+//	softhsm2-util --delete-token --token pkcs11-test
 func mustPKCS11(t TBTesting) *PKCS11 {
 	t.Helper()
 	testModule = "SoftHSM2"

--- a/kms/pkcs11/yubihsm2_test.go
+++ b/kms/pkcs11/yubihsm2_test.go
@@ -14,7 +14,8 @@ var yubiHSM2Once sync.Once
 
 // mustPKCS11 configures a *PKCS11 KMS to be used with YubiHSM2. To initialize
 // these tests, we should run:
-// 	yubihsm-connector -d
+//
+//	yubihsm-connector -d
 func mustPKCS11(t TBTesting) *PKCS11 {
 	t.Helper()
 	testModule = "YubiHSM2"

--- a/logging/clf.go
+++ b/logging/clf.go
@@ -19,7 +19,9 @@ type CommonLogFormat struct{}
 
 // Format implements the logrus.Formatter interface. It returns the given
 // logrus entry as a CLF line with the following format:
-// 	<request-id> <remote-address> <name> <user-id> <time> <duration> "<method> <path> <protocol>" <status> <size>
+//
+//	<request-id> <remote-address> <name> <user-id> <time> <duration> "<method> <path> <protocol>" <status> <size>
+//
 // If a field is not known, the hyphen symbol (-) will be used.
 func (f *CommonLogFormat) Format(entry *logrus.Entry) ([]byte, error) {
 	data := make([]string, len(clfFields))


### PR DESCRIPTION
There are some changes that manually edited, for example using '-' as
default list and grouping imports.
