### PR TITLE
Add (temporary) fix for missing null bytes in Apple JWS signatures

### DIFF
--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -474,7 +474,7 @@ func patchSignatures(jws *jose.JSONWebSignature) {
 		case jose.ES512:
 			expectedSize = 132
 		default:
-			// other cases are (currently) ignored; TODO(hs): need other cases too?
+			// other cases are (currently) ignored
 			continue
 		}
 		if diff := expectedSize - len(s.Signature); diff > 0 {


### PR DESCRIPTION
Apparently the Apple macOS (and iOS?) ACME client seems to omit leading null bytes from JWS signatures. The base64-url encoded bytes decode to a shorter byte slice than what the JOSE library expects (e.g. 63 bytes instead of 64 bytes for ES256), and then results in a `jose.ErrCryptoFailure`.

This commit retries verification of the JWS in case the first verification fails with `jose.ErrCryptoFailure`. The signatures are checked to be of the correct length, and if not, null bytes are prepended to the signature. Then verification is retried, which might fail again, but for other reasons. On success, the payload is returned.

Apple should fix this in their ACME client, but in the meantime this commit prevents some "bad request" error cases from happening.

Code from Apple ([source](https://github.com/apple-open-source/macos/blob/334179900a106c32514c8bee2f103fba50c87c5d/Security/OSX/sec/Security/SecJWS.m#L293-L323)):
```objc
    // We have an ASN.1 signature, but we need to return a JWS signature.
    // Per RFC 7515, this is just a concatenation of the two 32 byte integers
    // (R || S) in sequence, skipping leading zeroes if they were added.
    NSMutableData *data = [NSMutableData dataWithCapacity:0];
    DERReturn drtn = DR_GenericErr;
    DER_ECDSASig parsedSig;
    DERItem signatureItem = {
        .data = (DERByte *)CFDataGetBytePtr(signature),
        .length = (DERSize)CFDataGetLength(signature)
    };
    drtn = DERParseSequence(&signatureItem, DERNumECDSASigItemSpecs, DER_ECDSASigItemSpecs, &parsedSig, sizeof(parsedSig));
    if (drtn != DR_Success ||
        !parsedSig.r.data || parsedSig.r.length <= 0 ||
        !parsedSig.s.data || parsedSig.s.length <= 0) {
        secerror("Failed to parse signature: %d", drtn);
        CFReleaseNull(signature);
        return nil;
    }
    if (parsedSig.r.data[0] == 0x00 && parsedSig.r.length >= 1) {
        // Remove leading 0x00 bytes, if present
        [data appendData:[NSData dataWithBytes:(parsedSig.r.data + 1) length:(parsedSig.r.length - 1)]];
    } else {
        [data appendData:[NSData dataWithBytes:parsedSig.r.data length:parsedSig.r.length]];
    }

    if (parsedSig.s.data[0] == 0x00 && parsedSig.s.length >= 1) {
        // Remove leading 0x00 bytes, if present
        [data appendData:[NSData dataWithBytes:(parsedSig.s.data + 1) length:(parsedSig.s.length - 1)]];
    } else {
        [data appendData:[NSData dataWithBytes:parsedSig.s.data length:parsedSig.s.length]];
    }
    NSString *result = [self base64URLEncodedStringRepresentationWithData:data];
    CFReleaseNull(signature);

```

The code mentions RFC 7515, which itself doesn't say anything about the encoding for `R || S`. RFC 7518 however, mentions this [for signing with ECDSA](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.4):

```
   2.  Turn R and S into octet sequences in big-endian order, with each
       array being be 32 octets long.  The octet sequence
       representations MUST NOT be shortened to omit any leading zero
       octets contained in the values.

   3.  Concatenate the two octet sequences in the order R and then S.
       (Note that many ECDSA implementations will directly produce this
       concatenation as their output.)
```

Created FB13417710.


