### PR TITLE
Fix error string in tests

### DIFF
--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -3444,7 +3444,7 @@ func Test_deviceAttest01Validate(t *testing.T) {
 					},
 					payload: errorCBORPayload,
 				},
-				wantErr: NewErrorISE("error unmarshalling CBOR: cbor: cannot unmarshal positive integer into Go value of type acme.attestationObject"),
+				wantErr: NewErrorISE("error unmarshalling CBOR: cbor:"),
 			}
 		},
 		"ok/prov.IsAttestationFormatEnabled": func(t *testing.T) test {
@@ -4003,8 +4003,9 @@ func Test_deviceAttest01Validate(t *testing.T) {
 			tc := run(t)
 
 			if err := deviceAttest01Validate(tc.args.ctx, tc.args.ch, tc.args.db, tc.args.jwk, tc.args.payload); err != nil {
-				assert.Error(t, tc.wantErr)
-				assert.EqualError(t, err, tc.wantErr.Error())
+				if assert.Error(t, tc.wantErr) {
+					assert.ErrorContains(t, err, tc.wantErr.Error())
+				}
 				return
 			}
 


### PR DESCRIPTION
### Description

This commit fixes a test checking an error string from an external dependency. It also fixes random errors on CI because the server BaseContext MUST be set before the start of a server, and that was not the case on some unit tests.
