### PR TITLE
Verify CSR key fingerprint with attestation certificate key

### DIFF
--- a/acme/authorization.go
+++ b/acme/authorization.go
@@ -8,15 +8,16 @@ import (
 
 // Authorization representst an ACME Authorization.
 type Authorization struct {
-	ID         string       `json:"-"`
-	AccountID  string       `json:"-"`
-	Token      string       `json:"-"`
-	Identifier Identifier   `json:"identifier"`
-	Status     Status       `json:"status"`
-	Challenges []*Challenge `json:"challenges"`
-	Wildcard   bool         `json:"wildcard"`
-	ExpiresAt  time.Time    `json:"expires"`
-	Error      *Error       `json:"error,omitempty"`
+	ID          string       `json:"-"`
+	AccountID   string       `json:"-"`
+	Token       string       `json:"-"`
+	Identifier  Identifier   `json:"identifier"`
+	Status      Status       `json:"status"`
+	Challenges  []*Challenge `json:"challenges"`
+	Wildcard    bool         `json:"wildcard"`
+	ExpiresAt   time.Time    `json:"expires"`
+	Fingerprint string       `json:"fingerprint,omitempty"`
+	Error       *Error       `json:"error,omitempty"`
 }
 
 // ToLog enables response logging.

--- a/acme/authorization.go
+++ b/acme/authorization.go
@@ -11,12 +11,12 @@ type Authorization struct {
 	ID          string       `json:"-"`
 	AccountID   string       `json:"-"`
 	Token       string       `json:"-"`
+	Fingerprint string       `json:"-"`
 	Identifier  Identifier   `json:"identifier"`
 	Status      Status       `json:"status"`
 	Challenges  []*Challenge `json:"challenges"`
 	Wildcard    bool         `json:"wildcard"`
 	ExpiresAt   time.Time    `json:"expires"`
-	Fingerprint string       `json:"fingerprint,omitempty"`
 	Error       *Error       `json:"error,omitempty"`
 }
 

--- a/acme/db/nosql/authz.go
+++ b/acme/db/nosql/authz.go
@@ -17,6 +17,7 @@ type dbAuthz struct {
 	Identifier   acme.Identifier `json:"identifier"`
 	Status       acme.Status     `json:"status"`
 	Token        string          `json:"token"`
+	Fingerprint  string          `json:"fingerprint,omitempty"`
 	ChallengeIDs []string        `json:"challengeIDs"`
 	Wildcard     bool            `json:"wildcard"`
 	CreatedAt    time.Time       `json:"createdAt"`
@@ -61,15 +62,16 @@ func (db *DB) GetAuthorization(ctx context.Context, id string) (*acme.Authorizat
 		}
 	}
 	return &acme.Authorization{
-		ID:         dbaz.ID,
-		AccountID:  dbaz.AccountID,
-		Identifier: dbaz.Identifier,
-		Status:     dbaz.Status,
-		Challenges: chs,
-		Wildcard:   dbaz.Wildcard,
-		ExpiresAt:  dbaz.ExpiresAt,
-		Token:      dbaz.Token,
-		Error:      dbaz.Error,
+		ID:          dbaz.ID,
+		AccountID:   dbaz.AccountID,
+		Identifier:  dbaz.Identifier,
+		Status:      dbaz.Status,
+		Challenges:  chs,
+		Wildcard:    dbaz.Wildcard,
+		ExpiresAt:   dbaz.ExpiresAt,
+		Token:       dbaz.Token,
+		Fingerprint: dbaz.Fingerprint,
+		Error:       dbaz.Error,
 	}, nil
 }
 
@@ -97,6 +99,7 @@ func (db *DB) CreateAuthorization(ctx context.Context, az *acme.Authorization) e
 		Identifier:   az.Identifier,
 		ChallengeIDs: chIDs,
 		Token:        az.Token,
+		Fingerprint:  az.Fingerprint,
 		Wildcard:     az.Wildcard,
 	}
 
@@ -111,8 +114,8 @@ func (db *DB) UpdateAuthorization(ctx context.Context, az *acme.Authorization) e
 	}
 
 	nu := old.clone()
-
 	nu.Status = az.Status
+	nu.Fingerprint = az.Fingerprint
 	nu.Error = az.Error
 	return db.save(ctx, old.ID, nu, old, "authz", authzTable)
 }
@@ -136,15 +139,16 @@ func (db *DB) GetAuthorizationsByAccountID(ctx context.Context, accountID string
 			continue
 		}
 		authzs = append(authzs, &acme.Authorization{
-			ID:         dbaz.ID,
-			AccountID:  dbaz.AccountID,
-			Identifier: dbaz.Identifier,
-			Status:     dbaz.Status,
-			Challenges: nil, // challenges not required for current use case
-			Wildcard:   dbaz.Wildcard,
-			ExpiresAt:  dbaz.ExpiresAt,
-			Token:      dbaz.Token,
-			Error:      dbaz.Error,
+			ID:          dbaz.ID,
+			AccountID:   dbaz.AccountID,
+			Identifier:  dbaz.Identifier,
+			Status:      dbaz.Status,
+			Challenges:  nil, // challenges not required for current use case
+			Wildcard:    dbaz.Wildcard,
+			ExpiresAt:   dbaz.ExpiresAt,
+			Token:       dbaz.Token,
+			Fingerprint: dbaz.Fingerprint,
+			Error:       dbaz.Error,
 		})
 	}
 

--- a/acme/db/nosql/authz_test.go
+++ b/acme/db/nosql/authz_test.go
@@ -473,6 +473,7 @@ func TestDB_UpdateAuthorization(t *testing.T) {
 		ExpiresAt:    now.Add(5 * time.Minute),
 		ChallengeIDs: []string{"foo", "bar"},
 		Wildcard:     true,
+		Fingerprint:  "fingerprint",
 	}
 	b, err := json.Marshal(dbaz)
 	assert.FatalError(t, err)
@@ -549,10 +550,11 @@ func TestDB_UpdateAuthorization(t *testing.T) {
 					{ID: "foo"},
 					{ID: "bar"},
 				},
-				Token:     dbaz.Token,
-				Wildcard:  dbaz.Wildcard,
-				ExpiresAt: dbaz.ExpiresAt,
-				Error:     acme.NewError(acme.ErrorMalformedType, "malformed"),
+				Token:       dbaz.Token,
+				Wildcard:    dbaz.Wildcard,
+				ExpiresAt:   dbaz.ExpiresAt,
+				Fingerprint: "fingerprint",
+				Error:       acme.NewError(acme.ErrorMalformedType, "malformed"),
 			}
 			return test{
 				az: updAz,
@@ -582,6 +584,7 @@ func TestDB_UpdateAuthorization(t *testing.T) {
 						assert.Equals(t, dbNew.Wildcard, dbaz.Wildcard)
 						assert.Equals(t, dbNew.CreatedAt, dbaz.CreatedAt)
 						assert.Equals(t, dbNew.ExpiresAt, dbaz.ExpiresAt)
+						assert.Equals(t, dbNew.Fingerprint, dbaz.Fingerprint)
 						assert.Equals(t, dbNew.Error.Error(), acme.NewError(acme.ErrorMalformedType, "The request message was malformed").Error())
 						return nu, true, nil
 					},

--- a/cmd/step-ca/main.go
+++ b/cmd/step-ca/main.go
@@ -52,6 +52,7 @@ var (
 func init() {
 	step.Set("Smallstep CA", Version, BuildTime)
 	authority.GlobalVersion.Version = Version
+	//nolint:staticcheck // deprecated in Go 1.20
 	rand.Seed(time.Now().UnixNano())
 	// Add support for asking passwords
 	pemutil.PromptPassword = func(msg string) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
-	github.com/aws/aws-sdk-go v1.44.185 // indirect
+	github.com/aws/aws-sdk-go v1.44.195 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0
@@ -43,7 +43,7 @@ require (
 	github.com/urfave/cli v1.22.12
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	go.step.sm/cli-utils v0.7.5
-	go.step.sm/crypto v0.23.2
+	go.step.sm/crypto v0.25.0
 	go.step.sm/linkedca v0.19.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/net v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.44.185 h1:stasiou+Ucx2A0RyXRyPph4sLCBxVQK7DPPK8tNcl5g=
-github.com/aws/aws-sdk-go v1.44.185/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.195 h1:d5xFL0N83Fpsq2LFiHgtBUHknCRUPGHdOlCWt/jtOJs=
+github.com/aws/aws-sdk-go v1.44.195/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -690,8 +690,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.step.sm/cli-utils v0.7.5 h1:jyp6X8k8mN1B0uWJydTid0C++8tQhm2kaaAdXKQQzdk=
 go.step.sm/cli-utils v0.7.5/go.mod h1:taSsY8haLmXoXM3ZkywIyRmVij/4Aj0fQbNTlJvv71I=
 go.step.sm/crypto v0.9.0/go.mod h1:+CYG05Mek1YDqi5WK0ERc6cOpKly2i/a5aZmU1sfGj0=
-go.step.sm/crypto v0.23.2 h1:XGmQH9Pkpxop47cjYlUhF10L5roPCbu1BCZXopbeW8I=
-go.step.sm/crypto v0.23.2/go.mod h1:/IXGz8al8k7u7OV0RTWIi8TRVqO2FMyZVpedV+6Da6U=
+go.step.sm/crypto v0.25.0 h1:a+7sKyozZH9B30s0dHluygxreUxI1NtCBEmuNXx7a4k=
+go.step.sm/crypto v0.25.0/go.mod h1:kr1rzO6SzeQnLm6Zu6lNtksHZLiFe9k8LolSJNhoc94=
 go.step.sm/linkedca v0.19.0 h1:xuagkR35wrJI2gnu6FAM+q3VmjwsHScvGcJsfZ0GdsI=
 go.step.sm/linkedca v0.19.0/go.mod h1:b7vWPrHfYLEOTSUZitFEcztVCpTc+ileIN85CwEAluM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
### Description

This commit ensures that the attestation certificate key matches the key used on the CSR on an ACME device attestation flow.
