### PR TITLE
Add `/crl` and `/1.0/crl` to the insecure HTTP handler

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -336,7 +336,7 @@ func (ca *CA) shouldServeInsecureServer() bool {
 		return false
 	case ca.shouldServeSCEPEndpoints():
 		return true
-	case ca.config.CRL != nil && ca.config.CRL.Enabled:
+	case ca.config.CRL.IsEnabled():
 		return true
 	default:
 		return false


### PR DESCRIPTION
In addition to being served over HTTPS, the `/crl` and `/1.0/crl` endpoints are now also served on the HTTP server if the `insecureAddress` has been configured. This should help users that currently have to use workarounds to get this to work in certain scenarios.

Related issues:
- https://github.com/smallstep/certificates/issues/1284 
- https://github.com/smallstep/certificates/issues/206#issuecomment-1530219201