### PR TITLE
Address gosec warnings

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -149,7 +149,7 @@ func tlsalpn01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSON
 		// [RFC5246] or higher when connecting to clients for validation.
 		MinVersion:         tls.VersionTLS12,
 		ServerName:         serverName(ch),
-		InsecureSkipVerify: true, // we expect a self-signed challenge certificate
+		InsecureSkipVerify: true, // nolint:gosec // we expect a self-signed challenge certificate
 	}
 
 	hostPort := net.JoinHostPort(ch.Value, "443")

--- a/acme/client.go
+++ b/acme/client.go
@@ -56,6 +56,7 @@ func NewClient() Client {
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
+					// nolint:gosec // used on tls-alpn-01 challenge
 					InsecureSkipVerify: true, // lgtm[go/disabled-certificate-check]
 				},
 			},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1437,7 +1437,7 @@ func Test_fmtPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
+	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1463,7 +1463,7 @@ func Test_fmtPublicKey(t *testing.T) {
 		want string
 	}{
 		{"p256", args{p256.Public(), p256, nil}, "ECDSA P-256"},
-		{"rsa1024", args{rsa1024.Public(), rsa1024, nil}, "RSA 1024"},
+		{"rsa2048", args{rsa2048.Public(), rsa2048, nil}, "RSA 2048"},
 		{"ed25519", args{edPub, edPriv, nil}, "Ed25519"},
 		{"dsa2048", args{cert: &x509.Certificate{PublicKeyAlgorithm: x509.DSA, PublicKey: &dsa2048.PublicKey}}, "DSA 2048"},
 		{"unknown", args{cert: &x509.Certificate{PublicKeyAlgorithm: x509.ECDSA, PublicKey: []byte("12345678")}}, "ECDSA unknown"},

--- a/authority/config/tls_options.go
+++ b/authority/config/tls_options.go
@@ -169,6 +169,7 @@ func (t *TLSOptions) TLSConfig() *tls.Config {
 		rs = tls.RenegotiateNever
 	}
 
+	// nolint:gosec // default MinVersion 1.2, if defined but empty 1.3 is used
 	return &tls.Config{
 		CipherSuites:  t.CipherSuites.Value(),
 		MinVersion:    t.MinVersion.Value(),

--- a/authority/linkedca.go
+++ b/authority/linkedca.go
@@ -461,6 +461,7 @@ func getRootCertificate(endpoint, fingerprint string) (*x509.Certificate, error)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		// nolint:gosec // used in bootstrap protocol
 		InsecureSkipVerify: true, // lgtm[go/disabled-certificate-check]
 	})))
 	if err != nil {
@@ -514,7 +515,8 @@ func login(authority, token string, csr *x509.CertificateRequest, signer crypto.
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-		RootCAs: rootCAs,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
 	})))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error connecting %s", endpoint)
@@ -590,6 +592,7 @@ func login(authority, token string, csr *x509.CertificateRequest, signer crypto.
 	rootCAs.AddCert(bundle[last])
 
 	return cert, &tls.Config{
-		RootCAs: rootCAs,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
 	}, nil
 }

--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -35,6 +35,7 @@ const awsIdentityURL = "http://169.254.169.254/latest/dynamic/instance-identity/
 const awsSignatureURL = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
 
 // awsAPITokenURL is the url used to get the IMDSv2 API token
+// nolint:gosec // no credentials here
 const awsAPITokenURL = "http://169.254.169.254/latest/api/token"
 
 // awsAPITokenTTL is the default TTL to use when requesting IMDSv2 API tokens
@@ -42,9 +43,11 @@ const awsAPITokenURL = "http://169.254.169.254/latest/api/token"
 const awsAPITokenTTL = "30"
 
 // awsMetadataTokenHeader is the header that must be passed with every IMDSv2 request
+// nolint:gosec // no credentials here
 const awsMetadataTokenHeader = "X-aws-ec2-metadata-token"
 
 // awsMetadataTokenTTLHeader is the header used to indicate the token TTL requested
+// nolint:gosec // no credentials here
 const awsMetadataTokenTTLHeader = "X-aws-ec2-metadata-token-ttl-seconds"
 
 // awsCertificate is the certificate used to validate the instance identity

--- a/authority/provisioner/aws_test.go
+++ b/authority/provisioner/aws_test.go
@@ -316,7 +316,7 @@ func TestAWS_authorizeToken(t *testing.T) {
 	}
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	assert.FatalError(t, err)
-	badKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	badKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
 
 	type test struct {
@@ -579,7 +579,7 @@ func TestAWS_AuthorizeSign(t *testing.T) {
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	assert.FatalError(t, err)
 
-	badKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	badKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
 
 	t4, err := generateAWSToken(
@@ -748,6 +748,7 @@ func TestAWS_AuthorizeSSHSign(t *testing.T) {
 	pub := key.Public().Key
 	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
+	// nolint:gosec // tests minimum size of the key
 	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -25,6 +25,7 @@ import (
 const azureOIDCBaseURL = "https://login.microsoftonline.com"
 
 // azureIdentityTokenURL is the URL to get the identity token for an instance.
+// nolint:gosec // no credentials here
 const azureIdentityTokenURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F"
 
 // azureDefaultAudience is the default audience used.

--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -624,6 +624,7 @@ func TestAzure_AuthorizeSSHSign(t *testing.T) {
 	pub := key.Public().Key
 	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
+	// nolint:gosec // tests minimum size of the key
 	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/collection.go
+++ b/authority/provisioner/collection.go
@@ -1,7 +1,7 @@
 package provisioner
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // not used for cryptographic security
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
@@ -319,6 +319,7 @@ func loadProvisioner(m *sync.Map, key string) (Interface, bool) {
 // provisionerSum returns the SHA1 of the provisioners ID. From this we will
 // create the unique and sorted id.
 func provisionerSum(p Interface) []byte {
+	// nolint:gosec // not used for cryptographic security
 	sum := sha1.Sum([]byte(p.GetID()))
 	return sum[:]
 }

--- a/authority/provisioner/gcp_test.go
+++ b/authority/provisioner/gcp_test.go
@@ -623,6 +623,7 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 	pub := key.Public().Key
 	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
+	// nolint:gosec // tests minimum size of the key
 	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/jwk_test.go
+++ b/authority/provisioner/jwk_test.go
@@ -411,6 +411,7 @@ func TestJWK_AuthorizeSSHSign(t *testing.T) {
 	pub := key.Public().Key
 	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
+	// nolint:gosec // tests minimum size of the key
 	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/keystore.go
+++ b/authority/provisioner/keystore.go
@@ -85,14 +85,14 @@ func (ks *keyStore) reload() {
 // 0 it will randomly rotate between 0-12 hours, but every time we call to Get
 // it will automatically rotate.
 func (ks *keyStore) nextReloadDuration(age time.Duration) time.Duration {
-	n := rand.Int63n(int64(ks.jitter))
+	n := rand.Int63n(int64(ks.jitter)) // nolint:gosec // not used for cryptographic security
 	age -= time.Duration(n)
 	return abs(age)
 }
 
 func getKeysFromJWKsURI(uri string) (jose.JSONWebKeySet, time.Duration, error) {
 	var keys jose.JSONWebKeySet
-	resp, err := http.Get(uri)
+	resp, err := http.Get(uri) // nolint:gosec // openid-configuration jwks_uri
 	if err != nil {
 		return keys, 0, errors.Wrapf(err, "failed to connect to %s", uri)
 	}

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -464,7 +464,7 @@ func (o *OIDC) AuthorizeSSHRevoke(ctx context.Context, token string) error {
 }
 
 func getAndDecode(uri string, v interface{}) error {
-	resp, err := http.Get(uri)
+	resp, err := http.Get(uri) // nolint:gosec // openid-configuration uri
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to %s", uri)
 	}

--- a/authority/provisioner/oidc_test.go
+++ b/authority/provisioner/oidc_test.go
@@ -535,6 +535,7 @@ func TestOIDC_AuthorizeSSHSign(t *testing.T) {
 	pub := key.Public().Key
 	rsa2048, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.FatalError(t, err)
+	// nolint:gosec // tests minimum size of the key
 	rsa1024, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.FatalError(t, err)
 

--- a/authority/provisioner/options_test.go
+++ b/authority/provisioner/options_test.go
@@ -254,6 +254,7 @@ func TestCustomTemplateOptions(t *testing.T) {
 }
 
 func Test_unsafeParseSigned(t *testing.T) {
+	// nolint:gosec // no credentials here
 	okToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqYW5lQGRvZS5jb20iLCJpc3MiOiJodHRwczovL2RvZS5jb20iLCJqdGkiOiI4ZmYzMjQ4MS1mZDVmLTRlMmUtOTZkZi05MDhjMTI3Yzg1ZjciLCJpYXQiOjE1OTUzNjAwMjgsImV4cCI6MTU5NTM2MzYyOH0.aid8UuhFucJOFHXaob9zpNtVvhul9ulTGsA52mU6XIw"
 	type args struct {
 		s string

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -449,6 +449,7 @@ func generateAWSWithServer() (*AWS, *httptest.Server, error) {
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error signing document")
 	}
+	// nolint:gosec // tests minimum size of the key
 	token := "AQAEAEEO9-7Z88ewKFpboZuDlFYWz9A3AN-wMOVzjEhfAyXW31BvVw=="
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/authority/tls_test.go
+++ b/authority/tls_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -199,6 +199,7 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 	if _, err = asn1.Unmarshal(b, &info); err != nil {
 		return nil, fmt.Errorf("error unmarshaling public key: %w", err)
 	}
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(info.SubjectPublicKey.Bytes)
 	return hash[:], nil
 }

--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -200,6 +200,7 @@ func TestBootstrap(t *testing.T) {
 	}
 }
 
+// nolint:gosec // insecure test servers
 func TestBootstrapServerWithoutMTLS(t *testing.T) {
 	srv := startCABootstrapServer()
 	defer srv.Close()
@@ -256,6 +257,7 @@ func TestBootstrapServerWithoutMTLS(t *testing.T) {
 	}
 }
 
+// nolint:gosec // insecure test servers
 func TestBootstrapServerWithMTLS(t *testing.T) {
 	srv := startCABootstrapServer()
 	defer srv.Close()
@@ -405,6 +407,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 
 	// Create bootstrap server
 	token := generateBootstrapToken(caURL, "127.0.0.1", "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7")
+	// nolint:gosec // insecure test server
 	server, err := BootstrapServer(context.Background(), token, &http.Server{
 		Addr: ":0",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -523,6 +526,7 @@ func TestBootstrapClientServerFederation(t *testing.T) {
 
 	// Create bootstrap server
 	token := generateBootstrapToken(caURL1, "127.0.0.1", "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7")
+	// nolint:gosec // insecure test server
 	server, err := BootstrapServer(context.Background(), token, &http.Server{
 		Addr: ":0",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/ca/ca_test.go
+++ b/ca/ca_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -65,6 +65,8 @@ func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
 	if _, err = asn1.Unmarshal(b, &info); err != nil {
 		return nil, errors.Wrap(err, "error unmarshaling public key")
 	}
+
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(info.SubjectPublicKey.Bytes)
 	return hash[:], nil
 }

--- a/ca/identity/client.go
+++ b/ca/identity/client.go
@@ -62,6 +62,7 @@ func LoadClient() (*Client, error) {
 	// Prepare transport with information in defaults.json and identity.json
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.TLSClientConfig = &tls.Config{
+		MinVersion:           tls.VersionTLS12,
 		GetClientCertificate: identity.GetClientCertificateFunc(),
 	}
 

--- a/ca/identity/client_test.go
+++ b/ca/identity/client_test.go
@@ -58,6 +58,7 @@ func TestClient(t *testing.T) {
 		Certificates: []tls.Certificate{crt},
 		ClientCAs:    pool,
 		ClientAuth:   tls.VerifyClientCertIfGiven,
+		MinVersion:   tls.VersionTLS12,
 	}
 	okServer.StartTLS()
 
@@ -132,6 +133,7 @@ func TestLoadClient(t *testing.T) {
 	tr.TLSClientConfig = &tls.Config{
 		Certificates: []tls.Certificate{crt},
 		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
 	}
 	expected := &Client{
 		CaURL: &url.URL{Scheme: "https", Host: "127.0.0.1"},

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -296,6 +296,7 @@ func (i *Identity) Renew(client Renewer) error {
 		tr.TLSClientConfig = &tls.Config{
 			Certificates:             []tls.Certificate{cert},
 			RootCAs:                  client.GetRootCAs(),
+			MinVersion:               tls.VersionTLS12,
 			PreferServerCipherSuites: true,
 		}
 

--- a/ca/renew.go
+++ b/ca/renew.go
@@ -173,7 +173,7 @@ func (r *TLSRenewer) renewCertificate() {
 	cert, err := r.RenewCertificate()
 	if err != nil {
 		next = r.renewJitter / 2
-		next += time.Duration(rand.Int63n(int64(next)))
+		next += time.Duration(mathRandInt63n(int64(next)))
 	} else {
 		r.setCertificate(cert)
 		next = r.nextRenewDuration(cert.Leaf.NotAfter)
@@ -185,10 +185,15 @@ func (r *TLSRenewer) renewCertificate() {
 
 func (r *TLSRenewer) nextRenewDuration(notAfter time.Time) time.Duration {
 	d := time.Until(notAfter).Truncate(time.Second) - r.renewBefore
-	n := rand.Int63n(int64(r.renewJitter))
+	n := mathRandInt63n(int64(r.renewJitter))
 	d -= time.Duration(n)
 	if d < 0 {
 		d = 0
 	}
 	return d
+}
+
+// nolint:gosec // not used for cryptographic security
+func mathRandInt63n(n int64) int64 {
+	return rand.Int63n(n)
 }

--- a/ca/tls.go
+++ b/ca/tls.go
@@ -60,6 +60,7 @@ func init() {
 			d := &tls.Dialer{
 				NetDialer: getDefaultDialer(),
 				Config: &tls.Config{
+					MinVersion:           tls.VersionTLS12,
 					RootCAs:              pool,
 					GetClientCertificate: id.GetClientCertificateFunc(),
 				},

--- a/ca/tls_options_test.go
+++ b/ca/tls_options_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smallstep/certificates/api"
 )
 
+// nolint:gosec // test tls config
 func Test_newTLSOptionCtx(t *testing.T) {
 	client, err := NewClient("https://ca.smallstep.com", WithTransport(http.DefaultTransport))
 	if err != nil {
@@ -40,6 +41,7 @@ func Test_newTLSOptionCtx(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestTLSOptionCtx_apply(t *testing.T) {
 	fail := func() TLSOption {
 		return func(ctx *TLSOptionCtx) error {
@@ -76,6 +78,7 @@ func TestTLSOptionCtx_apply(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestRequireAndVerifyClientCert(t *testing.T) {
 	tests := []struct {
 		name string
@@ -100,6 +103,7 @@ func TestRequireAndVerifyClientCert(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestVerifyClientCertIfGiven(t *testing.T) {
 	tests := []struct {
 		name string
@@ -124,6 +128,7 @@ func TestVerifyClientCertIfGiven(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddRootCA(t *testing.T) {
 	cert := parseCertificate(rootPEM)
 	pool := x509.NewCertPool()
@@ -156,6 +161,7 @@ func TestAddRootCA(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddClientCA(t *testing.T) {
 	cert := parseCertificate(rootPEM)
 	pool := x509.NewCertPool()
@@ -188,6 +194,7 @@ func TestAddClientCA(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddRootsToRootCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()
@@ -242,6 +249,7 @@ func TestAddRootsToRootCAs(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddRootsToClientCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()
@@ -296,6 +304,7 @@ func TestAddRootsToClientCAs(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddFederationToRootCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()
@@ -360,6 +369,7 @@ func TestAddFederationToRootCAs(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddFederationToClientCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()
@@ -424,6 +434,7 @@ func TestAddFederationToClientCAs(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddRootsToCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()
@@ -478,6 +489,7 @@ func TestAddRootsToCAs(t *testing.T) {
 	}
 }
 
+// nolint:gosec // test tls config
 func TestAddFederationToCAs(t *testing.T) {
 	ca := startCATestServer()
 	defer ca.Close()

--- a/cmd/step-awskms-init/main.go
+++ b/cmd/step-awskms-init/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -239,6 +239,7 @@ func mustSubjectKeyID(key crypto.PublicKey) []byte {
 	if err != nil {
 		panic(err)
 	}
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(b)
 	return hash[:]
 }

--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	// Server profiler
+	// nolint:gosec // profile server, if enabled runs on a different port
 	_ "net/http/pprof"
 
 	"github.com/smallstep/certificates/authority"

--- a/cmd/step-cloudkms-init/main.go
+++ b/cmd/step-cloudkms-init/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -277,6 +277,7 @@ func mustSubjectKeyID(key crypto.PublicKey) []byte {
 	if err != nil {
 		panic(err)
 	}
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(b)
 	return hash[:]
 }

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -6,7 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -544,6 +544,7 @@ func mustSubjectKeyID(key crypto.PublicKey) []byte {
 	if err != nil {
 		panic(err)
 	}
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(b)
 	return hash[:]
 }

--- a/cmd/step-yubikey-init/main.go
+++ b/cmd/step-yubikey-init/main.go
@@ -6,7 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
@@ -346,6 +346,7 @@ func mustSubjectKeyID(key crypto.PublicKey) []byte {
 	if err != nil {
 		panic(err)
 	}
+	// nolint:gosec // used to create the Subject Key Identifier by RFC 5280
 	hash := sha1.Sum(b)
 	return hash[:]
 }

--- a/commands/onboard.go
+++ b/commands/onboard.go
@@ -92,6 +92,7 @@ func onboardAction(ctx *cli.Context) error {
 	token := ctx.Args().Get(0)
 	onboardingURL := u.ResolveReference(&url.URL{Path: token}).String()
 
+	// nolint:gosec // onboarding url
 	res, err := http.Get(onboardingURL)
 	if err != nil {
 		return errors.Wrap(err, "error connecting onboarding guide")
@@ -132,6 +133,7 @@ func onboardAction(ctx *cli.Context) error {
 		return errors.Wrap(err, "error marshaling payload")
 	}
 
+	// nolint:gosec // onboarding url
 	resp, err := http.Post(onboardingURL, "application/json", bytes.NewBuffer(payload))
 	if err != nil {
 		return errors.Wrap(err, "error connecting onboarding guide")

--- a/server/server.go
+++ b/server/server.go
@@ -39,13 +39,14 @@ func New(addr string, handler http.Handler, tlsConfig *tls.Config) *Server {
 // tls.Config.
 func newHTTPServer(addr string, handler http.Handler, tlsConfig *tls.Config) *http.Server {
 	return &http.Server{
-		Addr:         addr,
-		Handler:      handler,
-		TLSConfig:    tlsConfig,
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
-		IdleTimeout:  15 * time.Second,
-		ErrorLog:     log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Llongfile),
+		Addr:              addr,
+		Handler:           handler,
+		TLSConfig:         tlsConfig,
+		WriteTimeout:      15 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		ReadHeaderTimeout: 15 * time.Second,
+		IdleTimeout:       15 * time.Second,
+		ErrorLog:          log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Llongfile),
 	}
 }
 


### PR DESCRIPTION
### Description

This PR addresses all `gosec` warnings, most, if not all, false positives.

We can address some of them using go.step.sm/crypto to reduce the number of `nolint` comments.

We can also try to skip the test rules to avoid errors when a `tls.Config{}` or an `http.Server{}` is used:

@dopey what do you think about this?
```yaml
issues:
  exclude-rules:
    - path: '(.+)_test\.go'
      linters:
        - gosec
```

