### PR TITLE
Use vaultcas ttl as a duration string

### DIFF
--- a/cas/vaultcas/vaultcas.go
+++ b/cas/vaultcas/vaultcas.go
@@ -215,7 +215,7 @@ func (v *VaultCAS) createCertificate(cr *x509.CertificateRequest, lifetime time.
 			Bytes: cr.Raw,
 		})),
 		"format": "pem_bundle",
-		"ttl":    lifetime.Seconds(),
+		"ttl":    lifetime.String(),
 	}
 
 	secret, err := v.client.Logical().Write(v.config.PKIMountPath+"/sign/"+vaultPKIRole, vaultReq)


### PR DESCRIPTION
### Description

According to docs at https://developer.hashicorp.com/vault/api-docs/secret/pki#ttl the ttl can be sent as a time.Duration string.

Fixes #1375
