### PR TITLE
Use sh instead of bash in .version.sh script

### DIFF
--- a/.version.sh
+++ b/.version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 read -r firstline < .VERSION
 last_half="${firstline##*tag: }"
 if [[ ${last_half::1} == "v" ]]; then


### PR DESCRIPTION
### Description

This PR replaces bash with sh in the version script. This script is only used if certificates is built from a code that doesn't contain a git repository, for example, from the source file [asset](https://github.com/smallstep/certificates/releases/download/v0.22.1/step-ca_0.22.1.tar.gz) in GiHub releases

Fixes #1115
