### PR TITLE
Return the internal error instead of the ACME error

### DIFF
--- a/acme/db/nosql/authz_test.go
+++ b/acme/db/nosql/authz_test.go
@@ -77,7 +77,7 @@ func TestDB_getDBAuthz(t *testing.T) {
 				Token:        "token",
 				CreatedAt:    now,
 				ExpiresAt:    now.Add(5 * time.Minute),
-				Error:        acme.NewErrorISE("force"),
+				Error:        acme.NewErrorISE("The server experienced an internal error"),
 				ChallengeIDs: []string{"foo", "bar"},
 				Wildcard:     true,
 			}
@@ -254,7 +254,7 @@ func TestDB_GetAuthorization(t *testing.T) {
 				Token:        "token",
 				CreatedAt:    now,
 				ExpiresAt:    now.Add(5 * time.Minute),
-				Error:        acme.NewErrorISE("force"),
+				Error:        acme.NewErrorISE("The server experienced an internal error"),
 				ChallengeIDs: []string{"foo", "bar"},
 				Wildcard:     true,
 			}
@@ -532,7 +532,7 @@ func TestDB_UpdateAuthorization(t *testing.T) {
 						assert.Equals(t, dbNew.Wildcard, dbaz.Wildcard)
 						assert.Equals(t, dbNew.CreatedAt, dbaz.CreatedAt)
 						assert.Equals(t, dbNew.ExpiresAt, dbaz.ExpiresAt)
-						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "malformed").Error())
+						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 						return nil, false, errors.New("force")
 					},
 				},
@@ -582,7 +582,7 @@ func TestDB_UpdateAuthorization(t *testing.T) {
 						assert.Equals(t, dbNew.Wildcard, dbaz.Wildcard)
 						assert.Equals(t, dbNew.CreatedAt, dbaz.CreatedAt)
 						assert.Equals(t, dbNew.ExpiresAt, dbaz.ExpiresAt)
-						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "malformed").Error())
+						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 						return nu, true, nil
 					},
 				},

--- a/acme/db/nosql/challenge_test.go
+++ b/acme/db/nosql/challenge_test.go
@@ -72,7 +72,7 @@ func TestDB_getDBChallenge(t *testing.T) {
 				Value:       "test.ca.smallstep.com",
 				CreatedAt:   clock.Now(),
 				ValidatedAt: "foobar",
-				Error:       acme.NewErrorISE("force"),
+				Error:       acme.NewErrorISE("The server experienced an internal error"),
 			}
 			b, err := json.Marshal(dbc)
 			assert.FatalError(t, err)
@@ -264,7 +264,7 @@ func TestDB_GetChallenge(t *testing.T) {
 				Value:       "test.ca.smallstep.com",
 				CreatedAt:   clock.Now(),
 				ValidatedAt: "foobar",
-				Error:       acme.NewErrorISE("force"),
+				Error:       acme.NewErrorISE("The server experienced an internal error"),
 			}
 			b, err := json.Marshal(dbc)
 			assert.FatalError(t, err)
@@ -354,7 +354,7 @@ func TestDB_UpdateChallenge(t *testing.T) {
 				ID:          chID,
 				Status:      acme.StatusValid,
 				ValidatedAt: "foobar",
-				Error:       acme.NewError(acme.ErrorMalformedType, "malformed"),
+				Error:       acme.NewError(acme.ErrorMalformedType, "The request message was malformed"),
 			}
 			return test{
 				ch: updCh,
@@ -428,7 +428,7 @@ func TestDB_UpdateChallenge(t *testing.T) {
 						assert.Equals(t, dbNew.CreatedAt, dbc.CreatedAt)
 						assert.Equals(t, dbNew.Status, acme.StatusValid)
 						assert.Equals(t, dbNew.ValidatedAt, "foobar")
-						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "malformed").Error())
+						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 						return nu, true, nil
 					},
 				},

--- a/acme/db/nosql/order_test.go
+++ b/acme/db/nosql/order_test.go
@@ -80,7 +80,7 @@ func TestDB_getDBOrder(t *testing.T) {
 					{Type: "dns", Value: "example.foo.com"},
 				},
 				AuthorizationIDs: []string{"foo", "bar"},
-				Error:            acme.NewError(acme.ErrorMalformedType, "force"),
+				Error:            acme.NewError(acme.ErrorMalformedType, "The request message was malformed"),
 			}
 			b, err := json.Marshal(dbo)
 			assert.FatalError(t, err)
@@ -185,7 +185,7 @@ func TestDB_GetOrder(t *testing.T) {
 					{Type: "dns", Value: "example.foo.com"},
 				},
 				AuthorizationIDs: []string{"foo", "bar"},
-				Error:            acme.NewError(acme.ErrorMalformedType, "force"),
+				Error:            acme.NewError(acme.ErrorMalformedType, "The request message was malformed"),
 			}
 			b, err := json.Marshal(dbo)
 			assert.FatalError(t, err)
@@ -284,7 +284,7 @@ func TestDB_UpdateOrder(t *testing.T) {
 				ID:            orderID,
 				Status:        acme.StatusValid,
 				CertificateID: "certID",
-				Error:         acme.NewError(acme.ErrorMalformedType, "force"),
+				Error:         acme.NewError(acme.ErrorMalformedType, "The request message was malformed"),
 			}
 			return test{
 				o: o,
@@ -324,7 +324,7 @@ func TestDB_UpdateOrder(t *testing.T) {
 				ID:            orderID,
 				Status:        acme.StatusValid,
 				CertificateID: "certID",
-				Error:         acme.NewError(acme.ErrorMalformedType, "force"),
+				Error:         acme.NewError(acme.ErrorMalformedType, "The request message was malformed"),
 			}
 			return test{
 				o: o,
@@ -372,7 +372,7 @@ func TestDB_UpdateOrder(t *testing.T) {
 					assert.Equals(t, tc.o.ID, dbo.ID)
 					assert.Equals(t, tc.o.CertificateID, "certID")
 					assert.Equals(t, tc.o.Status, acme.StatusValid)
-					assert.Equals(t, tc.o.Error.Error(), acme.NewError(acme.ErrorMalformedType, "force").Error())
+					assert.Equals(t, tc.o.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 				}
 			}
 		})
@@ -659,7 +659,7 @@ func TestDB_updateAddOrderIDs(t *testing.T) {
 						assert.Equals(t, newdbo.ID, "foo")
 						assert.Equals(t, newdbo.Status, acme.StatusInvalid)
 						assert.Equals(t, newdbo.ExpiresAt, expiry)
-						assert.Equals(t, newdbo.Error.Error(), acme.NewError(acme.ErrorMalformedType, "order has expired").Error())
+						assert.Equals(t, newdbo.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 						return nil, false, errors.New("force")
 					},
 				},

--- a/acme/errors.go
+++ b/acme/errors.go
@@ -337,7 +337,10 @@ func (e *Error) StatusCode() int {
 
 // Error allows AError to implement the error interface.
 func (e *Error) Error() string {
-	return e.Detail
+	if e.Err == nil {
+		return e.Detail
+	}
+	return e.Err.Error()
 }
 
 // Cause returns the internal error and implements the Causer interface.

--- a/acme/errors.go
+++ b/acme/errors.go
@@ -335,7 +335,7 @@ func (e *Error) StatusCode() int {
 	return e.Status
 }
 
-// Error allows AError to implement the error interface.
+// Error implements the error interface.
 func (e *Error) Error() string {
 	if e.Err == nil {
 		return e.Detail


### PR DESCRIPTION
### Description

For ACME errors, return the internal error string instead of the ACME one on the "Error() string" function. This way, the logs will have more information about the cause of an error.

Fixes #1057