### PR TITLE
kms/uri: fix test on Parse for the next Go release

### DIFF
--- a/kms/uri/uri_119_test.go
+++ b/kms/uri/uri_119_test.go
@@ -1,6 +1,4 @@
-//TODO: Remove this file when go version in go.mod set to 1.19.
-//
-//go:build !go1.19
+//go:build go1.19
 
 package uri
 
@@ -116,7 +114,7 @@ func TestParse(t *testing.T) {
 			Values: url.Values{},
 		}, false},
 		{"ok file simple", args{"file:/tmp/ca.cert"}, &URI{
-			URL:    &url.URL{Scheme: "file", Path: "/tmp/ca.cert"},
+			URL:    &url.URL{Scheme: "file", Path: "/tmp/ca.cert", OmitHost: true},
 			Values: url.Values{},
 		}, false},
 		{"ok file host", args{"file://tmp/ca.cert"}, &URI{


### PR DESCRIPTION
The next Go release add field OmitHost to url.URL [1] which cause the
TestParse fail.
Since the CI supports two consecutive Go versions at the same times, we
copy the uri_test.go to uri_119_test.go for testing with Go 1.19.
    
While at it, print the got and want object using the same format
(%#v) and type (*URL) for consistency.
    
[1] https://go-review.googlesource.com/c/go/+/391294
