### PR TITLE
audience name should not be case sensitive, thus when case sensitivity is …

### DIFF
--- a/authority/provisioner/collection.go
+++ b/authority/provisioner/collection.go
@@ -332,7 +332,7 @@ func matchesAudience(as, bs []string) bool {
 
 	for _, b := range bs {
 		for _, a := range as {
-			if b == a || stripPort(a) == stripPort(b) {
+			if strings.ToLower(b) == strings.ToLower(a) || stripPort(strings.ToLower(a)) == stripPort(strings.ToLower(b)) {
 				return true
 			}
 		}


### PR DESCRIPTION
…different between server/client, step-ca creates invalid audience error.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
