### PR TITLE
No longer need to ignore context warnings when context in request

### DIFF
--- a/api/renew.go
+++ b/api/renew.go
@@ -17,7 +17,6 @@ const (
 // Renew uses the information of certificate in the TLS connection to create a
 // new one.
 func Renew(w http.ResponseWriter, r *http.Request) {
-	//nolint:contextcheck // the reqest has the context
 	cert, err := getPeerCertificate(r)
 	if err != nil {
 		render.Error(w, err)

--- a/api/sshRekey.go
+++ b/api/sshRekey.go
@@ -83,7 +83,6 @@ func SSHRekey(w http.ResponseWriter, r *http.Request) {
 	notBefore := time.Unix(int64(oldCert.ValidAfter), 0)
 	notAfter := time.Unix(int64(oldCert.ValidBefore), 0)
 
-	//nolint:contextcheck // the reqest has the context
 	identity, err := renewIdentityCertificate(r, notBefore, notAfter)
 	if err != nil {
 		render.Error(w, errs.ForbiddenErr(err, "error renewing identity certificate"))

--- a/api/sshRenew.go
+++ b/api/sshRenew.go
@@ -75,7 +75,6 @@ func SSHRenew(w http.ResponseWriter, r *http.Request) {
 	notBefore := time.Unix(int64(oldCert.ValidAfter), 0)
 	notAfter := time.Unix(int64(oldCert.ValidBefore), 0)
 
-	//nolint:contextcheck // the reqest has the context
 	identity, err := renewIdentityCertificate(r, notBefore, notAfter)
 	if err != nil {
 		render.Error(w, errs.ForbiddenErr(err, "error renewing identity certificate"))


### PR DESCRIPTION
- after upgrade to golangci-lint 1.50.0
