### PR TITLE
There is an error during RA installation which shows.

### DIFF
--- a/scripts/install-step-ra.sh
+++ b/scripts/install-step-ra.sh
@@ -188,7 +188,7 @@ CA_VERSION=$(curl -s https://api.github.com/repos/smallstep/certificates/release
 
 curl -sLO https://github.com/smallstep/certificates/releases/download/$CA_VERSION/step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 tar -xf step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
-install -m 0755 -t /usr/bin step-ca_${CA_VERSION:1}/bin/step-ca
+install -m 0755 -t /usr/bin step-ca_${CA_VERSION:1}/step-ca
 setcap CAP_NET_BIND_SERVICE=+eip $(which step-ca)
 rm step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 rm -rf step-ca_${CA_VERSION:1}


### PR DESCRIPTION
"install: cannot stat 'step-ca_0.23.2/bin/step-ca': No such file or directory" Upon checking the is no bin directory after step-ca_linux_0.23.2_amd64.tar.gz is extracted so by simply changing from step-ca_${CA_VERSION:1}/bin/step-ca to step-ca_${CA_VERSION:1}/step-ca the installation succeed.
