### PR TITLE
Fix webhooks signature

### DIFF
--- a/authority/provisioner/webhook.go
+++ b/authority/provisioner/webhook.go
@@ -173,7 +173,9 @@ retry:
 	if err != nil {
 		return nil, err
 	}
-	sig := hmac.New(sha256.New, secret).Sum(reqBytes)
+	h := hmac.New(sha256.New, secret)
+	h.Write(reqBytes)
+	sig := h.Sum(nil)
 	req.Header.Set("X-Smallstep-Signature", hex.EncodeToString(sig))
 	req.Header.Set("X-Smallstep-Webhook-ID", w.ID)
 

--- a/authority/provisioner/webhook_test.go
+++ b/authority/provisioner/webhook_test.go
@@ -482,7 +482,9 @@ func TestWebhook_Do(t *testing.T) {
 
 				secret, err := base64.StdEncoding.DecodeString(tc.webhook.Secret)
 				assert.FatalError(t, err)
-				mac := hmac.New(sha256.New, secret).Sum(body)
+				h := hmac.New(sha256.New, secret)
+				h.Write(body)
+				mac := h.Sum(nil)
 				assert.True(t, hmac.Equal(sig, mac))
 
 				switch {


### PR DESCRIPTION
### Description

This PR fixes the way webhooks signatures are created. Before this change, the signature of an empty body was prepended by the body itself.
