### PR TITLE
Fixes pcscd permission issue

### DIFF
--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -1,4 +1,4 @@
-FROM golang AS builder
+FROM golang:bullseye AS builder
 
 WORKDIR /src
 COPY . .
@@ -21,6 +21,11 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends pcscd libpcsclite1
 RUN mkdir -p /run/pcscd
 RUN chown step:step /run/pcscd
+
+# Add user `step` to pcscd group
+RUN groupadd pcscd
+RUN usermod -a -G pcscd step
+
 USER step
 
 ENV CONFIGPATH="/home/step/config/ca.json"


### PR DESCRIPTION
I raised this error in the discord: https://discord.com/channels/837031272227930163/841249977699401759/1132937016103936030 I also fixed an issue with building the image on a Raspberry Pi.

#### Name of feature:
Fixes pcscd permission in docker container. Adds a tag to the golang builder

#### Pain or issue this feature alleviates:
When the pcscd service is started (via `entrypoint.sh`) by a non-root user, 
the container cannot correctly access the yubikey (passed via the docker `--device` flag) 

The `bullseye` tag for the golang builder alleviates an issue when building the container on an OS that doesn't have the right GLIBC version for `step-ca` binary. I ran into this issue when building on a Raspberry Pi 4 running Ubuntu.

```
/usr/local/bin/step-ca: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/bin/step-ca)
/usr/local/bin/step-ca: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/step-ca)

```