### PR TITLE
Use RawSubject on renew and rekey

### DIFF
--- a/authority/tls.go
+++ b/authority/tls.go
@@ -320,7 +320,7 @@ func (a *Authority) Rekey(oldCert *x509.Certificate, pk crypto.PublicKey) ([]*x5
 	// Create new certificate from previous values.
 	// Issuer, NotBefore, NotAfter and SubjectKeyId will be set by the CAS.
 	newCert := &x509.Certificate{
-		Subject:                     oldCert.Subject,
+		RawSubject:                  oldCert.RawSubject,
 		KeyUsage:                    oldCert.KeyUsage,
 		UnhandledCriticalExtensions: oldCert.UnhandledCriticalExtensions,
 		ExtKeyUsage:                 oldCert.ExtKeyUsage,


### PR DESCRIPTION
### Description

Renew was not replicating exactly the subject because extra names get decoded into `pkix.Name.Names`, the non-default ones should be added to `pkix.Name.ExtraNames`. Instead, this PR sets the RawSubject to keep the order.

Fixes #1106
