### PR TITLE
Mark the IDP critical in the generated CRL data.

### DIFF
--- a/authority/tls.go
+++ b/authority/tls.go
@@ -786,7 +786,7 @@ func (a *Authority) GenerateCertificateRevocationList() error {
 	// Note that this is currently using the port 443 by default.
 	if b, err := marshalDistributionPoint(fullName, false); err == nil {
 		revocationList.ExtraExtensions = []pkix.Extension{
-			{Id: oidExtensionIssuingDistributionPoint, Value: b},
+			{Id: oidExtensionIssuingDistributionPoint, Critical: true, Value: b},
 		}
 	}
 


### PR DESCRIPTION
Trying to get CRL to work on my environment I've been reading up on [RFC5280](https://www.rfc-editor.org/rfc/rfc5280#section-5.2.5) ... and the IDP to be marked as `Critical`. I hope I'm correct and that my understanding on how to mark the IDP is critical. Looking at e.g. `https://github.com/smallstep/crypto/blob/3470b1ec576bc912e80ac6c65a495934d4fcc585/x509util/extensions_test.go#L48` makes me think so.

Using `step crl inspect URI/1.0/crl --insecure` I get:

```text
Certificate Revocation List (CRL):
    Data:
        Valid: false
        Version: 2 (0x1)
    Signature algorithm: ECDSA-SHA256
        Issuer: .... Intermediate CA
        Last Update: 2023-02-24 19:35:59 +0000 UTC
        Next Update: 2023-02-25 19:35:59 +0000 UTC
        CRL Extensions:
            X509v3 Authority Key Identifier:
                keyid:24:3A:FD:A9:26:F2:44:85:5C:28:3E:9A:75:BD:D5:99:39:A4:69:82
            X509v3 CRL Number:
                194
            X509v3 Issuing Distribution Point:
                Full Name:
                    URI:http://URI/1.0/crl
                Only User Certificates
        No Revoked Certificates.
    Signature Algorithm: ECDSA-SHA256
        30:46:02:21:00:94:0a:df:0e:5b:e7:f0:74:a5:1a:16:
        42:36:cf:a9:fc:7d:78:39:9d:93:be:34:e3:a3:fc:f7:
        ab:54:b9:23:0e:02:21:00:f0:28:8e:32:75:7f:61:6d:
        01:a1:e7:2c:5f:4a:29:bc:1f:68:74:e0:ad:58:4a:44:
        de:c2:62:64:db:36:40:53
```

As it can be seen `X509v3 Issuing Distribution Point:` is **NOT** marked as `Critical` like so: `X509v3 Issuing Distribution Point: critical`

E.g. run `step crl inspect http://crl.starfieldtech.com/sfig2s1-408.crl --insecure | more` and you'll see the issuing distribution point marked as critical. This on the CRL setup that https://www.rfc-editor.org/rfc/rfc5280 uses.

---

Hopefully the above change - if accepted - can get CRL's to work on my environment. If not we're at least one step closer.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: Fix IDP not marked as critical

#### Pain or issue this feature alleviates: CRL not working on my environment because of this. At least CRL's can't be verified and I believe this is part of it.

#### Is there documentation on how to use this feature? If so, where? No extra documentation needed here I would say.

#### In what environments or workflows is this feature supported? It's a bugfix

#### In what environments or workflows is this feature explicitly NOT supported (if any)? Don't believe so.

💔Thank you!
