### PR TITLE
Allowing GCP provisioner to issue SSH User Certificates - Option 2

### DIFF
--- a/api/ssh.go
+++ b/api/ssh.go
@@ -289,6 +289,7 @@ func SSHSign(w http.ResponseWriter, r *http.Request) {
 
 	ctx := provisioner.NewContextWithMethod(r.Context(), provisioner.SSHSignMethod)
 	ctx = provisioner.NewContextWithToken(ctx, body.OTT)
+	ctx = provisioner.NewContextWithCertType(ctx, opts.CertType)
 
 	a := mustAuthority(ctx)
 	signOpts, err := a.Authorize(ctx, body.OTT)

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -482,7 +482,7 @@ func (p *GCP) genHostOptions(_ context.Context, claims *gcpPayload) (SignSSHOpti
 func (p *GCP) genUserOptions(_ context.Context, claims *gcpPayload) (SignSSHOptions, string, []string, sshutil.CertType, string) {
 	keyID := claims.Email
 	principals := []string{
-		SanitizeSSHUserPrincipal(claims.Email),
+		fmt.Sprintf("sa_%v", claims.Subject),
 		claims.Email,
 	}
 

--- a/authority/provisioner/gcp_test.go
+++ b/authority/provisioner/gcp_test.go
@@ -213,11 +213,11 @@ func TestGCP_Init(t *testing.T) {
 				t.Errorf("GCP.Init() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if p.EnableSSHCAUser {
-				t.Errorf("By default EnableSSHCAUser should be false")
+			if *p.DisableSSHCAUser != true {
+				t.Errorf("By default DisableSSHCAUser should be true")
 			}
 
-			if p.DisableSSHCAHost {
+			if *p.DisableSSHCAHost != false {
 				t.Errorf("By default DisableSSHCAHost should be false")
 			}
 		})
@@ -601,7 +601,9 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 	p1, err := generateGCP()
 	assert.FatalError(t, err)
 	p1.DisableCustomSANs = true
-	p1.EnableSSHCAUser = true
+	// enable ssh user CA
+	disableSSCAUser := false
+	p1.DisableSSHCAUser = &disableSSCAUser
 
 	p2, err := generateGCP()
 	assert.FatalError(t, err)
@@ -617,7 +619,9 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 
 	p4, err := generateGCP()
 	assert.FatalError(t, err)
-	p4.DisableSSHCAHost = true
+	// disable ssh host CA
+	disableSSCAHost := true
+	p4.DisableSSHCAHost = &disableSSCAHost
 
 	t1, err := generateGCPToken(p1.ServiceAccounts[0],
 		"https://accounts.google.com", p1.GetID(),
@@ -662,7 +666,7 @@ func TestGCP_AuthorizeSSHSign(t *testing.T) {
 		ValidAfter: NewTimeDuration(tm), ValidBefore: NewTimeDuration(tm.Add(hostDuration)),
 	}
 	expectedUserOptions := &SignSSHOptions{
-		CertType: "user", Principals: []string{"foo", "foo@developer.gserviceaccount.com"},
+		CertType: "user", Principals: []string{FormatServiceAccountUsername(p1.ServiceAccounts[0]), "foo@developer.gserviceaccount.com"},
 		ValidAfter: NewTimeDuration(tm), ValidBefore: NewTimeDuration(tm.Add(p1.ctl.Claimer.DefaultUserSSHCertDuration())),
 	}
 

--- a/authority/provisioner/gcp_test.go
+++ b/authority/provisioner/gcp_test.go
@@ -187,6 +187,7 @@ func TestGCP_Init(t *testing.T) {
 		wantErr bool
 	}{
 		{"ok", fields{"GCP", "name", nil, zero, nil}, args{config, srv.URL}, false},
+		{"ok", fields{"GCP", "name", nil, zero, nil}, args{config, srv.URL}, false},
 		{"ok", fields{"GCP", "name", []string{"service-account"}, zero, nil}, args{config, srv.URL}, false},
 		{"ok", fields{"GCP", "name", []string{"service-account"}, Duration{Duration: 1 * time.Minute}, nil}, args{config, srv.URL}, false},
 		{"bad type", fields{"", "name", nil, zero, nil}, args{config, srv.URL}, true},
@@ -210,6 +211,14 @@ func TestGCP_Init(t *testing.T) {
 			}
 			if err := p.Init(tt.args.config); (err != nil) != tt.wantErr {
 				t.Errorf("GCP.Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if p.EnableSSHCAUser {
+				t.Errorf("By default EnableSSHCAUser should be false")
+			}
+
+			if p.DisableSSHCAHost {
+				t.Errorf("By default DisableSSHCAHost should be false")
 			}
 		})
 	}

--- a/authority/provisioner/method.go
+++ b/authority/provisioner/method.go
@@ -78,3 +78,17 @@ func TokenFromContext(ctx context.Context) (string, bool) {
 	token, ok := ctx.Value(tokenKey{}).(string)
 	return token, ok
 }
+
+// The key to save the certTypeKey in the context.
+type certTypeKey struct{}
+
+// NewContextWithCertType creates a new context with the given CertType.
+func NewContextWithCertType(ctx context.Context, certType string) context.Context {
+	return context.WithValue(ctx, certTypeKey{}, certType)
+}
+
+// CertTypeFromContext returns the certType stored in the given context.
+func CertTypeFromContext(ctx context.Context) (string, bool) {
+	certType, ok := ctx.Value(certTypeKey{}).(string)
+	return certType, ok
+}

--- a/authority/provisioner/utils_test.go
+++ b/authority/provisioner/utils_test.go
@@ -363,11 +363,13 @@ func generateGCP() (*GCP, error) {
 		return nil, err
 	}
 	p := &GCP{
-		Type:            "GCP",
-		Name:            name,
-		ServiceAccounts: []string{serviceAccount},
-		Claims:          &globalProvisionerClaims,
-		config:          newGCPConfig(),
+		Type:             "GCP",
+		Name:             name,
+		ServiceAccounts:  []string{serviceAccount},
+		Claims:           &globalProvisionerClaims,
+		DisableSSHCAHost: &DefaultDisableSSHCAHost,
+		DisableSSHCAUser: &DefaultDisableSSHCAUser,
+		config:           newGCPConfig(),
 		keyStore: &keyStore{
 			keySet: jose.JSONWebKeySet{Keys: []jose.JSONWebKey{*jwk}},
 			expiry: time.Now().Add(24 * time.Hour),


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Allowing **GCP** provisioner to issue SSH User Certificates - Option 2

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

Workloads running in GCP Compute Instances are run with an assigned Service Account. The Service Account authenticated on a given Compute Instance can be found in the Identity Token obtained from the metadata server that the GCP provisioner uses to obtain the Compute Instance identity and generate the SSH Host Certificate.

Allowing the GCP provisioner to issue SSH User Certificates would allow the above referred Workloads to use the smallstep infrastructure to sign into other Compute Instances. Examples of workloads that would benefit from this change are: CICD systems like Jenkins and Ansible.

Without this feature there would be two other options to achieve this:

- Have a separate JWK provisioner: This provisioner is present in the ca.json configuration file.
- Have a X5C provisioner to generate an intermediary X.509 certificate to then issue the SSH User Certificate from it: This option involves the creation of an intermediary certificate that could be used for TLS that will need to be maintained along with the SSH User Certificate.

However neither of these can validate the service account principal.

#### Is there documentation on how to use this feature? If so, where?

If this change is accepted we could update the documentation for the GCP provisioner [here](https://smallstep.com/docs/step-ca/provisioners/#cloud-provisioners)

#### In what environments or workflows is this feature supported?

This would work for smallstep-ca deployments that support GCP

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

This will not work outside of GCP

#### Supporting links/other PRs/issues:

This proposal leverages the use of the Context to find out what kind of certificate is requested because the only arguments available to the `AuthorizeSSHSign` is the context and the id Token (other provisioners that support both host and user certificates get access to an access token that has this information embedded). Because of this there is a significant refactor in the `AuthorizeSSHSign` function but the tests are almost untouched.

We propose a different approach which tries to do the least changes at:

https://github.com/smallstep/certificates/pull/1557

❤️ Thank you!