### PR TITLE
cas/cloudcas: update test on createPublicKey for the next Go release

### DIFF
--- a/cas/cloudcas/certificate_test.go
+++ b/cas/cloudcas/certificate_test.go
@@ -112,6 +112,7 @@ func Test_createPublicKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	ecCert := mustParseCertificate(t, testLeafCertificate)
+	ecCertPublicKey := ecCert.PublicKey.(*ecdsa.PublicKey)
 	rsaCert := mustParseCertificate(t, testRSACertificate)
 	type args struct {
 		key crypto.PublicKey
@@ -132,9 +133,14 @@ func Test_createPublicKey(t *testing.T) {
 		}, false},
 		{"fail ed25519", args{edpub}, nil, true},
 		{"fail ec marshal", args{&ecdsa.PublicKey{
-			Curve: &elliptic.CurveParams{Name: "FOO", BitSize: 256},
-			X:     ecCert.PublicKey.(*ecdsa.PublicKey).X,
-			Y:     ecCert.PublicKey.(*ecdsa.PublicKey).Y,
+			Curve: &elliptic.CurveParams{
+				Name:    "FOO",
+				BitSize: 256,
+				P:       ecCertPublicKey.Params().P,
+				B:       ecCertPublicKey.Params().B,
+			},
+			X: ecCertPublicKey.X,
+			Y: ecCertPublicKey.Y,
 		}}, nil, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The next Go release call panic on elliptic.Marshal [1][2], which
affect the test case fail_ec_marshal on createPublicKey.

This changes fix this by initializing the P and B in test case
PublicKey CurveParams to prevent panic.

[1] https://github.com/golang/go/issues/50975
[2] https://github.com/golang/go/commit/a218b3520a500254cc82b996b79ad6f5a355021c
