### PR TITLE
Sign certificates with the issuer signature algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Certificates signed by an issuer using an RSA key will use the same algorithm
+  and not default to PKCS #1. For example, if the issuer certificate uses
+  x509.SHA256WithRSAPSS, the signed certificate will also be signed using
+  x509.SHA256WithRSAPSS.
+
 ## [0.20.0] - 2022-05-26
 ### Added
 - Added Kubernetes auth method for Vault RAs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Certificates signed by an issuer using an RSA key will use the same algorithm
-  and not default to PKCS #1. For example, if the issuer certificate uses
-  x509.SHA256WithRSAPSS, the signed certificate will also be signed using
-  x509.SHA256WithRSAPSS.
+- Certificates signed by an issuer using an RSA key will be signed using the same algorithm as the issuer certificate was signed with. The signature will no longer default to PKCS #1. For example, if the issuer certificate was signed using RSA-PSS with SHA-256, a new certificate will also be signed using RSA-PSS with SHA-256.
 
 ## [0.20.0] - 2022-05-26
 ### Added

--- a/cas/softcas/softcas.go
+++ b/cas/softcas/softcas.go
@@ -3,6 +3,7 @@ package softcas
 import (
 	"context"
 	"crypto"
+	"crypto/rsa"
 	"crypto/x509"
 	"time"
 
@@ -244,6 +245,8 @@ func createCertificate(template, parent *x509.Certificate, pub crypto.PublicKey,
 	if template.SignatureAlgorithm == 0 {
 		if sa, ok := signer.(apiv1.SignatureAlgorithmGetter); ok {
 			template.SignatureAlgorithm = sa.SignatureAlgorithm()
+		} else if _, ok := parent.PublicKey.(*rsa.PublicKey); ok {
+			template.SignatureAlgorithm = parent.SignatureAlgorithm
 		}
 	}
 	return x509util.CreateCertificate(template, parent, pub, signer)


### PR DESCRIPTION
### Description

An RSA key can sign another certificate using the RSA PKCS#1 and the RSA-PSS scheme, this PR will keep the signature algorithm used in the issuer in the signed certificates instead of using PKCS#1 by default.

Fixes #952
