### PR TITLE
Adding crl idp config

### DIFF
--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -90,7 +90,7 @@ type CRLConfig struct {
 	GenerateOnRevoke bool                  `json:"generateOnRevoke,omitempty"`
 	CacheDuration    *provisioner.Duration `json:"cacheDuration,omitempty"`
 	RenewPeriod      *provisioner.Duration `json:"renewPeriod,omitempty"`
-	IDPurl           string                `json:"idpurl,omitempty"`
+	IDPurl           string                `json:"idpURL,omitempty"`
 }
 
 // IsEnabled returns if the CRL is enabled.

--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -90,7 +90,7 @@ type CRLConfig struct {
 	GenerateOnRevoke bool                  `json:"generateOnRevoke,omitempty"`
 	CacheDuration    *provisioner.Duration `json:"cacheDuration,omitempty"`
 	RenewPeriod      *provisioner.Duration `json:"renewPeriod,omitempty"`
-	IDPurl			 string				   `json:"idpurl"`
+	IDPurl           string                `json:"idpurl"`
 }
 
 // IsEnabled returns if the CRL is enabled.

--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -90,7 +90,7 @@ type CRLConfig struct {
 	GenerateOnRevoke bool                  `json:"generateOnRevoke,omitempty"`
 	CacheDuration    *provisioner.Duration `json:"cacheDuration,omitempty"`
 	RenewPeriod      *provisioner.Duration `json:"renewPeriod,omitempty"`
-	IDPurl           string                `json:"idpurl"`
+	IDPurl           string                `json:"idpurl,omitempty"`
 }
 
 // IsEnabled returns if the CRL is enabled.

--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -90,6 +90,7 @@ type CRLConfig struct {
 	GenerateOnRevoke bool                  `json:"generateOnRevoke,omitempty"`
 	CacheDuration    *provisioner.Duration `json:"cacheDuration,omitempty"`
 	RenewPeriod      *provisioner.Duration `json:"renewPeriod,omitempty"`
+	IDPurl			 string				   `json:"idpurl"`
 }
 
 // IsEnabled returns if the CRL is enabled.

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -773,10 +773,17 @@ func (a *Authority) GenerateCertificateRevocationList() error {
 		NextUpdate:          now.Add(updateDuration),
 	}
 
+	// Set CRL IDP to config item, otherwise, leave as default
+	var fullName string
+	if a.config.CRL.IDPurl != "" {
+		fullName = a.config.CRL.IDPurl
+	} else {
+		fullName = a.config.Audience("/1.0/crl")[0]
+	}
+
 	// Add distribution point.
 	//
 	// Note that this is currently using the port 443 by default.
-	fullName := a.config.Audience("/1.0/crl")[0]
 	if b, err := marshalDistributionPoint(fullName, false); err == nil {
 		revocationList.ExtraExtensions = []pkix.Extension{
 			{Id: oidExtensionIssuingDistributionPoint, Value: b},


### PR DESCRIPTION
This PR adds a configuration option for adding a custom IDP to the CRLs that Step generates.

This essentially allows the CRL to be hosted off of Step CA. In my case (and in previous environments I have worked with), CRLs and OCSP are hosted in a highly available fashion, so this PR would allow the IDP on the CRL to be set to this location.

Getting the CRL off of step and to that HA location is on the administrator though 😃 .

I created this PR after testing CRL generation, and then attempting to host them off of the Step-CA server. Originally, I set `crlDistributionPoints` on a Step template to reflect my HA location, and manually hosted the CRL there, but I noticed that Windows was having a hard time validating the CRL because the IDP on the CRL did not match said location.

Some of this was kicked around in https://github.com/smallstep/certificates/issues/1144.

💔Thank you!
