### PR TITLE
Acme attestation information

### DIFF
--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -77,6 +77,12 @@ func (fn CertificateEnforcerFunc) Enforce(cert *x509.Certificate) error {
 	return fn(cert)
 }
 
+// AttestationData is a SignOption used to pass attestation information to the
+// sign methods.
+type AttestationData struct {
+	PermanentIdentifier string
+}
+
 // emailOnlyIdentity is a CertificateRequestValidator that checks that the only
 // SAN provided is the given email address.
 type emailOnlyIdentity string

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -94,6 +94,7 @@ func (a *Authority) Sign(csr *x509.CertificateRequest, signOpts provisioner.Sign
 
 	var prov provisioner.Interface
 	var pInfo *casapi.ProvisionerInfo
+	var attData provisioner.AttestationData
 	for _, op := range extraOpts {
 		switch k := op.(type) {
 		// Capture current provisioner
@@ -129,6 +130,11 @@ func (a *Authority) Sign(csr *x509.CertificateRequest, signOpts provisioner.Sign
 		case provisioner.CertificateEnforcer:
 			certEnforcers = append(certEnforcers, k)
 
+		// Extra information from ACME attestations.
+		case provisioner.AttestationData:
+			attData = k
+			// TODO(mariano,areed): remove me once attData is used.
+			_ = attData
 		default:
 			return nil, errs.InternalServer("authority.Sign; invalid extra option type %T", append([]interface{}{k}, opts...)...)
 		}

--- a/cas/cloudcas/cloudcas_test.go
+++ b/cas/cloudcas/cloudcas_test.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -402,6 +403,14 @@ func TestNew_real(t *testing.T) {
 		})
 	}
 
+	failDefaultCredentials := true
+	if home, err := os.UserHomeDir(); err == nil {
+		file := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+		if _, err := os.Stat(file); err == nil {
+			failDefaultCredentials = false
+		}
+	}
+
 	type args struct {
 		ctx  context.Context
 		opts apiv1.Options
@@ -412,7 +421,7 @@ func TestNew_real(t *testing.T) {
 		args     args
 		wantErr  bool
 	}{
-		{"fail default credentials", true, args{context.Background(), apiv1.Options{CertificateAuthority: testAuthorityName}}, true},
+		{"fail default credentials", true, args{context.Background(), apiv1.Options{CertificateAuthority: testAuthorityName}}, failDefaultCredentials},
 		{"fail certificate authority", false, args{context.Background(), apiv1.Options{}}, true},
 		{"fail with credentials", false, args{context.Background(), apiv1.Options{
 			CertificateAuthority: testAuthorityName, CredentialsFile: "testdata/missing.json",


### PR DESCRIPTION
### Description

This PR adds a new sign option to pass attestation information to the `authority.Sign` method. This permits sending this information to authorizing webhooks.

This PR also solves a test skipped in CI when it runs on local environments with gcloud configured.