### PR TITLE
Improve SCEP request handling

### DIFF
--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -235,7 +235,7 @@ func decodeMessage(message string, r *http.Request) ([]byte, error) {
 	rawMessage = strings.ReplaceAll(rawMessage, "%3D", "=") // apparently the padding arrives encoded; the others (+, /) not?
 	decodedMessage, err = base64.StdEncoding.DecodeString(rawMessage)
 	if err != nil {
-		return nil, fmt.Errorf("failed decoding raw message: %w", err)
+		return nil, fmt.Errorf("failed base64 decoding raw message: %w", err)
 	}
 
 	return decodedMessage, nil

--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -203,7 +203,7 @@ func decodeMessage(message string, r *http.Request) ([]byte, error) {
 
 	// decode the message, which should be base64 standard encoded. Any characters that
 	// were escaped in the original query, were unescaped as part of url.ParseQuery, so
-	// that doesn't need to be performed here. Return early if successfull.
+	// that doesn't need to be performed here. Return early if successful.
 	decodedMessage, err := base64.StdEncoding.DecodeString(message)
 	if err == nil {
 		return decodedMessage, nil
@@ -211,7 +211,8 @@ func decodeMessage(message string, r *http.Request) ([]byte, error) {
 
 	// only interested in corrupt input errors below this. This type of error is the
 	// most likely to return, but better safe than sorry.
-	if _, ok := err.(base64.CorruptInputError); !ok {
+	var cie base64.CorruptInputError
+	if !errors.As(err, &cie) {
 		return nil, fmt.Errorf("failed base64 decoding message: %w", err)
 	}
 


### PR DESCRIPTION
This PR:

*  Improves the logic for handling SCEP requests
* Adds a workaround for macOS SCEP clients sending weird GET PKIOperation messages

Apparently the macOS SCEP client sends a SCEP message in the query
that's not fully escaped. Only the base64 padding is escaped, the
'+' and '/' characters aren't.

This is a bit of a special case, because the macOS SCEP client
will default to using HTTP POST for the PKIOperation. But if the
CA is configured without the POSTPKIOperation capability, the
macOS SCEP client will use HTTP GET instead. This behavior might
be the same on iOS.