### PR TITLE
Add step-kms-plugin to docker images and build a CGO based one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: smallstep/step-ca
+      DOCKER_IMAGE_HSM: smallstep/step-ca-hsm
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}
       is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
       docker_tags: ${{ env.DOCKER_TAGS }}
+      docker_tags_hsm: ${{ env.DOCKER_TAGS_HSM }}
     steps:
       - name: Is Pre-release
         id: is_prerelease
@@ -36,10 +38,12 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_IMAGE_HSM }}:${VERSION}" >> ${GITHUB_ENV}
       - name: Add Latest Tag
         if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
         run: |
           echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_TAGS_HSM }},${{ env.DOCKER_IMAGE_HSM }}:latest" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -96,5 +100,19 @@ jobs:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64
       tags: ${{ needs.create_release.outputs.docker_tags }}
       docker_image: smallstep/step-ca
-      docker_file: docker/Dockerfile.step-ca
+      docker_file: docker/Dockerfile
+    secrets: inherit
+
+  build_upload_docker_hsm:
+    name: Build & Upload HSM Enabled Docker Images
+    needs: create_release
+    permissions:
+      id-token: write
+      contents: write
+    uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
+    with:
+      platforms: linux/amd64,linux/386,linux/arm,linux/arm64
+      tags: ${{ needs.create_release.outputs.docker_tags_hsm }}
+      docker_image: smallstep/step-ca-hsm
+      docker_file: docker/Dockerfile.hsm
     secrets: inherit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,12 @@ RUN apk add --no-cache curl git make
 RUN make V=1 download
 RUN make V=1 bin/step-ca
 
+FROM smallstep/step-kms-plugin-cloud:latest AS kms
+
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
+COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -8,13 +8,18 @@ RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
 RUN make V=1 download
 RUN make V=1 GOFLAGS="" build
 
+FROM smallstep/step-kms-plugin:latest AS kms
+
 FROM smallstep/step-cli:latest
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
+COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
 RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
 RUN apk add --no-cache pcsc-lite pcsc-lite-libs
+RUN mkdir -p /run/pcscd
+RUN chown step:step /run/pcscd
 USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"


### PR DESCRIPTION
### Description

This PR adds a new docker image, `smallstep/step-ca-hsm`, where `step-ca` is compiled with CGO. This image can be used with a PKCS#11 HSM. This image also includes a CGO compiled `step-kms-plugin`.

The old image `smallstep/step-ca` also includes `step-kms-plugin` but without CGO, but it still can be used to create a PKI on cloud-based KMSs.

Requires:
- [x] https://github.com/smallstep/step-kms-plugin/pull/33