### PR TITLE
Wait for Accept in TestBootstrapClientServerRotation

### DIFF
--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -606,7 +606,13 @@ func doReload(ca *CA) error {
 	}
 	// Use same address in new server
 	newCA.srv.Addr = ca.srv.Addr
-	return ca.srv.Reload(newCA.srv)
+	if err := ca.srv.Reload(newCA.srv); err != nil {
+		return err
+	}
+
+	// Wait a few ms until the http server calls listener.Accept()
+	time.Sleep(100 * time.Millisecond)
+	return nil
 }
 
 func TestBootstrapListener(t *testing.T) {


### PR DESCRIPTION
### Description

The TestBootstrapClientServerRotation often fails because the reload returns once the Server loop gets the new listener, but the server hasn't really started yet. This commit makes the test pass, adding a small sleep after the reload.

A proper fix might require a wrapper over the `net.Listener` with an ACK callback on a `sync.Once` on a custom `Accept`.
