### PR TITLE
Initial support for SCEP Polling

### DIFF
--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -82,10 +82,16 @@ type Config struct {
 	Templates        *templates.Templates `json:"templates,omitempty"`
 	CommonName       string               `json:"commonName,omitempty"`
 	CRL              *CRLConfig           `json:"crl,omitempty"`
+	Polling          *PollingConfig       `json:"polling,omitempty"`
 	SkipValidation   bool                 `json:"-"`
 
 	// Keeps record of the filename the Config is read from
 	loadedFromFilepath string
+}
+
+// PollingConfig represents config options for SCEP polling
+type PollingConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 // CRLConfig represents config options for CRL generation
@@ -95,6 +101,11 @@ type CRLConfig struct {
 	CacheDuration    *provisioner.Duration `json:"cacheDuration,omitempty"`
 	RenewPeriod      *provisioner.Duration `json:"renewPeriod,omitempty"`
 	IDPurl           string                `json:"idpURL,omitempty"`
+}
+
+// IsEnabled returns if polling is enabled.
+func (c *PollingConfig) IsEnabled() bool {
+	return c != nil && c.Enabled
 }
 
 // IsEnabled returns if the CRL is enabled.

--- a/scep/polling.go
+++ b/scep/polling.go
@@ -1,0 +1,46 @@
+package scep
+
+import (
+	"crypto/x509"
+
+	"github.com/pkg/errors"
+)
+
+func (a *Authority) CertificateIsSigned(csr *x509.CertificateRequest) (bool, error) {
+	_, err := a.db.GetCertificateByCSR(csr)
+	if err != nil {
+		return false, errors.Errorf("Error finding certificate in database")
+	}
+	// If there's no errors, then it exists and is signed.
+	return true, nil
+}
+
+func (a *Authority) CertificateRequestInDB(transactionID string) (bool, error) {
+	csr, err := a.db.GetCSR(transactionID)
+	if err != nil {
+		return false, nil
+	}
+	if csr == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (a *Authority) StoreCertificateRequest(transactionID string, csr *x509.CertificateRequest) error {
+	err := a.db.StoreCSR(transactionID, csr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (a *Authority) GetCertificateRequest(transactionID string) (*x509.CertificateRequest, error) {
+	csr, err := a.db.GetCSR(transactionID)
+	if err != nil {
+		return nil, errors.Errorf("Error finding serial number in database")
+	}
+	return csr, nil
+}
+
+func (a *Authority) IsEnabled() bool {
+	return a.polling
+}


### PR DESCRIPTION
### **Description:**

This pull request adds SCEP polling mode which can be configured via ca.json. When enabled, the CA will return a PENDING response which will cause the client to poll the CA server. Fixes #1170 .

Two new databases have been created named `x509_csr` and `x509_certs_csr` to save the certificate requests that have been signed.