### PR TITLE
Fix webhook controller ignoring cert type

### DIFF
--- a/authority/provisioner/controller.go
+++ b/authority/provisioner/controller.go
@@ -86,6 +86,7 @@ func (c *Controller) newWebhookController(templateData WebhookSetter, certType l
 		TemplateData: templateData,
 		client:       client,
 		webhooks:     c.webhooks,
+		certType:     certType,
 	}
 }
 

--- a/authority/provisioner/controller_test.go
+++ b/authority/provisioner/controller_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.step.sm/crypto/x509util"
+	"go.step.sm/linkedca"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/smallstep/certificates/authority/policy"
@@ -443,5 +445,20 @@ func TestDefaultAuthorizeSSHRenew(t *testing.T) {
 				t.Errorf("DefaultAuthorizeSSHRenew() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func Test_newWebhookController(t *testing.T) {
+	c := &Controller{}
+	data := x509util.TemplateData{"foo": "bar"}
+	ctl := c.newWebhookController(data, linkedca.Webhook_X509)
+	if !reflect.DeepEqual(ctl.TemplateData, data) {
+		t.Error("Failed to set templateData")
+	}
+	if ctl.certType != linkedca.Webhook_X509 {
+		t.Error("Failed to set certType")
+	}
+	if ctl.client == nil {
+		t.Error("Failed to set client")
 	}
 }


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Provisioner webhooks

#### Pain or issue this feature alleviates:
Webhooks configured for x509 only are being called for ssh certs and vice versa.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
