### PR TITLE
Send X5C leaf certificate to webhooks

### DIFF
--- a/authority/provisioner/controller.go
+++ b/authority/provisioner/controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/errs"
+	"github.com/smallstep/certificates/webhook"
 	"go.step.sm/linkedca"
 	"golang.org/x/crypto/ssh"
 )
@@ -77,7 +78,7 @@ func (c *Controller) AuthorizeSSHRenew(ctx context.Context, cert *ssh.Certificat
 	return DefaultAuthorizeSSHRenew(ctx, c, cert)
 }
 
-func (c *Controller) newWebhookController(templateData WebhookSetter, certType linkedca.Webhook_CertType) *WebhookController {
+func (c *Controller) newWebhookController(templateData WebhookSetter, certType linkedca.Webhook_CertType, opts ...webhook.RequestBodyOption) *WebhookController {
 	client := c.webhookClient
 	if client == nil {
 		client = http.DefaultClient
@@ -87,6 +88,7 @@ func (c *Controller) newWebhookController(templateData WebhookSetter, certType l
 		client:       client,
 		webhooks:     c.webhooks,
 		certType:     certType,
+		options:      opts,
 	}
 }
 

--- a/authority/provisioner/webhook.go
+++ b/authority/provisioner/webhook.go
@@ -30,6 +30,7 @@ type WebhookController struct {
 	client       *http.Client
 	webhooks     []*Webhook
 	certType     linkedca.Webhook_CertType
+	options      []webhook.RequestBodyOption
 	TemplateData WebhookSetter
 }
 
@@ -39,6 +40,14 @@ func (wc *WebhookController) Enrich(req *webhook.RequestBody) error {
 	if wc == nil {
 		return nil
 	}
+
+	// Apply extra options in the webhook controller
+	for _, fn := range wc.options {
+		if err := fn(req); err != nil {
+			return err
+		}
+	}
+
 	for _, wh := range wc.webhooks {
 		if wh.Kind != linkedca.Webhook_ENRICHING.String() {
 			continue
@@ -63,6 +72,14 @@ func (wc *WebhookController) Authorize(req *webhook.RequestBody) error {
 	if wc == nil {
 		return nil
 	}
+
+	// Apply extra options in the webhook controller
+	for _, fn := range wc.options {
+		if err := fn(req); err != nil {
+			return err
+		}
+	}
+
 	for _, wh := range wc.webhooks {
 		if wh.Kind != linkedca.Webhook_AUTHORIZING.String() {
 			continue

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -15,6 +15,7 @@ import (
 	"go.step.sm/linkedca"
 
 	"github.com/smallstep/certificates/errs"
+	"github.com/smallstep/certificates/webhook"
 )
 
 // x5cPayload extends jwt.Claims with step attributes.
@@ -215,7 +216,8 @@ func (p *X5C) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 	// The X509 certificate will be available using the template variable
 	// AuthorizationCrt. For example {{ .AuthorizationCrt.DNSNames }} can be
 	// used to get all the domains.
-	data.SetAuthorizationCertificate(claims.chains[0][0])
+	x5cLeaf := claims.chains[0][0]
+	data.SetAuthorizationCertificate(x5cLeaf)
 
 	templateOptions, err := TemplateOptions(p.Options, data)
 	if err != nil {
@@ -238,7 +240,7 @@ func (p *X5C) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 		newProvisionerExtensionOption(TypeX5C, p.Name, ""),
 		profileLimitDuration{
 			p.ctl.Claimer.DefaultTLSCertDuration(),
-			claims.chains[0][0].NotBefore, claims.chains[0][0].NotAfter,
+			x5cLeaf.NotBefore, x5cLeaf.NotAfter,
 		},
 		// validators
 		commonNameValidator(claims.Subject),
@@ -246,7 +248,7 @@ func (p *X5C) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 		defaultPublicKeyValidator{},
 		newValidityValidator(p.ctl.Claimer.MinTLSCertDuration(), p.ctl.Claimer.MaxTLSCertDuration()),
 		newX509NamePolicyValidator(p.ctl.getPolicy().getX509()),
-		p.ctl.newWebhookController(data, linkedca.Webhook_X509),
+		p.ctl.newWebhookController(data, linkedca.Webhook_X509, webhook.WithX5CCertificate(x5cLeaf)),
 	}, nil
 }
 
@@ -305,7 +307,8 @@ func (p *X5C) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 	// The X509 certificate will be available using the template variable
 	// AuthorizationCrt. For example {{ .AuthorizationCrt.DNSNames }} can be
 	// used to get all the domains.
-	data.SetAuthorizationCertificate(claims.chains[0][0])
+	x5cLeaf := claims.chains[0][0]
+	data.SetAuthorizationCertificate(x5cLeaf)
 
 	templateOptions, err := TemplateSSHOptions(p.Options, data)
 	if err != nil {
@@ -325,7 +328,7 @@ func (p *X5C) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 	return append(signOptions,
 		p,
 		// Checks the validity bounds, and set the validity if has not been set.
-		&sshLimitDuration{p.ctl.Claimer, claims.chains[0][0].NotAfter},
+		&sshLimitDuration{p.ctl.Claimer, x5cLeaf.NotAfter},
 		// Validate public key.
 		&sshDefaultPublicKeyValidator{},
 		// Validate the validity period.
@@ -335,6 +338,6 @@ func (p *X5C) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 		// Ensure that all principal names are allowed
 		newSSHNamePolicyValidator(p.ctl.getPolicy().getSSHHost(), p.ctl.getPolicy().getSSHUser()),
 		// Call webhooks
-		p.ctl.newWebhookController(data, linkedca.Webhook_SSH),
+		p.ctl.newWebhookController(data, linkedca.Webhook_SSH, webhook.WithX5CCertificate(x5cLeaf)),
 	), nil
 }

--- a/authority/provisioner/x5c_test.go
+++ b/authority/provisioner/x5c_test.go
@@ -12,6 +12,7 @@ import (
 	"go.step.sm/crypto/jose"
 	"go.step.sm/crypto/pemutil"
 	"go.step.sm/crypto/randutil"
+	"go.step.sm/linkedca"
 
 	"github.com/smallstep/assert"
 	"github.com/smallstep/certificates/api/render"
@@ -497,6 +498,8 @@ func TestX5C_AuthorizeSign(t *testing.T) {
 								assert.Equals(t, nil, v.policyEngine)
 							case *WebhookController:
 								assert.Len(t, 0, v.webhooks)
+								assert.Equals(t, linkedca.Webhook_X509, v.certType)
+								assert.Len(t, 1, v.options)
 							default:
 								assert.FatalError(t, fmt.Errorf("unexpected sign option of type %T", v))
 							}
@@ -801,6 +804,8 @@ func TestX5C_AuthorizeSSHSign(t *testing.T) {
 							case *sshDefaultPublicKeyValidator, *sshCertDefaultValidator, sshCertificateOptionsFunc:
 							case *WebhookController:
 								assert.Len(t, 0, v.webhooks)
+								assert.Equals(t, linkedca.Webhook_SSH, v.certType)
+								assert.Len(t, 1, v.options)
 							default:
 								assert.FatalError(t, fmt.Errorf("unexpected sign option of type %T", v))
 							}

--- a/webhook/options.go
+++ b/webhook/options.go
@@ -95,3 +95,23 @@ func WithSSHCertificate(cert *sshutil.Certificate, certTpl *ssh.Certificate) Req
 		return nil
 	}
 }
+
+func WithX5CCertificate(leaf *x509.Certificate) RequestBodyOption {
+	return func(rb *RequestBody) error {
+		rb.X5CCertificate = &X5CCertificate{
+			Raw:                leaf.Raw,
+			PublicKeyAlgorithm: leaf.PublicKeyAlgorithm.String(),
+			NotBefore:          leaf.NotBefore,
+			NotAfter:           leaf.NotAfter,
+		}
+		if leaf.PublicKey != nil {
+			key, err := x509.MarshalPKIXPublicKey(leaf.PublicKey)
+			if err != nil {
+				return err
+			}
+			rb.X5CCertificate.PublicKey = key
+		}
+
+		return nil
+	}
+}

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -56,6 +56,17 @@ type AttestationData struct {
 	PermanentIdentifier string `json:"permanentIdentifier"`
 }
 
+// X5CCertificate is the authorization certificate sent to webhook servers for
+// enriching or authorizing webhooks when signing X509 or SSH certificates using
+// the X5C provisioner.
+type X5CCertificate struct {
+	Raw                []byte    `json:"raw"`
+	PublicKey          []byte    `json:"publicKey"`
+	PublicKeyAlgorithm string    `json:"publicKeyAlgorithm"`
+	NotBefore          time.Time `json:"notBefore"`
+	NotAfter           time.Time `json:"notAfter"`
+}
+
 // RequestBody is the body sent to webhook servers.
 type RequestBody struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -71,4 +82,6 @@ type RequestBody struct {
 	// Only set for SCEP challenge validation requests
 	SCEPChallenge     string `json:"scepChallenge,omitempty"`
 	SCEPTransactionID string `json:"scepTransactionID,omitempty"`
+	// Only set for X5C provisioners
+	X5CCertificate *X5CCertificate `json:"x5cCertificate,omitempty"`
 }


### PR DESCRIPTION
### Description

This commit adds a new property that will be sent to authorizing and enriching webhooks when signing certificates using the X5C provisioner.

cc: @joshdrake 