### PR TITLE
Add identity token issuance for all Azure cloud environments

### DIFF
--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -166,6 +166,8 @@ func TestAzure_GetIdentityToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// reset environment between tests to avoid caching issues
+			p1.environment = ""
 			tt.azure.config.identityTokenURL = tt.identityTokenURL + "?want_resource=" + azureEnvironments[tt.wantEnvironment]
 			tt.azure.config.instanceComputeURL = tt.instanceComputeURL + "/" + tt.wantEnvironment
 			got, err := tt.azure.GetIdentityToken(tt.args.subject, tt.args.caURL)

--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -100,7 +100,14 @@ func TestAzure_GetIdentityToken(t *testing.T) {
 		time.Now(), &p1.keyStore.keySet.Keys[0])
 	assert.FatalError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srvIdentity := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantResource := r.URL.Query().Get("want_resource")
+		resource := r.URL.Query().Get("resource")
+		if wantResource == "" || resource != wantResource {
+			http.Error(w, fmt.Sprintf("Azure query param resource = %s, wantResource %s", resource, wantResource), http.StatusBadRequest)
+			return
+		}
+
 		switch r.URL.Path {
 		case "/bad-request":
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
@@ -111,29 +118,56 @@ func TestAzure_GetIdentityToken(t *testing.T) {
 			fmt.Fprintf(w, `{"access_token":"%s"}`, t1)
 		}
 	}))
-	defer srv.Close()
+	defer srvIdentity.Close()
+
+	srvInstance := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/bad-request":
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		case "/AzureChinaCloud":
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte("AzureChinaCloud"))
+		case "/AzureGermanCloud":
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte("AzureGermanCloud"))
+		case "/AzureUSGovernmentCloud":
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte("AzureUSGovernmentCloud"))
+		default:
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte("AzurePublicCloud"))
+		}
+	}))
+	defer srvInstance.Close()
 
 	type args struct {
 		subject string
 		caURL   string
 	}
 	tests := []struct {
-		name             string
-		azure            *Azure
-		args             args
-		identityTokenURL string
-		want             string
-		wantErr          bool
+		name               string
+		azure              *Azure
+		args               args
+		identityTokenURL   string
+		instanceComputeURL string
+		wantEnvironment    string
+		want               string
+		wantErr            bool
 	}{
-		{"ok", p1, args{"subject", "caURL"}, srv.URL, t1, false},
-		{"fail request", p1, args{"subject", "caURL"}, srv.URL + "/bad-request", "", true},
-		{"fail unmarshal", p1, args{"subject", "caURL"}, srv.URL + "/bad-json", "", true},
-		{"fail url", p1, args{"subject", "caURL"}, "://ca.smallstep.com", "", true},
-		{"fail connect", p1, args{"subject", "caURL"}, "foobarzar", "", true},
+		{"ok", p1, args{"subject", "caURL"}, srvIdentity.URL, srvInstance.URL, "AzurePublicCloud", t1, false},
+		{"ok azure china", p1, args{"subject", "caURL"}, srvIdentity.URL, srvInstance.URL, "AzurePublicCloud", t1, false},
+		{"ok azure germany", p1, args{"subject", "caURL"}, srvIdentity.URL, srvInstance.URL, "AzureGermanCloud", t1, false},
+		{"ok azure us gov", p1, args{"subject", "caURL"}, srvIdentity.URL, srvInstance.URL, "AzureUSGovernmentCloud", t1, false},
+		{"fail instance request", p1, args{"subject", "caURL"}, srvIdentity.URL + "/bad-request", srvInstance.URL + "/bad-request", "AzurePublicCloud", "", true},
+		{"fail request", p1, args{"subject", "caURL"}, srvIdentity.URL + "/bad-request", srvInstance.URL, "AzurePublicCloud", "", true},
+		{"fail unmarshal", p1, args{"subject", "caURL"}, srvIdentity.URL + "/bad-json", srvInstance.URL, "AzurePublicCloud", "", true},
+		{"fail url", p1, args{"subject", "caURL"}, "://ca.smallstep.com", srvInstance.URL, "AzurePublicCloud", "", true},
+		{"fail connect", p1, args{"subject", "caURL"}, "foobarzar", srvInstance.URL, "AzurePublicCloud", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.azure.config.identityTokenURL = tt.identityTokenURL
+			tt.azure.config.identityTokenURL = tt.identityTokenURL + "?want_resource=" + azureEnvironments[tt.wantEnvironment]
+			tt.azure.config.instanceComputeURL = tt.instanceComputeURL + "/" + tt.wantEnvironment
 			got, err := tt.azure.GetIdentityToken(tt.args.subject, tt.args.caURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Azure.GetIdentityToken() error = %v, wantErr %v", err, tt.wantErr)

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -665,6 +665,9 @@ func generateAzureWithServer() (*Azure, *httptest.Server, error) {
 					AccessToken: tok,
 				})
 			}
+		case "/metadata/instance/compute/azEnvironment":
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte("AzurePublicCloud"))
 		default:
 			http.NotFound(w, r)
 		}
@@ -672,6 +675,7 @@ func generateAzureWithServer() (*Azure, *httptest.Server, error) {
 	srv.Start()
 	az.config.oidcDiscoveryURL = srv.URL + "/" + az.TenantID + "/.well-known/openid-configuration"
 	az.config.identityTokenURL = srv.URL + "/metadata/identity/oauth2/token"
+	az.config.instanceComputeURL = srv.URL + "/metadata/instance/compute/azEnvironment"
 	return az, srv, nil
 }
 


### PR DESCRIPTION
#### Name of feature: 
Support issuing identity token for all Azure cloud environments (Public, China, German and US Gov)

#### Pain or issue this feature alleviates:
When step-cli (which will need a go.mod update) issues an identity token from an Azure virtual machine, if the virtual machine runs in an Azure cloud different from "Public", the token issuance fails due to using an incorrect identity URL. This PR addresses this issue by doing a lookup into the IMDS API to fetch the current instance/virtual machine environment and sub-sequently set the resource query parameter to the correct resource URL.

#### Why is this important to the project (if not answered above):
Provides greater support for more environment.

#### Is there documentation on how to use this feature? If so, where?
No as there is no external configuration change needed for this feature

#### In what environments or workflows is this feature supported?
For Azure provisioner only

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:
List of all environments:
https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=windows#sample-5-get-the-azure-environment-where-the-vm-is-running

Environments and endpoints from Go SDK:
https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L95

