### PR TITLE
Skip challenge feature

### DIFF
--- a/acme/api/order.go
+++ b/acme/api/order.go
@@ -269,11 +269,18 @@ func newAuthorization(ctx context.Context, az *acme.Authorization) error {
 			Token:     az.Token,
 			Status:    acme.StatusPending,
 		}
+
 		if err := db.CreateChallenge(ctx, ch); err != nil {
 			return acme.WrapErrorISE(err, "error creating challenge")
 		}
 		az.Challenges = append(az.Challenges, ch)
 	}
+
+	//If no challenges were created, set authorization status as valid.
+	if len(az.Challenges) == 0 {
+		az.Status = acme.StatusValid
+	}
+
 	if err = db.CreateAuthorization(ctx, az); err != nil {
 		return acme.WrapErrorISE(err, "error creating authorization")
 	}

--- a/authority/provisioner/acme.go
+++ b/authority/provisioner/acme.go
@@ -286,13 +286,10 @@ func (p *ACME) AuthorizeRenew(ctx context.Context, cert *x509.Certificate) error
 	return p.ctl.AuthorizeRenew(ctx, cert)
 }
 
-// IsChallengeEnabled checks if the given challenge is enabled. By default
-// http-01, dns-01 and tls-alpn-01 are enabled, to disable any of them the
-// Challenge provisioner property should have at least one element.
+// IsChallengeEnabled checks if the given challenge is enabled.
+// Leave the challenges empty to skip challenge validation.
 func (p *ACME) IsChallengeEnabled(_ context.Context, challenge ACMEChallenge) bool {
-	enabledChallenges := []ACMEChallenge{
-		HTTP_01, DNS_01, TLS_ALPN_01,
-	}
+	enabledChallenges := []ACMEChallenge{}
 	if len(p.Challenges) > 0 {
 		enabledChallenges = p.Challenges
 	}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Skip challenge validation if provisioner challenges empty

#### Pain or issue this feature alleviates:
DNS configuration was required for personal use on local machines. With this feature, projects can be run over https using only step-ca and traefik.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
