### PR TITLE
Fix TPM simulator initialization for tests

### DIFF
--- a/acme/challenge_tpmsimulator_test.go
+++ b/acme/challenge_tpmsimulator_test.go
@@ -49,8 +49,9 @@ func withSimulator(t *testing.T) tpm.NewTPMOption {
 		err := sim.Close()
 		require.NoError(t, err)
 	})
-	sim = simulator.New()
-	err := sim.Open()
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	err = sim.Open()
 	require.NoError(t, err)
 	return tpm.WithSimulator(sim)
 }


### PR DESCRIPTION
Issue most probably introduced through https://github.com/smallstep/certificates/pull/1459. 