### PR TITLE
Add support for linked RA renewals

### DIFF
--- a/authority/linkedca.go
+++ b/authority/linkedca.go
@@ -265,8 +265,20 @@ func (c *linkedCaClient) GetCertificateData(serial string) (*db.CertificateData,
 			ID: p.Id, Name: p.Name, Type: p.Type.String(),
 		}
 	}
+
+	var raInfo *provisioner.RAInfo
+	if p := resp.RaProvisioner; p != nil && p.Provisioner != nil {
+		raInfo = &provisioner.RAInfo{
+			AuthorityID:     p.AuthorityId,
+			ProvisionerID:   p.Provisioner.Id,
+			ProvisionerType: p.Provisioner.Type.String(),
+			ProvisionerName: p.Provisioner.Name,
+		}
+	}
+
 	return &db.CertificateData{
 		Provisioner: pd,
+		RaInfo:      raInfo,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	go.step.sm/cli-utils v0.7.5
 	go.step.sm/crypto v0.23.1
-	go.step.sm/linkedca v0.19.0-rc.4
+	go.step.sm/linkedca v0.19.0
 	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
 	golang.org/x/net v0.1.0
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ go.step.sm/cli-utils v0.7.5/go.mod h1:taSsY8haLmXoXM3ZkywIyRmVij/4Aj0fQbNTlJvv71
 go.step.sm/crypto v0.9.0/go.mod h1:+CYG05Mek1YDqi5WK0ERc6cOpKly2i/a5aZmU1sfGj0=
 go.step.sm/crypto v0.23.1 h1:Yr9vlzjGqIKVi88KcpZtEcNTcpDkt1nVR7tumW4h+CU=
 go.step.sm/crypto v0.23.1/go.mod h1:djAhDYpNAuWF2LkzbCVcf0JDy1UWgrxR3eQ7pQ8EQ/w=
-go.step.sm/linkedca v0.19.0-rc.4 h1:kaBW+xHkRRgMNDa4gWiIj7gBq5yjbJKGlTWYYo5z2KQ=
-go.step.sm/linkedca v0.19.0-rc.4/go.mod h1:b7vWPrHfYLEOTSUZitFEcztVCpTc+ileIN85CwEAluM=
+go.step.sm/linkedca v0.19.0 h1:xuagkR35wrJI2gnu6FAM+q3VmjwsHScvGcJsfZ0GdsI=
+go.step.sm/linkedca v0.19.0/go.mod h1:b7vWPrHfYLEOTSUZitFEcztVCpTc+ileIN85CwEAluM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
### Description

This PR adds support for linked RA renewals. Related to #1021 and #1156.

RA renewals must use renewal tokens instead of mTLS:
```
step ca renew localhost.crt localhost.key --mtls=false
```

