### PR TITLE
Add support for custom acme ports

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -44,6 +44,18 @@ const (
 	DEVICEATTEST01 ChallengeType = "device-attest-01"
 )
 
+var (
+	// InsecurePortHTTP01 is the port used to verify http-01 challenges. If not set it
+	// defaults to 80.
+	InsecurePortHTTP01 int
+
+	// InsecurePortTLSALPN01 is the port used to verify tls-alpn-01 challenges. If not
+	// set it defaults to 443.
+	//
+	// This variable can be used for testing purposes.
+	InsecurePortTLSALPN01 int
+)
+
 // Challenge represents an ACME response Challenge type.
 type Challenge struct {
 	ID              string        `json:"-"`
@@ -92,6 +104,12 @@ func (ch *Challenge) Validate(ctx context.Context, db DB, jwk *jose.JSONWebKey, 
 
 func http01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSONWebKey) error {
 	u := &url.URL{Scheme: "http", Host: http01ChallengeHost(ch.Value), Path: fmt.Sprintf("/.well-known/acme-challenge/%s", ch.Token)}
+
+	// Append insecure port if set.
+	// Only used for testing purposes.
+	if InsecurePortHTTP01 != 0 {
+		u.Host += ":" + strconv.Itoa(InsecurePortHTTP01)
+	}
 
 	vc := MustClientFromContext(ctx)
 	resp, err := vc.Get(u.String())
@@ -165,7 +183,14 @@ func tlsalpn01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSON
 		InsecureSkipVerify: true, //nolint:gosec // we expect a self-signed challenge certificate
 	}
 
-	hostPort := net.JoinHostPort(ch.Value, "443")
+	var hostPort string
+
+	// Allow to change TLS port for testing purposes.
+	if port := InsecurePortTLSALPN01; port == 0 {
+		hostPort = net.JoinHostPort(ch.Value, "443")
+	} else {
+		hostPort = net.JoinHostPort(ch.Value, strconv.Itoa(port))
+	}
 
 	vc := MustClientFromContext(ctx)
 	conn, err := vc.TLSDial("tcp", hostPort, config)

--- a/commands/app.go
+++ b/commands/app.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/acme"
 	"github.com/smallstep/certificates/authority/config"
 	"github.com/smallstep/certificates/authority/provisioner"
 	"github.com/smallstep/certificates/ca"
@@ -71,6 +72,19 @@ certificate issuer private key used in the RA mode.`,
 			Usage:  "The name of the authority's context.",
 			EnvVar: "STEP_CA_CONTEXT",
 		},
+		cli.IntFlag{
+			Name: "acme-http-port",
+			Usage: `The port used on http-01 challenges. It can be changed for testing purposes.
+Requires **--insecure** flag.`,
+		},
+		cli.IntFlag{
+			Name: "acme-tls-port",
+			Usage: `The port used on tls-alpn-01 challenges. It can be changed for testing purposes.
+Requires **--insecure** flag.`,
+		},
+		cli.BoolFlag{
+			Name: "insecure",
+		},
 	},
 }
 
@@ -88,6 +102,23 @@ func appAction(ctx *cli.Context) error {
 		return errs.TooManyArguments(ctx)
 	}
 
+	// Allow custom ACME ports with insecure
+	if acmePort := ctx.Int("acme-http-port"); acmePort != 0 {
+		if ctx.Bool("insecure") {
+			acme.InsecurePortHTTP01 = acmePort
+		} else {
+			return fmt.Errorf("flag '--acme-http-port' requires the '--insecure' flag")
+		}
+	}
+	if acmePort := ctx.Int("acme-tls-port"); acmePort != 0 {
+		if ctx.Bool("insecure") {
+			acme.InsecurePortTLSALPN01 = acmePort
+		} else {
+			return fmt.Errorf("flag '--acme-tls-port' requires the '--insecure' flag")
+		}
+	}
+
+	// Allow custom contexts.
 	if caCtx := ctx.String("context"); caCtx != "" {
 		if err := step.Contexts().SetCurrent(caCtx); err != nil {
 			return err


### PR DESCRIPTION
### Description

This change adds the flags `--acme-http-port`, `--acme-tls-port`, that combined with `--insecure` can be used to set custom ports for ACME `http-01` and `tls-alpn-01` challenges. These flags should only be used for testing purposes.

Fixes #1015