### PR TITLE
Add support for renew when using stepcas

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -40,6 +40,7 @@ type Authority interface {
 	Root(shasum string) (*x509.Certificate, error)
 	Sign(cr *x509.CertificateRequest, opts provisioner.SignOptions, signOpts ...provisioner.SignOption) ([]*x509.Certificate, error)
 	Renew(peer *x509.Certificate) ([]*x509.Certificate, error)
+	RenewContext(ctx context.Context, peer *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error)
 	Rekey(peer *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error)
 	LoadProvisionerByCertificate(*x509.Certificate) (provisioner.Interface, error)
 	LoadProvisionerByName(string) (provisioner.Interface, error)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -192,6 +192,7 @@ type mockAuthority struct {
 	sign                         func(cr *x509.CertificateRequest, opts provisioner.SignOptions, signOpts ...provisioner.SignOption) ([]*x509.Certificate, error)
 	renew                        func(cert *x509.Certificate) ([]*x509.Certificate, error)
 	rekey                        func(oldCert *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error)
+	renewContext                 func(ctx context.Context, oldCert *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error)
 	loadProvisionerByCertificate func(cert *x509.Certificate) (provisioner.Interface, error)
 	loadProvisionerByName        func(name string) (provisioner.Interface, error)
 	getProvisioners              func(nextCursor string, limit int) (provisioner.List, string, error)
@@ -260,6 +261,13 @@ func (m *mockAuthority) Sign(cr *x509.CertificateRequest, opts provisioner.SignO
 func (m *mockAuthority) Renew(cert *x509.Certificate) ([]*x509.Certificate, error) {
 	if m.renew != nil {
 		return m.renew(cert)
+	}
+	return []*x509.Certificate{m.ret1.(*x509.Certificate), m.ret2.(*x509.Certificate)}, m.err
+}
+
+func (m *mockAuthority) RenewContext(ctx context.Context, oldcert *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error) {
+	if m.renewContext != nil {
+		return m.renewContext(ctx, oldcert, pk)
 	}
 	return []*x509.Certificate{m.ret1.(*x509.Certificate), m.ret2.(*x509.Certificate)}, m.err
 }

--- a/api/renew.go
+++ b/api/renew.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/smallstep/certificates/api/render"
+	"github.com/smallstep/certificates/authority"
 	"github.com/smallstep/certificates/errs"
 )
 
@@ -17,14 +18,22 @@ const (
 // Renew uses the information of certificate in the TLS connection to create a
 // new one.
 func Renew(w http.ResponseWriter, r *http.Request) {
-	cert, err := getPeerCertificate(r)
+	ctx := r.Context()
+
+	// Get the leaf certificate from the peer or the token.
+	cert, token, err := getPeerCertificate(r)
 	if err != nil {
 		render.Error(w, err)
 		return
 	}
 
-	a := mustAuthority(r.Context())
-	certChain, err := a.Renew(cert)
+	// The token can be used by RAs to renew a certificate.
+	if token != "" {
+		ctx = authority.NewTokenContext(ctx, token)
+	}
+
+	a := mustAuthority(ctx)
+	certChain, err := a.RenewContext(ctx, cert, nil)
 	if err != nil {
 		render.Error(w, errs.Wrap(http.StatusInternalServerError, err, "cahandler.Renew"))
 		return
@@ -44,15 +53,16 @@ func Renew(w http.ResponseWriter, r *http.Request) {
 	}, http.StatusCreated)
 }
 
-func getPeerCertificate(r *http.Request) (*x509.Certificate, error) {
+func getPeerCertificate(r *http.Request) (*x509.Certificate, string, error) {
 	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		return r.TLS.PeerCertificates[0], nil
+		return r.TLS.PeerCertificates[0], "", nil
 	}
 	if s := r.Header.Get(authorizationHeader); s != "" {
 		if parts := strings.SplitN(s, bearerScheme+" ", 2); len(parts) == 2 {
 			ctx := r.Context()
-			return mustAuthority(ctx).AuthorizeRenewToken(ctx, parts[1])
+			peer, err := mustAuthority(ctx).AuthorizeRenewToken(ctx, parts[1])
+			return peer, parts[1], err
 		}
 	}
-	return nil, errs.BadRequest("missing client certificate")
+	return nil, "", errs.BadRequest("missing client certificate")
 }

--- a/authority/authorize_test.go
+++ b/authority/authorize_test.go
@@ -876,7 +876,7 @@ func TestAuthority_authorizeRenew(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := genTestCase(t)
 
-			err := tc.auth.authorizeRenew(tc.cert)
+			err := tc.auth.authorizeRenew(context.Background(), tc.cert)
 			if err != nil {
 				if assert.NotNil(t, tc.err) {
 					var sc render.StatusCodedError
@@ -1459,6 +1459,37 @@ func TestAuthority_AuthorizeRenewToken(t *testing.T) {
 		})
 		return nil
 	}))
+	a4 := testAuthority(t)
+	a4.db = &db.MockAuthDB{
+		MUseToken: func(id, tok string) (bool, error) {
+			return true, nil
+		},
+		MGetCertificateData: func(serialNumber string) (*db.CertificateData, error) {
+			return &db.CertificateData{
+				Provisioner: &db.ProvisionerData{ID: "Max:IMi94WBNI6gP5cNHXlZYNUzvMjGdHyBRmFoo-lCEaqk", Name: "Max"},
+				RaInfo:      &provisioner.RAInfo{ProvisionerName: "ra"},
+			}, nil
+		},
+	}
+	t4, c4 := generateX5cToken(a1, signer, jose.Claims{
+		Audience:  []string{"https://ra.example.com/1.0/renew"},
+		Subject:   "test.example.com",
+		Issuer:    "step-ca-client/1.0",
+		NotBefore: jose.NewNumericDate(now),
+		Expiry:    jose.NewNumericDate(now.Add(5 * time.Minute)),
+	}, provisioner.CertificateEnforcerFunc(func(cert *x509.Certificate) error {
+		cert.NotBefore = now
+		cert.NotAfter = now.Add(time.Hour)
+		b, err := asn1.Marshal(stepProvisionerASN1{int(provisioner.TypeJWK), []byte("step-cli"), nil, nil})
+		if err != nil {
+			return err
+		}
+		cert.ExtraExtensions = append(cert.ExtraExtensions, pkix.Extension{
+			Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 37476, 9000, 64, 1},
+			Value: b,
+		})
+		return nil
+	}))
 	badSigner, _ := generateX5cToken(a1, otherSigner, jose.Claims{
 		Audience:  []string{"https://example.com/1.0/renew"},
 		Subject:   "test.example.com",
@@ -1627,6 +1658,7 @@ func TestAuthority_AuthorizeRenewToken(t *testing.T) {
 		{"ok", a1, args{ctx, t1}, c1, false},
 		{"ok expired cert", a1, args{ctx, t2}, c2, false},
 		{"ok provisioner issuer", a1, args{ctx, t3}, c3, false},
+		{"ok ra provisioner", a4, args{ctx, t4}, c4, false},
 		{"fail token", a1, args{ctx, "not.a.token"}, nil, true},
 		{"fail token reuse", a1, args{ctx, t1}, nil, true},
 		{"fail token signature", a1, args{ctx, badSigner}, nil, true},

--- a/authority/provisioners_test.go
+++ b/authority/provisioners_test.go
@@ -333,3 +333,54 @@ func TestProvisionerWebhookToLinkedca(t *testing.T) {
 		})
 	}
 }
+
+func Test_wrapRAProvisioner(t *testing.T) {
+	type args struct {
+		p      provisioner.Interface
+		raInfo *provisioner.RAInfo
+	}
+	tests := []struct {
+		name string
+		args args
+		want *wrappedProvisioner
+	}{
+		{"ok", args{&provisioner.JWK{Name: "jwt"}, &provisioner.RAInfo{ProvisionerName: "ra"}}, &wrappedProvisioner{
+			Interface: &provisioner.JWK{Name: "jwt"},
+			raInfo:    &provisioner.RAInfo{ProvisionerName: "ra"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wrapRAProvisioner(tt.args.p, tt.args.raInfo); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("wrapRAProvisioner() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isRAProvisioner(t *testing.T) {
+	type args struct {
+		p provisioner.Interface
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"true", args{&wrappedProvisioner{
+			Interface: &provisioner.JWK{Name: "jwt"},
+			raInfo:    &provisioner.RAInfo{ProvisionerName: "ra"},
+		}}, true},
+		{"nil ra", args{&wrappedProvisioner{
+			Interface: &provisioner.JWK{Name: "jwt"},
+		}}, false},
+		{"not ra", args{&provisioner.JWK{Name: "jwt"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRAProvisioner(tt.args.p); got != tt.want {
+				t.Errorf("isRAProvisioner() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/authority/tls_test.go
+++ b/authority/tls_test.go
@@ -992,14 +992,14 @@ func TestAuthority_Renew(t *testing.T) {
 			return &renewTest{
 				auth: _a,
 				cert: cert,
-				err:  errors.New("authority.Rekey: error creating certificate"),
+				err:  errors.New("error creating certificate"),
 				code: http.StatusInternalServerError,
 			}, nil
 		},
 		"fail/unauthorized": func() (*renewTest, error) {
 			return &renewTest{
 				cert: certNoRenew,
-				err:  errors.New("authority.Rekey: authority.authorizeRenew: renew is disabled for provisioner 'dev'"),
+				err:  errors.New("authority.authorizeRenew: renew is disabled for provisioner 'dev'"),
 				code: http.StatusUnauthorized,
 			}, nil
 		},
@@ -1012,7 +1012,7 @@ func TestAuthority_Renew(t *testing.T) {
 			return &renewTest{
 				auth: aa,
 				cert: cert,
-				err:  errors.New("authority.Rekey: authority.authorizeRenew: not authorized"),
+				err:  errors.New("authority.authorizeRenew: not authorized"),
 				code: http.StatusUnauthorized,
 			}, nil
 		},
@@ -1221,14 +1221,14 @@ func TestAuthority_Rekey(t *testing.T) {
 			return &renewTest{
 				auth: _a,
 				cert: cert,
-				err:  errors.New("authority.Rekey: error creating certificate"),
+				err:  errors.New("error creating certificate"),
 				code: http.StatusInternalServerError,
 			}, nil
 		},
 		"fail/unauthorized": func() (*renewTest, error) {
 			return &renewTest{
 				cert: certNoRenew,
-				err:  errors.New("authority.Rekey: authority.authorizeRenew: renew is disabled for provisioner 'dev'"),
+				err:  errors.New("authority.authorizeRenew: renew is disabled for provisioner 'dev'"),
 				code: http.StatusUnauthorized,
 			}, nil
 		},

--- a/cas/apiv1/requests.go
+++ b/cas/apiv1/requests.go
@@ -81,6 +81,7 @@ type RenewCertificateRequest struct {
 	CSR       *x509.CertificateRequest
 	Lifetime  time.Duration
 	Backdate  time.Duration
+	Token     string
 	RequestID string
 }
 

--- a/cas/apiv1/services.go
+++ b/cas/apiv1/services.go
@@ -83,3 +83,23 @@ func (e NotImplementedError) Error() string {
 func (e NotImplementedError) StatusCode() int {
 	return http.StatusNotImplemented
 }
+
+// ValidationError is the type of error returned if request is not properly
+// validated.
+type ValidationError struct {
+	Message string
+}
+
+// NotImplementedError implements the error interface.
+func (e ValidationError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return "bad request"
+}
+
+// StatusCode implements the StatusCoder interface and returns the HTTP 400
+// error.
+func (e ValidationError) StatusCode() int {
+	return http.StatusBadRequest
+}

--- a/cas/apiv1/services_test.go
+++ b/cas/apiv1/services_test.go
@@ -71,3 +71,51 @@ func TestNotImplementedError_StatusCode(t *testing.T) {
 		})
 	}
 }
+
+func TestValidationError_Error(t *testing.T) {
+	type fields struct {
+		Message string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{"default", fields{""}, "bad request"},
+		{"with message", fields{"token is empty"}, "token is empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := ValidationError{
+				Message: tt.fields.Message,
+			}
+			if got := e.Error(); got != tt.want {
+				t.Errorf("ValidationError.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidationError_StatusCode(t *testing.T) {
+	type fields struct {
+		Message string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		{"default", fields{""}, 400},
+		{"with message", fields{"token is empty"}, 400},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := ValidationError{
+				Message: tt.fields.Message,
+			}
+			if got := e.StatusCode(); got != tt.want {
+				t.Errorf("ValidationError.StatusCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cas/stepcas/stepcas.go
+++ b/cas/stepcas/stepcas.go
@@ -101,7 +101,25 @@ func (s *StepCAS) CreateCertificate(req *apiv1.CreateCertificateRequest) (*apiv1
 // RenewCertificate will always return a non-implemented error as mTLS renewals
 // are not supported yet.
 func (s *StepCAS) RenewCertificate(req *apiv1.RenewCertificateRequest) (*apiv1.RenewCertificateResponse, error) {
-	return nil, apiv1.NotImplementedError{Message: "stepCAS does not support mTLS renewals"}
+	if req.Token == "" {
+		return nil, apiv1.ValidationError{Message: "renewCertificateRequest `token` cannot be empty"}
+	}
+
+	resp, err := s.client.RenewWithToken(req.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	var chain []*x509.Certificate
+	cert := resp.CertChainPEM[0].Certificate
+	for _, c := range resp.CertChainPEM[1:] {
+		chain = append(chain, c.Certificate)
+	}
+
+	return &apiv1.RenewCertificateResponse{
+		Certificate:      cert,
+		CertificateChain: chain,
+	}, nil
 }
 
 // RevokeCertificate revokes a certificate.


### PR DESCRIPTION
It supports renewing X.509 certificates when an RA is configured with stepcas. This will only work when the renewal uses a token, and it won't work with mTLS.

The audience cannot be properly verified when an RA is used, to avoid this we will get from the database if an RA was used to issue the initial certificate and we will accept the renew token.

Fixes #1021 for stepcas.

The support for cloudcas was already implemented, and the renew token cannot be used for vaultcas because the CSR is [required](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-certificate) and it's not available in a renew flow.