### PR TITLE
Fix nil pointer exception

### DIFF
--- a/authority/authorize.go
+++ b/authority/authorize.go
@@ -434,7 +434,7 @@ func (a *Authority) AuthorizeRenewToken(ctx context.Context, ott string) (*x509.
 
 	audiences := a.config.GetAudiences().Renew
 	if !matchesAudience(claims.Audience, audiences) {
-		return nil, errs.InternalServerErr(err, errs.WithMessage("error validating renew token: invalid audience claim (aud)"))
+		return nil, errs.InternalServerErr(jose.ErrInvalidAudience, errs.WithMessage("error validating renew token: invalid audience claim (aud)"))
 	}
 
 	// validate issuer: old versions used the provisioner name, new version uses


### PR DESCRIPTION
### Description

This PR fixes a nil pointer caused because an error was null.