### PR TITLE
Return an appropriate error when requests fail

### DIFF
--- a/ca/adminClient.go
+++ b/ca/adminClient.go
@@ -144,7 +144,7 @@ func (c *AdminClient) GetAdmin(id string) (*linkedca.Admin, error) {
 retry:
 	resp, err := c.client.Get(u.String())
 	if err != nil {
-		return nil, errors.Wrapf(err, "client GET %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -227,7 +227,7 @@ func (c *AdminClient) GetAdminsPaginate(opts ...AdminOption) (*adminAPI.GetAdmin
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client GET %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -282,7 +282,7 @@ func (c *AdminClient) CreateAdmin(createAdminRequest *adminAPI.CreateAdminReques
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client POST %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -314,7 +314,7 @@ func (c *AdminClient) RemoveAdmin(id string) error {
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "client DELETE %s failed", u)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -340,13 +340,13 @@ func (c *AdminClient) UpdateAdmin(id string, uar *adminAPI.UpdateAdminRequest) (
 	}
 	req, err := http.NewRequest("PATCH", u.String(), bytes.NewReader(body))
 	if err != nil {
-		return nil, errors.Wrapf(err, "create PUT %s request failed", u)
+		return nil, errors.Wrapf(err, "create PATCH %s request failed", u)
 	}
 	req.Header.Add("Authorization", tok)
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client PUT %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -387,13 +387,13 @@ func (c *AdminClient) GetProvisioner(opts ...ProvisionerOption) (*linkedca.Provi
 	}
 	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
-		return nil, errors.Wrapf(err, "create PUT %s request failed", u)
+		return nil, errors.Wrapf(err, "create GET %s request failed", u)
 	}
 	req.Header.Add("Authorization", tok)
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client GET %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -426,13 +426,13 @@ func (c *AdminClient) GetProvisionersPaginate(opts ...ProvisionerOption) (*admin
 	}
 	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
-		return nil, errors.Wrapf(err, "create PUT %s request failed", u)
+		return nil, errors.Wrapf(err, "create GET %s request failed", u)
 	}
 	req.Header.Add("Authorization", tok)
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client GET %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -502,7 +502,7 @@ func (c *AdminClient) RemoveProvisioner(opts ...ProvisionerOption) error {
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "client DELETE %s failed", u)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -534,7 +534,7 @@ func (c *AdminClient) CreateProvisioner(prov *linkedca.Provisioner) (*linkedca.P
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client POST %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -570,7 +570,7 @@ func (c *AdminClient) UpdateProvisioner(name string, prov *linkedca.Provisioner)
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "client PUT %s failed", u)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -609,7 +609,7 @@ func (c *AdminClient) GetExternalAccountKeysPaginate(provisionerName, reference 
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client GET %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -645,7 +645,7 @@ func (c *AdminClient) CreateExternalAccountKey(provisionerName string, eakReques
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "client POST %s failed", u)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -677,7 +677,7 @@ func (c *AdminClient) RemoveExternalAccountKey(provisionerName, keyID string) er
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "client DELETE %s failed", u)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -704,7 +704,7 @@ func (c *AdminClient) GetAuthorityPolicy() (*linkedca.Policy, error) {
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client GET %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -739,7 +739,7 @@ func (c *AdminClient) CreateAuthorityPolicy(p *linkedca.Policy) (*linkedca.Polic
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client POST %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -774,7 +774,7 @@ func (c *AdminClient) UpdateAuthorityPolicy(p *linkedca.Policy) (*linkedca.Polic
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client PUT %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -805,7 +805,7 @@ func (c *AdminClient) RemoveAuthorityPolicy() error {
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client DELETE %s failed: %w", u, err)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -832,7 +832,7 @@ func (c *AdminClient) GetProvisionerPolicy(provisionerName string) (*linkedca.Po
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client GET %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -867,7 +867,7 @@ func (c *AdminClient) CreateProvisionerPolicy(provisionerName string, p *linkedc
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client POST %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -902,7 +902,7 @@ func (c *AdminClient) UpdateProvisionerPolicy(provisionerName string, p *linkedc
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client PUT %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -933,7 +933,7 @@ func (c *AdminClient) RemoveProvisionerPolicy(provisionerName string) error {
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client DELETE %s failed: %w", u, err)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -967,7 +967,7 @@ func (c *AdminClient) GetACMEPolicy(provisionerName, reference, keyID string) (*
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client GET %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1009,7 +1009,7 @@ func (c *AdminClient) CreateACMEPolicy(provisionerName, reference, keyID string,
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client POST %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1051,7 +1051,7 @@ func (c *AdminClient) UpdateACMEPolicy(provisionerName, reference, keyID string,
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client PUT %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1089,7 +1089,7 @@ func (c *AdminClient) RemoveACMEPolicy(provisionerName, reference, keyID string)
 retry:
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client DELETE %s failed: %w", u, err)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1120,7 +1120,7 @@ retry:
 	req.Header.Add("Authorization", tok)
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client POST %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1155,7 +1155,7 @@ retry:
 	req.Header.Add("Authorization", tok)
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("client PUT %s failed: %w", u, err)
+		return nil, clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {
@@ -1186,7 +1186,7 @@ retry:
 	req.Header.Add("Authorization", tok)
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client DELETE %s failed: %w", u, err)
+		return clientError(err)
 	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) {


### PR DESCRIPTION
### Description

If an http client `Do` method fails, it always returns an `*url.URL` error, this change generalizes all those errors in one common method instead of returning a fake HTTP error.

Fixes smallstep/cli#738