### PR TITLE
Split build and download in Dockerfiles

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY . .
 
 RUN apk add --no-cache curl git make
+RUN make V=1 download
 RUN make V=1 bin/step-ca bin/step-awskms-init bin/step-cloudkms-init
 
 

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -5,6 +5,7 @@ COPY . .
 
 RUN apk add --no-cache curl git make
 RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
+RUN make V=1 download
 RUN make V=1 GOFLAGS="" build
 
 


### PR DESCRIPTION
### Description

The command `go mod download` can fail on systems with low resources. This causes long builds of the docker images. This PR adds a new layer in the docker build, splitting the build and download into two steps.

Fixes #1114