### PR TITLE
Add DOCKER_STEPCA_INIT_PASSWORD_FILE variable for Docker secrets

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,7 +46,10 @@ function step_ca_init () {
         --provisioner-password-file "${STEPPATH}/provisioner_password"
         --address "${DOCKER_STEPCA_INIT_ADDRESS}"
     )
-    if [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
+    if [ -n "${DOCKER_STEPCA_INIT_PASSWORD_FILE}" ]; then
+        cat < "${DOCKER_STEPCA_INIT_PASSWORD_FILE}" > "${STEPPATH}/password"
+        cat < "${DOCKER_STEPCA_INIT_PASSWORD_FILE}" > "${STEPPATH}/provisioner_password"
+    elif [ -n "${DOCKER_STEPCA_INIT_PASSWORD}" ]; then
         echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/password"
         echo "${DOCKER_STEPCA_INIT_PASSWORD}" > "${STEPPATH}/provisioner_password"
     else


### PR DESCRIPTION
Add the management of the DOCKER_STEPCA_INIT_PASSWORD_FILE variable.  over DOCKER_STEPCA_INIT_PASSWORD. If both are used only DOCKER_STEPCA_INIT_PASSWORD_FILE will be used.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Add DOCKER_STEPCA_INIT_PASSWORD_FILE variable for Docker secrets
#### Pain or issue this feature alleviates:
Allow the possibility to use Docker Secrets for step-ca init password
#### Why is this important to the project (if not answered above):
This allow to use a predefined password with having to use enviromental variables
#### Is there documentation on how to use this feature? If so, where?
I can do it, but I don't know where in this repo
#### In what environments or workflows is this feature supported?
Docker
#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
