### PR TITLE
Clarify bootstrap error when root certificate is not found

### DIFF
--- a/ca/client.go
+++ b/ca/client.go
@@ -671,6 +671,10 @@ retry:
 	if err != nil {
 		return nil, clientError(err)
 	}
+	if resp.StatusCode == 404 {
+		defer resp.Body.Close()
+		return nil, errs.BadRequest("a root certificate with that fingerprint was not found")
+	}
 	if resp.StatusCode >= 400 {
 		if !retried && c.retryOnError(resp) { //nolint:contextcheck // deeply nested context; retry using the same context
 			retried = true


### PR DESCRIPTION
New output:

```
bin/step ca bootstrap --ca-url https://ca:4443 --fingerprint abc123
The request could not be completed: a root certificate with that fingerprint was not found.
Re-run with STEPDEBUG=1 for more info.
```
