### PR TITLE
Do not render CRLs in memory

### DIFF
--- a/api/crl.go
+++ b/api/crl.go
@@ -17,13 +17,13 @@ func CRL(w http.ResponseWriter, r *http.Request) {
 
 	_, formatAsPEM := r.URL.Query()["pem"]
 	if formatAsPEM {
-		pemBytes := pem.EncodeToMemory(&pem.Block{
+		w.Header().Add("Content-Type", "application/x-pem-file")
+		w.Header().Add("Content-Disposition", "attachment; filename=\"crl.pem\"")
+
+		_ = pem.Encode(w, &pem.Block{
 			Type:  "X509 CRL",
 			Bytes: crlBytes,
 		})
-		w.Header().Add("Content-Type", "application/x-pem-file")
-		w.Header().Add("Content-Disposition", "attachment; filename=\"crl.pem\"")
-		w.Write(pemBytes)
 	} else {
 		w.Header().Add("Content-Type", "application/pkix-crl")
 		w.Header().Add("Content-Disposition", "attachment; filename=\"crl.der\"")


### PR DESCRIPTION
This PR refactors the way PEM-encoded CRLs are served so that they're directly rendered into the underlying `http.ResponseWriter`.