### PR TITLE
Docker: Generate and use independent provisioner and private key passwords

### DIFF
--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -7,7 +7,6 @@ RUN apk add --no-cache curl git make
 RUN make V=1 download
 RUN make V=1 bin/step-ca bin/step-awskms-init bin/step-cloudkms-init
 
-
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
@@ -20,6 +19,7 @@ USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"
 ENV PWDPATH="/home/step/secrets/password"
+ENV PROVISIONER_PWDPATH="/home/step/secrets/provisioner_password"
 
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
@@ -28,4 +28,4 @@ HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 COPY docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
-CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH --provisioner-password-file $PROVISIONER_PWDPATH $CONFIGPATH

--- a/docker/Dockerfile.step-ca
+++ b/docker/Dockerfile.step-ca
@@ -19,7 +19,6 @@ USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"
 ENV PWDPATH="/home/step/secrets/password"
-ENV PROVISIONER_PWDPATH="/home/step/secrets/provisioner_password"
 
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
@@ -28,4 +27,4 @@ HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 COPY docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
-CMD exec /usr/local/bin/step-ca --password-file $PWDPATH --provisioner-password-file $PROVISIONER_PWDPATH $CONFIGPATH
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -24,7 +24,6 @@ USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"
 ENV PWDPATH="/home/step/secrets/password"
-ENV PROVISIONER_PWDPATH="/home/step/secrets/provisioner_password"
 
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
@@ -33,4 +32,4 @@ HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 COPY docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
-CMD exec /usr/local/bin/step-ca --password-file $PWDPATH --provisioner-password-file $PROVISIONER_PWDPATH $CONFIGPATH
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH

--- a/docker/Dockerfile.step-ca.hsm
+++ b/docker/Dockerfile.step-ca.hsm
@@ -24,6 +24,7 @@ USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"
 ENV PWDPATH="/home/step/secrets/password"
+ENV PROVISIONER_PWDPATH="/home/step/secrets/provisioner_password"
 
 VOLUME ["/home/step"]
 STOPSIGNAL SIGTERM
@@ -32,4 +33,4 @@ HEALTHCHECK CMD step ca health 2>/dev/null | grep "^ok" >/dev/null
 COPY docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
-CMD exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH
+CMD exec /usr/local/bin/step-ca --password-file $PWDPATH --provisioner-password-file $PROVISIONER_PWDPATH $CONFIGPATH

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,12 +34,16 @@ function generate_password () {
 
 # Initialize a CA if not already initialized
 function step_ca_init () {
+    DOCKER_STEPCA_INIT_PROVISIONER_NAME="${DOCKER_STEPCA_INIT_PROVISIONER_NAME:-admin}"
+    DOCKER_STEPCA_INIT_ADMIN_SUBJECT="${DOCKER_STEPCA_INIT_ADMIN_SUBJECT:-step}"
+
     local -a setup_args=(
         --name "${DOCKER_STEPCA_INIT_NAME}"
         --dns "${DOCKER_STEPCA_INIT_DNS_NAMES}"
-        --provisioner "${DOCKER_STEPCA_INIT_PROVISIONER_NAME:-admin}"
+        --provisioner "${DOCKER_STEPCA_INIT_PROVISIONER_NAME}"
         --password-file "${STEPPATH}/password"
         --provisioner-password-file "${STEPPATH}/provisioner_password"
+        --admin-subject "${DOCKER_STEPCA_INIT_ADMIN_SUBJECT}"
         --address ":9000"
     )
     if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
@@ -61,7 +65,7 @@ function step_ca_init () {
     step ca init "${setup_args[@]}"
    	echo ""
     if [ -n "${DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT}" ]; then
-        echo "👉 Your CA administrative username is: step"
+        echo "👉 Your CA administrative username is: ${DOCKER_STEPCA_INIT_ADMIN_SUBJECT}"
     fi
     echo "👉 Your CA administrative password is: $(< $STEPPATH/provisioner_password )"
     echo "🤫 This will only be displayed once."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,7 +19,7 @@ function init_if_possible () {
         fi
     done
     if [ ${missing_vars} = 1 ]; then
-		>&2 echo "there is no ca.json config file; please run step ca init, or provide config parameters via DOCKER_STEPCA_INIT_ vars"
+        >&2 echo "there is no ca.json config file; please run step ca init, or provide config parameters via DOCKER_STEPCA_INIT_ vars"
     else
         step_ca_init "${@}"
     fi
@@ -36,18 +36,18 @@ function generate_password () {
 function step_ca_init () {
     local -a setup_args=(
         --name "${DOCKER_STEPCA_INIT_NAME}"
-		--dns "${DOCKER_STEPCA_INIT_DNS_NAMES}"
-		--provisioner "${DOCKER_STEPCA_INIT_PROVISIONER_NAME:-admin}"
-		--password-file "${STEPPATH}/password"
-		--provisioner-password-file "${STEPPATH}/provisioner_password"
+        --dns "${DOCKER_STEPCA_INIT_DNS_NAMES}"
+        --provisioner "${DOCKER_STEPCA_INIT_PROVISIONER_NAME:-admin}"
+        --password-file "${STEPPATH}/password"
+        --provisioner-password-file "${STEPPATH}/provisioner_password"
         --address ":9000"
     )
     if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
         echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
         echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/provisioner_password"
-	else
-		generate_password > "${STEPPATH}/password"
-		generate_password > "${STEPPATH}/provisioner_password"
+    else
+        generate_password > "${STEPPATH}/password"
+        generate_password > "${STEPPATH}/provisioner_password"
     fi
     if [ -n "${DOCKER_STEPCA_INIT_SSH}" ]; then
         setup_args=("${setup_args[@]}" --ssh)
@@ -60,22 +60,22 @@ function step_ca_init () {
     fi
     step ca init "${setup_args[@]}"
     mv $STEPPATH/password $PWDPATH
-	mv $STEPPATH/provisioner_password $PROVISIONER_PWDPATH
+    mv $STEPPATH/provisioner_password $PROVISIONER_PWDPATH
 }
 
 if [ -f /usr/sbin/pcscd ]; then
-	/usr/sbin/pcscd
+    /usr/sbin/pcscd
 fi
 
 if [ ! -f "${STEPPATH}/config/ca.json" ]; then
-	init_if_possible
+    init_if_possible
 fi
 
 if [ ! -f "${PROVISIONER_PWDPATH}" ]; then
-	# For backward compatibility,
-	# if the --provisioner-password-file doesn't exist,
-	# use the same password as the CA.
-	cp ${PWDPATH} ${PROVISIONER_PWDPATH}
+    # For backward compatibility,
+    # if the --provisioner-password-file doesn't exist,
+    # use the same password as the CA.
+    cp ${PWDPATH} ${PROVISIONER_PWDPATH}
 fi
 
 exec "${@}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,7 +65,7 @@ function step_ca_init () {
     fi
     echo "👉 Your CA administrative password is: $(< $STEPPATH/provisioner_password )"
     echo "🤫 This will only be displayed once."
-    rm $STEPPATH/provisioner_password
+    shred -u $STEPPATH/provisioner_password
     mv $STEPPATH/password $PWDPATH
 }
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -63,16 +63,16 @@ if [ -f /usr/sbin/pcscd ]; then
 	/usr/sbin/pcscd
 fi
 
-if [ ! -f "${STEPPATH}/config/ca.json" ]; then
-	init_if_possible
-fi
-
 if [ ! -f "${STEPPATH}/password" ]; then
     generate_password > "${STEPPATH}/password"
 fi
 
 if [ ! -f "${STEPPATH}/provisioner_password" ]; then
 	generate_password > "${STEPPATH}/provisioner_password"
+fi
+
+if [ ! -f "${STEPPATH}/config/ca.json" ]; then
+	init_if_possible
 fi
 
 exec "${@}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -60,7 +60,6 @@ function step_ca_init () {
     fi
     step ca init "${setup_args[@]}"
     mv $STEPPATH/password $PWDPATH
-    mv $STEPPATH/provisioner_password $PROVISIONER_PWDPATH
 }
 
 if [ -f /usr/sbin/pcscd ]; then
@@ -69,13 +68,6 @@ fi
 
 if [ ! -f "${STEPPATH}/config/ca.json" ]; then
     init_if_possible
-fi
-
-if [ -f "${PWDPATH}" ] && [ ! -f "${PROVISIONER_PWDPATH}" ]; then
-    # For backward compatibility,
-    # if the --provisioner-password-file doesn't exist,
-    # use the same password as the CA.
-    cp ${PWDPATH} ${PROVISIONER_PWDPATH}
 fi
 
 exec "${@}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -71,7 +71,7 @@ if [ ! -f "${STEPPATH}/config/ca.json" ]; then
     init_if_possible
 fi
 
-if [ ! -f "${PROVISIONER_PWDPATH}" ]; then
+if [ -f "${PWDPATH}" ] && [ ! -f "${PROVISIONER_PWDPATH}" ]; then
     # For backward compatibility,
     # if the --provisioner-password-file doesn't exist,
     # use the same password as the CA.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,12 +39,12 @@ function step_ca_init () {
 		--dns "${DOCKER_STEPCA_INIT_DNS_NAMES}"
 		--provisioner "${DOCKER_STEPCA_INIT_PROVISIONER_NAME:-admin}"
 		--password-file "${STEPPATH}/password"
+		--provisioner-password-file "${STEPPATH}/provisioner_password"
         --address ":9000"
     )
     if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
         echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
-    else
-        generate_password > "${STEPPATH}/password"
+        echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/provisioner_password"
     fi
     if [ -n "${DOCKER_STEPCA_INIT_SSH}" ]; then
         setup_args=("${setup_args[@]}" --ssh)
@@ -65,6 +65,14 @@ fi
 
 if [ ! -f "${STEPPATH}/config/ca.json" ]; then
 	init_if_possible
+fi
+
+if [ ! -f "${STEPPATH}/password" ]; then
+    generate_password > "${STEPPATH}/password"
+fi
+
+if [ ! -f "${STEPPATH}/provisioner_password" ]; then
+	generate_password > "${STEPPATH}/provisioner_password"
 fi
 
 exec "${@}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -59,6 +59,13 @@ function step_ca_init () {
         setup_args=("${setup_args[@]}" --remote-management)
     fi
     step ca init "${setup_args[@]}"
+   	echo ""
+    if [ -n "${DOCKER_STEPCA_INIT_REMOTE_MANAGEMENT}" ]; then
+        echo "👉 Your CA administrative username is: step"
+    fi
+    echo "👉 Your CA administrative password is: $(< $STEPPATH/provisioner_password )"
+    echo "🤫 This will only be displayed once."
+    rm $STEPPATH/provisioner_password
     mv $STEPPATH/password $PWDPATH
 }
 


### PR DESCRIPTION
When using our Docker image, it usually makes sense to enable Remote Provisioner Management.

In the current version, we only generate one password file for the CA when we initialize a PKI via `docker run`, and we pass it to `step ca init` for use with both the CA keys and the admin provisioner.

This change adds a bit more security by also generating a provisioner password file by default when the CA is being initialized. The CA admin provisioner username and password are printed after `step ca init` runs, and the provisioner password file is deleted.

I'm also updating our Docker README setup instructions to enable Remote Management by default.

cc @hslatman 