### PR TITLE
Add env vars for enabling Remote Management and ACME provisioner

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -49,6 +49,12 @@ function step_ca_init () {
     if [ -n "${DOCKER_STEPCA_INIT_SSH}" ]; then
         setup_args=("${setup_args[@]}" --ssh)
     fi
+    if [ -n "${DOCKER_STEPCA_INIT_ACME}" ]; then
+        setup_args=("${setup_args[@]}" --acme)
+    fi
+    if [ -n "${DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT}" ]; then
+        setup_args=("${setup_args[@]}" --remote-management)
+    fi
     step ca init "${setup_args[@]}"
     mv $STEPPATH/password $PWDPATH
 }


### PR DESCRIPTION
A `step-ca` instance created in a container can now be initialized with Remote Management by setting `DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT`. An ACME provisioner with default settings can be created at initialization by setting `DOCKER_STEPCA_INIT_ACME`.

