### PR TITLE
Ask for admin name/subject when creating creating first provisioner

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -573,7 +573,7 @@ func (a *Authority) init() error {
 		}
 		if len(provs) == 0 && !strings.EqualFold(a.config.AuthorityConfig.DeploymentType, "linked") {
 			// Create First Provisioner
-			prov, err := CreateFirstProvisioner(ctx, a.adminDB, string(a.password))
+			prov, subject, err := CreateFirstProvisioner(ctx, a.adminDB, string(a.password))
 			if err != nil {
 				return admin.WrapErrorISE(err, "error creating first provisioner")
 			}
@@ -581,7 +581,7 @@ func (a *Authority) init() error {
 			// Create first admin
 			if err := a.adminDB.CreateAdmin(ctx, &linkedca.Admin{
 				ProvisionerId: prov.Id,
-				Subject:       "step",
+				Subject:       subject,
 				Type:          linkedca.Admin_SUPER_ADMIN,
 			}); err != nil {
 				return admin.WrapErrorISE(err, "error creating first admin")


### PR DESCRIPTION
In enableAdmin=true mode, the first provisioner is created on startup.

This patch asks for the admin name/subject when creating the provisioner.
This is necessary if the root CA has nameConstraints and only permits
certain subjects.

Otherwise, there will be an error when using the provisioner with an
admin command (e.g. `step ca admin list`). See #962

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:
Fixes issue described in #962 if the root CA has name constraints

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
