### PR TITLE
Include authorization principal in provisioner webhooks.

### DIFF
--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -24,6 +24,7 @@ import (
 	"go.step.sm/linkedca"
 
 	"github.com/smallstep/certificates/errs"
+	"github.com/smallstep/certificates/webhook"
 )
 
 // awsIssuer is the string used as issuer in the generated tokens.
@@ -521,7 +522,11 @@ func (p *AWS) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 		commonNameValidator(payload.Claims.Subject),
 		newValidityValidator(p.ctl.Claimer.MinTLSCertDuration(), p.ctl.Claimer.MaxTLSCertDuration()),
 		newX509NamePolicyValidator(p.ctl.getPolicy().getX509()),
-		p.ctl.newWebhookController(data, linkedca.Webhook_X509),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_X509,
+			webhook.WithAuthorizationPrincipal(doc.InstanceID),
+		),
 	), nil
 }
 
@@ -804,6 +809,10 @@ func (p *AWS) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 		// Ensure that all principal names are allowed
 		newSSHNamePolicyValidator(p.ctl.getPolicy().getSSHHost(), nil),
 		// Call webhooks
-		p.ctl.newWebhookController(data, linkedca.Webhook_SSH),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_SSH,
+			webhook.WithAuthorizationPrincipal(doc.InstanceID),
+		),
 	), nil
 }

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -21,6 +21,7 @@ import (
 	"go.step.sm/linkedca"
 
 	"github.com/smallstep/certificates/errs"
+	"github.com/smallstep/certificates/webhook"
 )
 
 // gcpCertsURL is the url that serves Google OAuth2 public keys.
@@ -275,7 +276,11 @@ func (p *GCP) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 		defaultPublicKeyValidator{},
 		newValidityValidator(p.ctl.Claimer.MinTLSCertDuration(), p.ctl.Claimer.MaxTLSCertDuration()),
 		newX509NamePolicyValidator(p.ctl.getPolicy().getX509()),
-		p.ctl.newWebhookController(data, linkedca.Webhook_X509),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_X509,
+			webhook.WithAuthorizationPrincipal(ce.InstanceID),
+		),
 	), nil
 }
 
@@ -442,6 +447,10 @@ func (p *GCP) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 		// Ensure that all principal names are allowed
 		newSSHNamePolicyValidator(p.ctl.getPolicy().getSSHHost(), nil),
 		// Call webhooks
-		p.ctl.newWebhookController(data, linkedca.Webhook_SSH),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_SSH,
+			webhook.WithAuthorizationPrincipal(ce.InstanceID),
+		),
 	), nil
 }

--- a/authority/provisioner/x5c.go
+++ b/authority/provisioner/x5c.go
@@ -248,7 +248,12 @@ func (p *X5C) AuthorizeSign(_ context.Context, token string) ([]SignOption, erro
 		defaultPublicKeyValidator{},
 		newValidityValidator(p.ctl.Claimer.MinTLSCertDuration(), p.ctl.Claimer.MaxTLSCertDuration()),
 		newX509NamePolicyValidator(p.ctl.getPolicy().getX509()),
-		p.ctl.newWebhookController(data, linkedca.Webhook_X509, webhook.WithX5CCertificate(x5cLeaf)),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_X509,
+			webhook.WithX5CCertificate(x5cLeaf),
+			webhook.WithAuthorizationPrincipal(x5cLeaf.Subject.CommonName),
+		),
 	}, nil
 }
 
@@ -338,6 +343,11 @@ func (p *X5C) AuthorizeSSHSign(_ context.Context, token string) ([]SignOption, e
 		// Ensure that all principal names are allowed
 		newSSHNamePolicyValidator(p.ctl.getPolicy().getSSHHost(), p.ctl.getPolicy().getSSHUser()),
 		// Call webhooks
-		p.ctl.newWebhookController(data, linkedca.Webhook_SSH, webhook.WithX5CCertificate(x5cLeaf)),
+		p.ctl.newWebhookController(
+			data,
+			linkedca.Webhook_SSH,
+			webhook.WithX5CCertificate(x5cLeaf),
+			webhook.WithAuthorizationPrincipal(x5cLeaf.Subject.CommonName),
+		),
 	), nil
 }

--- a/authority/provisioner/x5c_test.go
+++ b/authority/provisioner/x5c_test.go
@@ -499,7 +499,7 @@ func TestX5C_AuthorizeSign(t *testing.T) {
 							case *WebhookController:
 								assert.Len(t, 0, v.webhooks)
 								assert.Equals(t, linkedca.Webhook_X509, v.certType)
-								assert.Len(t, 1, v.options)
+								assert.Len(t, 2, v.options)
 							default:
 								assert.FatalError(t, fmt.Errorf("unexpected sign option of type %T", v))
 							}
@@ -805,7 +805,7 @@ func TestX5C_AuthorizeSSHSign(t *testing.T) {
 							case *WebhookController:
 								assert.Len(t, 0, v.webhooks)
 								assert.Equals(t, linkedca.Webhook_SSH, v.certType)
-								assert.Len(t, 1, v.options)
+								assert.Len(t, 2, v.options)
 							default:
 								assert.FatalError(t, fmt.Errorf("unexpected sign option of type %T", v))
 							}

--- a/webhook/options.go
+++ b/webhook/options.go
@@ -68,6 +68,13 @@ func WithAttestationData(data *AttestationData) RequestBodyOption {
 	}
 }
 
+func WithAuthorizationPrincipal(p string) RequestBodyOption {
+	return func(rb *RequestBody) error {
+		rb.AuthorizationPrincipal = p
+		return nil
+	}
+}
+
 func WithSSHCertificateRequest(cr sshutil.CertificateRequest) RequestBodyOption {
 	return func(rb *RequestBody) error {
 		rb.SSHCertificateRequest = &SSHCertificateRequest{

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -84,4 +84,6 @@ type RequestBody struct {
 	SCEPTransactionID string `json:"scepTransactionID,omitempty"`
 	// Only set for X5C provisioners
 	X5CCertificate *X5CCertificate `json:"x5cCertificate,omitempty"`
+	// Set for X5C, AWS, GCP, and Azure provisioners
+	AuthorizationPrincipal string `json:"authorizationPrincipal,omitempty"`
 }


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Provisioner Webhooks

#### Pain or issue this feature alleviates:

Webhook responders may want to make authorization decisions or enrich certificate requests based on how the signing request was initially authorized. The entire authorization token cannot be sent due to potential replay attacks or proliferation of sensitive material, but the present principals from that token can often satisfy these requirements.

#### Is there documentation on how to use this feature? If so, where?

https://github.com/smallstep/docs/compare/josh/enrich-authorization-principal?expand=1

#### In what environments or workflows is this feature supported?

Cloud (AWS, GCP, Azure) provisioners, X5C provisioners.

#### Supporting links/other PRs/issues:

https://github.com/smallstep/docs/compare/josh/enrich-authorization-principal?expand=1

💔Thank you!
