### PR TITLE
Remove `charset=utf-8` from ACME certificate responses

### DIFF
--- a/acme/api/handler.go
+++ b/acme/api/handler.go
@@ -394,6 +394,6 @@ func GetCertificate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	api.LogCertificate(w, cert.Leaf)
-	w.Header().Set("Content-Type", "application/pem-certificate-chain; charset=utf-8")
+	w.Header().Set("Content-Type", "application/pem-certificate-chain")
 	w.Write(certBytes)
 }

--- a/acme/api/handler_test.go
+++ b/acme/api/handler_test.go
@@ -514,7 +514,7 @@ func TestHandler_GetCertificate(t *testing.T) {
 				assert.Equals(t, res.Header["Content-Type"], []string{"application/problem+json"})
 			} else {
 				assert.Equals(t, bytes.TrimSpace(body), bytes.TrimSpace(certBytes))
-				assert.Equals(t, res.Header["Content-Type"], []string{"application/pem-certificate-chain; charset=utf-8"})
+				assert.Equals(t, res.Header["Content-Type"], []string{"application/pem-certificate-chain"})
 			}
 		})
 	}


### PR DESCRIPTION
Addresses https://github.com/smallstep/certificates/issues/1171. 

In internal discussions the fact that some information is lost from the response when `charset` is removed came up. Ideally, we think the Erlang client in case should be updated to be more lenient in what it accepts, in line with the _robustness principle_. The change is small, so maybe it gets done. On the other hand, the change here is small too, so we may merge it. 

Awaiting approval and some compatibility testing. 