### PR TITLE
Use the same version for building and running

### DIFF
--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -1,4 +1,4 @@
-FROM golang AS builder
+FROM golang:bullseye AS builder
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
### Description

This commit makes sure to use the same version for building step-ca with CGO and running it.

Fixes #1611

A new issue has been created to upgrade builds to bookworm https://github.com/smallstep/certificates/issues/1615