### PR TITLE
Cache-Control HTTP header for server endpoints

### DIFF
--- a/authority/admin/api/provisioner.go
+++ b/authority/admin/api/provisioner.go
@@ -55,6 +55,8 @@ func GetProvisioner(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, err)
 		return
 	}
+
+	w.Header().Set("Cache-Control", "private, no-store")
 	render.ProtoJSON(w, prov)
 }
 
@@ -72,6 +74,7 @@ func GetProvisioners(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, errs.InternalServerErr(err))
 		return
 	}
+
 	render.JSON(w, &GetProvisionersResponse{
 		Provisioners: p,
 		NextCursor:   next,
@@ -102,6 +105,8 @@ func CreateProvisioner(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, admin.WrapErrorISE(err, "error storing provisioner %s", prov.Name))
 		return
 	}
+
+	w.Header().Set("Cache-Control", "private, no-store")
 	render.ProtoJSONStatus(w, prov, http.StatusCreated)
 }
 
@@ -198,6 +203,8 @@ func UpdateProvisioner(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, err)
 		return
 	}
+
+	w.Header().Set("Cache-Control", "private, no-store")
 	render.ProtoJSON(w, nu)
 }
 

--- a/authority/admin/api/webhook.go
+++ b/authority/admin/api/webhook.go
@@ -127,6 +127,7 @@ func (war *webhookAdminResponder) CreateProvisionerWebhook(w http.ResponseWriter
 		return
 	}
 
+	w.Header().Set("Cache-Control", "private, no-store")
 	render.ProtoJSONStatus(w, newWebhook, http.StatusCreated)
 }
 
@@ -231,5 +232,7 @@ func (war *webhookAdminResponder) UpdateProvisionerWebhook(w http.ResponseWriter
 		Auth:                 newWebhook.Auth,
 		DisableTlsClientAuth: newWebhook.DisableTlsClientAuth,
 	}
+
+	w.Header().Set("Cache-Control", "private, no-store")
 	render.ProtoJSONStatus(w, whResponse, http.StatusCreated)
 }


### PR DESCRIPTION
Add `Cache-Control: private, no-store` HTTP header to server endpoints that respond with sensitive info.

Fixes #793

I decided which endpoints to add the header to by investigating each endpoint and the data it returns.

Please let me know if it would be a good idea to update or add tests to check for the new header where needed. My own judgment as of the time of opening this PR was to not update the tests because 1) existing tests aren't checking HTTP response headers from what I saw and 2) I felt like the addition of a header might be too trivial to be worth adding new test code.