### PR TITLE
Allow missing Email claim in OIDC tokens

### DIFF
--- a/authority/provisioner/ssh_test.go
+++ b/authority/provisioner/ssh_test.go
@@ -20,7 +20,7 @@ func validateSSHCertificate(cert *ssh.Certificate, opts *SignSSHOptions) error {
 		return fmt.Errorf("certificate signature is nil")
 	case cert.SignatureKey == nil:
 		return fmt.Errorf("certificate signature is nil")
-	case !reflect.DeepEqual(cert.ValidPrincipals, opts.Principals):
+	case !reflect.DeepEqual(cert.ValidPrincipals, opts.Principals) && (len(opts.Principals) > 0 || len(cert.ValidPrincipals) > 0):
 		return fmt.Errorf("certificate principals are not equal, want %v, got %v", opts.Principals, cert.ValidPrincipals)
 	case cert.CertType != ssh.UserCert && cert.CertType != ssh.HostCert:
 		return fmt.Errorf("certificate type %v is not valid", cert.CertType)


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Remove requirement of needing `Email` claim on OIDC tokens for SSH Signing. This pull removes the requirement for an `Email` claim in the token, and if it is missing will pass a minimal data set to the template renderer with no Principals defined, and using the `Subject` claim as KeyID.

This way a user may setup an OIDC provisioner that accepts JWTs from the CI/CD pipeline, and use templates to strictly control what principals are added to the issued Certificates (in the case of SSH certificates)

#### Pain or issue this feature alleviates:
JWTs issued by several CI/CD pipelines don't include `Email` claims [Gitlab](https://docs.gitlab.com/ee/ci/cloud_services/#how-it-works), Github, etc

Removing the requirement for an `Email` claim allows a token to be resolved and SSH certs to be issued when using these JWTs.

#### Supporting links/other PRs/issues:
* [Gitlab JWT documentation](https://docs.gitlab.com/ee/ci/cloud_services/#how-it-works)
* [Github JWT documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
* Resolves https://github.com/smallstep/certificates/issues/1039

