### PR TITLE
Update Dockerfile.hsm to use debian:bullseye base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: smallstep/step-ca
-      DOCKER_IMAGE_HSM: smallstep/step-ca-hsm
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}
       is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
@@ -38,12 +37,12 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
-          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_IMAGE_HSM }}:${VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_IMAGE }}:${VERSION}-hsm" >> ${GITHUB_ENV}
       - name: Add Latest Tag
         if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
         run: |
           echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
-          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_TAGS_HSM }},${{ env.DOCKER_IMAGE_HSM }}:latest" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_HSM=${{ env.DOCKER_TAGS_HSM }},${{ env.DOCKER_IMAGE }}:hsm" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache curl git make
 RUN make V=1 download
 RUN make V=1 bin/step-ca
 
-FROM smallstep/step-kms-plugin-cloud:latest AS kms
+FROM smallstep/step-kms-plugin:cloud AS kms
 
 FROM smallstep/step-cli:latest
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:alpine AS builder
 WORKDIR /src
 COPY . .
 
-RUN apk add --no-cache curl git make
-RUN make V=1 download
+RUN apk add --no-cache curl git make libcap
 RUN make V=1 bin/step-ca
+RUN setcap CAP_NET_BIND_SERVICE=+eip bin/step-ca
 
 FROM smallstep/step-kms-plugin:cloud AS kms
 
@@ -14,8 +14,6 @@ FROM smallstep/step-cli:latest
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
-USER root
-RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
 USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -6,8 +6,9 @@ COPY . .
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
         gcc pkgconf libpcsclite-dev
-RUN make V=1 download
-RUN make V=1 GOFLAGS="" build
+RUN make V=1 GOFLAGS="" bin/step-ca
+RUN apt-get install -y --no-install-recommends libcap2-bin && \
+    setcap CAP_NET_BIND_SERVICE=+eip bin/step-ca
 
 FROM smallstep/step-kms-plugin:bullseye AS kms
 
@@ -18,8 +19,6 @@ COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends libcap2-bin && \
-    setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
 RUN apt-get install -y --no-install-recommends pcscd libpcsclite1
 RUN mkdir -p /run/pcscd
 RUN chown step:step /run/pcscd

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -5,10 +5,9 @@ COPY . .
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-        gcc pkgconf libpcsclite-dev
+        gcc pkgconf libpcsclite-dev libcap2-bin
 RUN make V=1 GOFLAGS="" bin/step-ca
-RUN apt-get install -y --no-install-recommends libcap2-bin && \
-    setcap CAP_NET_BIND_SERVICE=+eip bin/step-ca
+RUN setcap CAP_NET_BIND_SERVICE=+eip bin/step-ca
 
 FROM smallstep/step-kms-plugin:bullseye AS kms
 

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -17,6 +17,7 @@ COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
+RUN apt-get update
 RUN apt-get install -y --no-install-recommends libcap2-bin && \
     setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
 RUN apt-get install -y --no-install-recommends pcscd libpcsclite1

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -1,23 +1,25 @@
-FROM golang:alpine AS builder
+FROM golang AS builder
 
 WORKDIR /src
 COPY . .
 
-RUN apk add --no-cache curl git make
-RUN apk add --no-cache gcc musl-dev pkgconf pcsc-lite-dev
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+        gcc pkgconf libpcsclite-dev
 RUN make V=1 download
 RUN make V=1 GOFLAGS="" build
 
-FROM smallstep/step-kms-plugin:latest AS kms
+FROM smallstep/step-kms-plugin:debian AS kms
 
-FROM smallstep/step-cli:latest
+FROM smallstep/step-cli:debian
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
-RUN apk add --no-cache libcap && setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
-RUN apk add --no-cache pcsc-lite pcsc-lite-libs
+RUN apt-get install -y --no-install-recommends libcap2-bin && \
+    setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/step-ca
+RUN apt-get install -y --no-install-recommends pcscd libpcsclite1
 RUN mkdir -p /run/pcscd
 RUN chown step:step /run/pcscd
 USER step

--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -9,9 +9,9 @@ RUN apt-get install -y --no-install-recommends \
 RUN make V=1 download
 RUN make V=1 GOFLAGS="" build
 
-FROM smallstep/step-kms-plugin:debian AS kms
+FROM smallstep/step-kms-plugin:bullseye AS kms
 
-FROM smallstep/step-cli:debian
+FROM smallstep/step-cli:bullseye
 
 COPY --from=builder /src/bin/step-ca /usr/local/bin/step-ca
 COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin


### PR DESCRIPTION
- [x] update Docker.hsm to use Debian
- [x] Deprecate the `step-ca-hsm` image in favor of `step-ca:hsm`

To merge & release this PR:

- [ ] Publish cli "bullseye" image _before_ merging this
- [ ] Publish step-kms-plugin "bullseye" image _before_ merging this
- [ ] Publish step-kms-plugin "cloud" image tag _before_ merging this
- [ ] Post-release: Update Docker Hub readmes to explain new tags

Related:
- https://github.com/smallstep/step-kms-plugin/pull/47
- https://github.com/smallstep/cli/pull/861

fixes #1286 