### PR TITLE
Change CommonName validator in JWK

### DIFF
--- a/authority/provisioner/jwk.go
+++ b/authority/provisioner/jwk.go
@@ -190,7 +190,7 @@ func (p *JWK) AuthorizeSign(ctx context.Context, token string) ([]SignOption, er
 		newProvisionerExtensionOption(TypeJWK, p.Name, p.Key.KeyID).WithControllerOptions(p.ctl),
 		profileDefaultDuration(p.ctl.Claimer.DefaultTLSCertDuration()),
 		// validators
-		commonNameValidator(claims.Subject),
+		commonNameSliceValidator(append([]string{claims.Subject}, claims.SANs...)),
 		defaultPublicKeyValidator{},
 		newDefaultSANsValidator(ctx, claims.SANs),
 		newValidityValidator(p.ctl.Claimer.MinTLSCertDuration(), p.ctl.Claimer.MaxTLSCertDuration()),

--- a/authority/provisioner/jwk_test.go
+++ b/authority/provisioner/jwk_test.go
@@ -309,8 +309,8 @@ func TestJWK_AuthorizeSign(t *testing.T) {
 							assert.Len(t, 0, v.KeyValuePairs)
 						case profileDefaultDuration:
 							assert.Equals(t, time.Duration(v), tt.prov.ctl.Claimer.DefaultTLSCertDuration())
-						case commonNameValidator:
-							assert.Equals(t, string(v), "subject")
+						case commonNameSliceValidator:
+							assert.Equals(t, []string(v), append([]string{"subject"}, tt.sans...))
 						case defaultPublicKeyValidator:
 						case *validityValidator:
 							assert.Equals(t, v.min, tt.prov.ctl.Claimer.MinTLSCertDuration())


### PR DESCRIPTION
### Description

This commit changes the common name validator in the JWK provisioner to accept either the token subject or any of the sans in the token.

This PR allows admin tokens on RA to work with the changes in https://github.com/smallstep/certificates/pull/1608