### PR TITLE
Add deprecation notices to step-x-init binaries

### DIFF
--- a/cmd/step-awskms-init/main.go
+++ b/cmd/step-awskms-init/main.go
@@ -34,6 +34,9 @@ func main() {
 	// Initialize windows terminal
 	ui.Init()
 
+	ui.Println("⚠️  This command is deprecated and will be removed in future releases.")
+	ui.Println("⚠️  Please use https://github.com/smallstep/step-kms-plugin instead.")
+
 	c, err := awskms.New(context.Background(), apiv1.Options{
 		Type:            apiv1.AmazonKMS,
 		Region:          region,

--- a/cmd/step-cloudkms-init/main.go
+++ b/cmd/step-cloudkms-init/main.go
@@ -65,6 +65,9 @@ func main() {
 	// Initialize windows terminal
 	ui.Init()
 
+	ui.Println("⚠️  This command is deprecated and will be removed in future releases.")
+	ui.Println("⚠️  Please use https://github.com/smallstep/step-kms-plugin instead.")
+
 	c, err := cloudkms.New(context.Background(), apiv1.Options{
 		Type:            apiv1.CloudKMS,
 		CredentialsFile: credentialsFile,

--- a/cmd/step-pkcs11-init/main.go
+++ b/cmd/step-pkcs11-init/main.go
@@ -151,6 +151,9 @@ func main() {
 	// Initialize windows terminal
 	ui.Init()
 
+	ui.Println("⚠️  This command is deprecated and will be removed in future releases.")
+	ui.Println("⚠️  Please use https://github.com/smallstep/step-kms-plugin instead.")
+
 	switch {
 	case u.Get("pin-value") != "":
 	case u.Get("pin-source") != "":

--- a/cmd/step-yubikey-init/main.go
+++ b/cmd/step-yubikey-init/main.go
@@ -90,6 +90,9 @@ func main() {
 	// Initialize windows terminal
 	ui.Init()
 
+	ui.Println("⚠️  This command is deprecated and will be removed in future releases.")
+	ui.Println("⚠️  Please use https://github.com/smallstep/step-kms-plugin instead.")
+
 	pin, err := ui.PromptPassword("What is the YubiKey PIN?")
 	if err != nil {
 		fatal(err)


### PR DESCRIPTION
### Description

This PR adds deprecation notices to the following binaries:
* `step-awskms-init`
* `step-cloudkms-init`
* `step-pkcs11-init`
* `step-yubikey-init`

Fixes #1044