### PR TITLE
docs: set environment CI=true when building from source

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The only prerequisites are [`go`](https://golang.org/) and make.
 
 To build from source:
 
-    make bootstrap && make
+    make bootstrap && make CI=true
 
 Find your binaries in `bin/`.
 


### PR DESCRIPTION
Without setting CI=true, the make command will always fail on
TestNew_real/fail_default_credentials and TestNew/cloudkms.
