### PR TITLE
Log SSH certificates

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/dsa" //nolint:staticcheck // support legacy algorithms
@@ -20,6 +21,8 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/pkg/errors"
+	"go.step.sm/crypto/sshutil"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/smallstep/certificates/api/log"
 	"github.com/smallstep/certificates/api/render"
@@ -469,7 +472,7 @@ func logOtt(w http.ResponseWriter, token string) {
 	}
 }
 
-// LogCertificate add certificate fields to the log message.
+// LogCertificate adds certificate fields to the log message.
 func LogCertificate(w http.ResponseWriter, cert *x509.Certificate) {
 	if rl, ok := w.(logging.ResponseLogger); ok {
 		m := map[string]interface{}{
@@ -496,6 +499,30 @@ func LogCertificate(w http.ResponseWriter, cert *x509.Certificate) {
 				m["provisioner"] = string(val.Name)
 			}
 			break
+		}
+		rl.WithFields(m)
+	}
+}
+
+// LogSSHCertificate adds SSH certificate fields to the log message.
+func LogSSHCertificate(w http.ResponseWriter, cert *ssh.Certificate) {
+	if rl, ok := w.(logging.ResponseLogger); ok {
+		mak := bytes.TrimSpace(ssh.MarshalAuthorizedKey(cert))
+		certType := "user"
+		if cert.CertType == ssh.HostCert {
+			certType = "host"
+		}
+		m := map[string]interface{}{
+			"serial":           cert.Serial,
+			"principals":       cert.ValidPrincipals,
+			"valid-from":       time.Unix(int64(cert.ValidAfter), 0).Format(time.RFC3339),
+			"valid-to":         time.Unix(int64(cert.ValidBefore), 0).Format(time.RFC3339),
+			"certificate":      string(mak),
+			"certificate-type": certType,
+		}
+		fingerprint, err := sshutil.FormatFingerprint(mak, sshutil.DefaultFingerprint)
+		if err == nil {
+			m["public-key"] = fingerprint
 		}
 		rl.WithFields(m)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1680,9 +1680,9 @@ func TestLogSSHCertificate(t *testing.T) {
 	fields := rl.Fields()
 	sassert.Equal(t, uint64(14376510277651266987), fields["serial"])
 	sassert.Equal(t, []string{"herman"}, fields["principals"])
-	sassert.Equal(t, "user", fields["certificate-type"])
+	sassert.Equal(t, "ecdsa-sha2-nistp256-cert-v01@openssh.com user certificate", fields["certificate-type"])
 	sassert.Equal(t, time.Unix(1674129191, 0).Format(time.RFC3339), fields["valid-from"])
 	sassert.Equal(t, time.Unix(1674186851, 0).Format(time.RFC3339), fields["valid-to"])
-	sassert.Equal(t, "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgLnkvSk4odlo3b1R+RDw+LmorL3RkN354IilCIVFVen4AAAAIbmlzdHAyNTYAAABBBHjKHss8WM2ffMYlavisoLXR0I6UEIU+cidV1ogEH1U6+/SYaFPrlzQo0tGLM5CNkMbhInbyasQsrHzn8F1Rt7nHg5/tcSf9qwAAAAEAAAAGaGVybWFuAAAACgAAAAZoZXJtYW4AAAAAY8kvJwAAAABjyhBjAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAGgAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAAhuaXN0cDI1NgAAAEEE/ayqpPrZZF5uA1UlDt4FreTf15agztQIzpxnWq/XoxAHzagRSkFGkdgFpjgsfiRpP8URHH3BZScqc0ZDCTxhoQAAAGQAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAEkAAAAhAJuP1wCVwoyrKrEtHGfFXrVbRHySDjvXtS1tVTdHyqymAAAAIBa/CSSzfZb4D2NLP+eEmOOMJwSjYOiNM8fiOoAaqglI", fields["certificate"])
-	sassert.Equal(t, "256 SHA256:RvkDPGwl/G9d7LUFm1kmWhvOD9I/moPq4yxcb0STwr0 no comment (ECDSA-CERT)", fields["public-key"])
+	sassert.Equal(t, "AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgLnkvSk4odlo3b1R+RDw+LmorL3RkN354IilCIVFVen4AAAAIbmlzdHAyNTYAAABBBHjKHss8WM2ffMYlavisoLXR0I6UEIU+cidV1ogEH1U6+/SYaFPrlzQo0tGLM5CNkMbhInbyasQsrHzn8F1Rt7nHg5/tcSf9qwAAAAEAAAAGaGVybWFuAAAACgAAAAZoZXJtYW4AAAAAY8kvJwAAAABjyhBjAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAGgAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAAhuaXN0cDI1NgAAAEEE/ayqpPrZZF5uA1UlDt4FreTf15agztQIzpxnWq/XoxAHzagRSkFGkdgFpjgsfiRpP8URHH3BZScqc0ZDCTxhoQAAAGQAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAEkAAAAhAJuP1wCVwoyrKrEtHGfFXrVbRHySDjvXtS1tVTdHyqymAAAAIBa/CSSzfZb4D2NLP+eEmOOMJwSjYOiNM8fiOoAaqglI", fields["certificate"])
+	sassert.Equal(t, "SHA256:RvkDPGwl/G9d7LUFm1kmWhvOD9I/moPq4yxcb0STwr0 (ECDSA-CERT)", fields["public-key"])
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1681,8 +1681,8 @@ func TestLogSSHCertificate(t *testing.T) {
 	sassert.Equal(t, uint64(14376510277651266987), fields["serial"])
 	sassert.Equal(t, []string{"herman"}, fields["principals"])
 	sassert.Equal(t, "user", fields["certificate-type"])
-	sassert.Equal(t, "2023-01-19T12:53:11+01:00", fields["valid-from"])
-	sassert.Equal(t, "2023-01-20T04:54:11+01:00", fields["valid-to"])
+	sassert.Equal(t, time.Unix(1674129191, 0).Format(time.RFC3339), fields["valid-from"])
+	sassert.Equal(t, time.Unix(1674186851, 0).Format(time.RFC3339), fields["valid-to"])
 	sassert.Equal(t, "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgLnkvSk4odlo3b1R+RDw+LmorL3RkN354IilCIVFVen4AAAAIbmlzdHAyNTYAAABBBHjKHss8WM2ffMYlavisoLXR0I6UEIU+cidV1ogEH1U6+/SYaFPrlzQo0tGLM5CNkMbhInbyasQsrHzn8F1Rt7nHg5/tcSf9qwAAAAEAAAAGaGVybWFuAAAACgAAAAZoZXJtYW4AAAAAY8kvJwAAAABjyhBjAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAGgAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAAhuaXN0cDI1NgAAAEEE/ayqpPrZZF5uA1UlDt4FreTf15agztQIzpxnWq/XoxAHzagRSkFGkdgFpjgsfiRpP8URHH3BZScqc0ZDCTxhoQAAAGQAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAEkAAAAhAJuP1wCVwoyrKrEtHGfFXrVbRHySDjvXtS1tVTdHyqymAAAAIBa/CSSzfZb4D2NLP+eEmOOMJwSjYOiNM8fiOoAaqglI", fields["certificate"])
 	sassert.Equal(t, "256 SHA256:RvkDPGwl/G9d7LUFm1kmWhvOD9I/moPq4yxcb0STwr0 no comment (ECDSA-CERT)", fields["public-key"])
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -29,13 +29,14 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/pkg/errors"
 	sassert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.step.sm/crypto/jose"
+	"go.step.sm/crypto/x509util"
 	"golang.org/x/crypto/ssh"
 	squarejose "gopkg.in/square/go-jose.v2"
 
-	"go.step.sm/crypto/jose"
-	"go.step.sm/crypto/x509util"
-
 	"github.com/smallstep/assert"
+
 	"github.com/smallstep/certificates/authority"
 	"github.com/smallstep/certificates/authority/provisioner"
 	"github.com/smallstep/certificates/errs"
@@ -1656,4 +1657,32 @@ func TestProvisionersResponse_MarshalJSON(t *testing.T) {
 
 	// MarshalJSON must not affect the struct properties itself
 	sassert.Equal(t, expList, r.Provisioners)
+}
+
+const (
+	fixtureECDSACertificate = `ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgLnkvSk4odlo3b1R+RDw+LmorL3RkN354IilCIVFVen4AAAAIbmlzdHAyNTYAAABBBHjKHss8WM2ffMYlavisoLXR0I6UEIU+cidV1ogEH1U6+/SYaFPrlzQo0tGLM5CNkMbhInbyasQsrHzn8F1Rt7nHg5/tcSf9qwAAAAEAAAAGaGVybWFuAAAACgAAAAZoZXJtYW4AAAAAY8kvJwAAAABjyhBjAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAGgAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAAhuaXN0cDI1NgAAAEEE/ayqpPrZZF5uA1UlDt4FreTf15agztQIzpxnWq/XoxAHzagRSkFGkdgFpjgsfiRpP8URHH3BZScqc0ZDCTxhoQAAAGQAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAEkAAAAhAJuP1wCVwoyrKrEtHGfFXrVbRHySDjvXtS1tVTdHyqymAAAAIBa/CSSzfZb4D2NLP+eEmOOMJwSjYOiNM8fiOoAaqglI herman`
+)
+
+func TestLogSSHCertificate(t *testing.T) {
+
+	out, _, _, _, err := ssh.ParseAuthorizedKey([]byte(fixtureECDSACertificate))
+	require.NoError(t, err)
+
+	cert, ok := out.(*ssh.Certificate)
+	require.True(t, ok)
+
+	w := httptest.NewRecorder()
+	rl := logging.NewResponseLogger(w)
+	LogSSHCertificate(rl, cert)
+
+	sassert.Equal(t, 200, w.Result().StatusCode)
+
+	fields := rl.Fields()
+	sassert.Equal(t, uint64(14376510277651266987), fields["serial"])
+	sassert.Equal(t, []string{"herman"}, fields["principals"])
+	sassert.Equal(t, "user", fields["certificate-type"])
+	sassert.Equal(t, "2023-01-19T12:53:11+01:00", fields["valid-from"])
+	sassert.Equal(t, "2023-01-20T04:54:11+01:00", fields["valid-to"])
+	sassert.Equal(t, "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgLnkvSk4odlo3b1R+RDw+LmorL3RkN354IilCIVFVen4AAAAIbmlzdHAyNTYAAABBBHjKHss8WM2ffMYlavisoLXR0I6UEIU+cidV1ogEH1U6+/SYaFPrlzQo0tGLM5CNkMbhInbyasQsrHzn8F1Rt7nHg5/tcSf9qwAAAAEAAAAGaGVybWFuAAAACgAAAAZoZXJtYW4AAAAAY8kvJwAAAABjyhBjAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAGgAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAAhuaXN0cDI1NgAAAEEE/ayqpPrZZF5uA1UlDt4FreTf15agztQIzpxnWq/XoxAHzagRSkFGkdgFpjgsfiRpP8URHH3BZScqc0ZDCTxhoQAAAGQAAAATZWNkc2Etc2hhMi1uaXN0cDI1NgAAAEkAAAAhAJuP1wCVwoyrKrEtHGfFXrVbRHySDjvXtS1tVTdHyqymAAAAIBa/CSSzfZb4D2NLP+eEmOOMJwSjYOiNM8fiOoAaqglI", fields["certificate"])
+	sassert.Equal(t, "256 SHA256:RvkDPGwl/G9d7LUFm1kmWhvOD9I/moPq4yxcb0STwr0 no comment (ECDSA-CERT)", fields["public-key"])
 }

--- a/api/sign.go
+++ b/api/sign.go
@@ -88,6 +88,7 @@ func Sign(w http.ResponseWriter, r *http.Request) {
 	if len(certChainPEM) > 1 {
 		caPEM = certChainPEM[1]
 	}
+
 	LogCertificate(w, certChain[0])
 	render.JSONStatus(w, &SignResponse{
 		ServerPEM:    certChainPEM[0],

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -337,7 +337,7 @@ func SSHSign(w http.ResponseWriter, r *http.Request) {
 		}
 		identityCertificate = certChainToPEM(certChain)
 	}
-
+	LogSSHCertificate(w, cert)
 	render.JSONStatus(w, &SSHSignResponse{
 		Certificate:         SSHCertificate{cert},
 		AddUserCertificate:  addUserCertificate,

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -337,6 +337,7 @@ func SSHSign(w http.ResponseWriter, r *http.Request) {
 		}
 		identityCertificate = certChainToPEM(certChain)
 	}
+
 	LogSSHCertificate(w, cert)
 	render.JSONStatus(w, &SSHSignResponse{
 		Certificate:         SSHCertificate{cert},

--- a/api/sshRekey.go
+++ b/api/sshRekey.go
@@ -89,6 +89,7 @@ func SSHRekey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	LogSSHCertificate(w, newCert)
 	render.JSONStatus(w, &SSHRekeyResponse{
 		Certificate:         SSHCertificate{newCert},
 		IdentityCertificate: identity,

--- a/api/sshRenew.go
+++ b/api/sshRenew.go
@@ -81,6 +81,7 @@ func SSHRenew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	LogSSHCertificate(w, newCert)
 	render.JSONStatus(w, &SSHSignResponse{
 		Certificate:         SSHCertificate{newCert},
 		IdentityCertificate: identity,


### PR DESCRIPTION
This PR closes #1257 

A log looks like this:

```console
INFO[0015] 
certificate="ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2Vyd.......EpFTvWiOGbbCSb7WLd68HQU=" 
certificate-type=user 
duration=1.622708ms 
duration-ns=1622708 
fields.time="2023-05-04T15:30:42+02:00" 
method=POST 
name=ca 
ott=eyJhbGciOiJFUzI1NiIsImtpZCI6IlJ.....O9tewjVFtNfQ 
path=/ssh/sign 
principals="[newpub new.pub]" 
protocol=HTTP/2.0 
public-key="256 SHA256:vgL0C7eN7RtGK0b2r7Ptpoig8fokQqUwLcONsZ/m/ao no comment (ECDSA-CERT)" 
referer= 
remote-address=127.0.0.1 
request-id=ch9r70lroa2scelp5gg0 
serial=8612232055386440238 
size=783 
status=201 
user-agent="Smallstep CLI/0000000-dev (darwin/arm64)" 
user-id= 
valid-from="2023-05-04T15:29:42+02:00" 
valid-to="2023-05-05T07:30:42+02:00"
```

The `certificate` can be used as the input for `step ssh inspect` via STDIN directly:

```console
echo "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12.........WiOGbbCSb7WLd68HQU=" | step ssh inspect

        Type: ecdsa-sha2-nistp256-cert-v01@openssh.com user certificate
        Public key: ECDSA-CERT SHA256:vgL0C7eN7RtGK0b2r7Ptpoig8fokQqUwLcONsZ/m/ao
        Signing CA: ECDSA SHA256:voxCttks8QgK6m08l5IpbiyCiQ5F9/6RbaKHvk1CWaA (using ecdsa-sha2-nistp256)
        Key ID: "new.pub"
        Serial: 8612232055386440238
        Valid: from 2023-05-04T15:29:42 to 2023-05-05T07:30:42
        Principals:
                newpub
                new.pub
        Critical Options: (none)
        Extensions:
                permit-user-rc
                permit-X11-forwarding
                permit-agent-forwarding
                permit-port-forwarding
                permit-pty
        Signature:
                00:00:00:20:21:80:cb:2e:c7:7e:71:ec:18:4f:32:34:
                99:58:f8:2a:2f:a7:91:fd:81:9f:a6:d7:80:00:ee:ea:
                b9:c5:80:ac:00:00:00:20:3b:21:92:40:95:b5:1c:c6:
                b2:66:73:d7:8b:56:ac:12:91:53:bd:68:8e:19:b6:c2:
                49:be:d6:2d:de:bc:1d:05
```

The latter also works without the `ecdsa-sha2-nistp256-cert-v01@openssh.com` prefixed, so we could remove that from the `certificate` field? Then we could add that to the `certificate-type` field, so that its output becomes more similar to the `Public key` in the certificate inspect output. The output for the `public-key` could also be made to look more like inspect output. Do we want the `comment` to be in the `certificate` field too? The CLI appends this when writing the certificate to disk and uses the "subject" for that. Thoughts?