### PR TITLE
Add namespace field to VaultCAS JSON config

### DIFF
--- a/cas/vaultcas/vaultcas.go
+++ b/cas/vaultcas/vaultcas.go
@@ -37,6 +37,7 @@ type VaultOptions struct {
 	PKIRoleEd25519 string          `json:"pkiRoleEd25519,omitempty"`
 	AuthType       string          `json:"authType,omitempty"`
 	AuthMountPath  string          `json:"authMountPath,omitempty"`
+	Namespace      string          `json:"namespace,omitempty"`
 	AuthOptions    json.RawMessage `json:"authOptions,omitempty"`
 }
 
@@ -88,6 +89,10 @@ func New(ctx context.Context, opts apiv1.Options) (*VaultCAS, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to configure %s auth method: %w", vc.AuthType, err)
+	}
+
+	if vc.Namespace != "" {
+		client.SetNamespace(vc.Namespace)
 	}
 
 	authInfo, err := client.Auth().Login(ctx, method)


### PR DESCRIPTION
#### Name of feature:
Add optional use of namespaces to VaultCAS

#### Pain or issue this feature alleviates:
Currently, using step-ca as a Registration Authority downstream from Vault (https://smallstep.com/docs/step-ca/registration-authority-ra-mode/#5-configure-the-ra-server) does not allow for using the namespaces feature of Vault Enterprise. Specifically, proper approle authentication with Vault can't occur because there is no way to include the `X-Vault-Namespace` header. Vault's API client that step-ca uses includes a function to set the namespace: https://github.com/hashicorp/vault/blob/main/api/client.go#L949-L955. The optional use of this function is all this PR adds.

(Side note: A workaround for tne absence of the header this would be to include the namespace in the path; however, this doesn't work because when the `authMountPath` field is used, the path is improperly constructed. If the namespace is `my/custom/path` and `ca.json` includes `"authMountPath": "my/custom/path/approle"`, step-ca tries to authenticate against https://some-vault-instance.com/v1/auth/my/custom/path/approle/login rather than the correct https://some-vault-instance.com/v1/my/custom/path/auth/approle/login. Because step-ca uses Hashicorp's Vault library, it seems to me that this would be more difficult to fix than my namespace fix provided here.)

#### Why is this important to the project (if not answered above):
It's important because many companies use Vault Enterprise with namespaces.

#### Is there documentation on how to use this feature? If so, where?
https://github.com/smallstep/docs/pull/245/files

#### In what environments or workflows is this feature supported?
This is used when using step-ca in Registration Authority mode with Vault and approle authentication. It's not relevant to nor has impact on anything else.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A

#### Supporting links/other PRs/issues:
https://discord.com/channels/837031272227930163/841249977699401759/1115741417294274612

💔Thank you!
