### PR TITLE
Use a struct for the Wire DPoP token

### DIFF
--- a/acme/api/wire_integration_test.go
+++ b/acme/api/wire_integration_test.go
@@ -370,7 +370,7 @@ MCowBQYDK2VwAyEA5c+4NKZSNQcR1T8qN6SjwgdPZQ0Ge12Ylx/YeGAJ35k=
 		require.NoError(t, err)
 
 		// TODO(hs): move these to a more appropriate place and/or provide more realistic value
-		err = db.CreateDpopToken(ctx, order.ID, map[string]any{"fake-dpop": "dpop-value"})
+		err = db.CreateDpopToken(ctx, order.ID, &acme.WireDpopToken{Challenge: "challenge", Handle: "handle", Team: "wire"})
 		require.NoError(t, err)
 		err = db.CreateOidcToken(ctx, order.ID, map[string]any{"fake-oidc": "oidc-value"})
 		require.NoError(t, err)

--- a/acme/challenge_test.go
+++ b/acme/challenge_test.go
@@ -4320,7 +4320,6 @@ MCowBQYDK2VwAyEAB2IYqBWXAouDt3WcCZgCM3t9gumMEKMlgMsGenSu+fA=
 
 	token := `eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IkIySVlxQldYQW91RHQzV2NDWmdDTTN0OWd1bU1FS01sZ01zR2VuU3UtZkEifX0.eyJpYXQiOjE3MDQ5ODUyMDUsImV4cCI6MTcwNDk4OTE2NSwibmJmIjoxNzA0OTg1MjA1LCJpc3MiOiJodHRwOi8vd2lyZS5jb206MTk5ODMvY2xpZW50cy83YTQxY2Y1Yjc5NjgzNDEwL2FjY2Vzcy10b2tlbiIsInN1YiI6IndpcmVhcHA6Ly9ndVZYNXhlRlMzZVRhdG1YQkl5QTRBITdhNDFjZjViNzk2ODM0MTBAd2lyZS5jb20iLCJhdWQiOiJodHRwOi8vd2lyZS5jb206MTk5ODMvY2xpZW50cy83YTQxY2Y1Yjc5NjgzNDEwL2FjY2Vzcy10b2tlbiIsImp0aSI6IjQyYzQ2ZDRjLWU1MTAtNDE3NS05ZmI1LWQwNTVlMTI1YTQ5ZCIsIm5vbmNlIjoiVUVKeVIyZHFPRWh6WkZKRVlXSkJhVGt5T0RORVlURTJhRXMwZEhJeGNFYyIsImNoYWwiOiJiWFVHTnBVZmNSeDNFaEIzNHhQM3k2MmFRWm9HWlM2aiIsImNuZiI6eyJraWQiOiJvTVdmTkRKUXNJNWNQbFhONVVvQk5uY0t0YzRmMmRxMnZ3Q2pqWHNxdzdRIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pTVV3eFpVZ3lZVFpCWjFaMmVsUndOVnBoYkV0U1puRTJjRlpRVDNSRmFrazNhRGhVVUhwQ1dVWm5UU0o5ZlEuZXlKcFlYUWlPakUzTURRNU9EVXlNRFVzSW1WNGNDSTZNVGN3TkRrNU1qUXdOU3dpYm1KbUlqb3hOekEwT1RnMU1qQTFMQ0p6ZFdJaU9pSjNhWEpsWVhCd09pOHZaM1ZXV0RWNFpVWlRNMlZVWVhSdFdFSkplVUUwUVNFM1lUUXhZMlkxWWpjNU5qZ3pOREV3UUhkcGNtVXVZMjl0SWl3aWFuUnBJam9pTldVMk5qZzBZMkl0Tm1JME9DMDBOamhrTFdJd09URXRabVl3TkdKbFpEWmxZekpsSWl3aWJtOXVZMlVpT2lKVlJVcDVVakprY1U5RmFIcGFSa3BGV1ZkS1FtRlVhM2xQUkU1RldWUkZNbUZGY3pCa1NFbDRZMFZqSWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5M2FYSmxMbU52YlRveE9UazRNeTlqYkdsbGJuUnpMemRoTkRGalpqVmlOemsyT0RNME1UQXZZV05qWlhOekxYUnZhMlZ1SWl3aVkyaGhiQ0k2SW1KWVZVZE9jRlZtWTFKNE0wVm9Rak0wZUZBemVUWXlZVkZhYjBkYVV6WnFJaXdpYUdGdVpHeGxJam9pZDJseVpXRndjRG92THlVME1HRnNhV05sWDNkcGNtVkFkMmx5WlM1amIyMGlMQ0owWldGdElqb2lkMmx5WlNKOS52bkN1T2JURFRLVFhCYXpyX3Z2X0xyZDBZT1Rac2xteHQtM2xKNWZKSU9iRVRidUVCTGlEaS1JVWZHcFJHTm1Dbm9IZjVocHNsWW5HeFMzSjloUmVDZyIsImNsaWVudF9pZCI6IndpcmVhcHA6Ly9ndVZYNXhlRlMzZVRhdG1YQkl5QTRBITdhNDFjZjViNzk2ODM0MTBAd2lyZS5jb20iLCJhcGlfdmVyc2lvbiI6NSwic2NvcGUiOiJ3aXJlX2NsaWVudF9pZCJ9.uCVYhmvCJm7nM1NxJQKl_XZJcSqm9eFmNmbRJkA5Wpsw70ZF1YANYC9nQ91QgsnuAbaRZMJiJt3P8ZntR2ozDQ`
 	ch := &Challenge{
-		Type:  WIREDPOP01,
 		Token: "bXUGNpUfcRx3EhB34xP3y62aQZoGZS6j",
 	}
 
@@ -4361,14 +4360,13 @@ MCowBQYDK2VwAyEAB2IYqBWXAouDt3WcCZgCM3t9gumMEKMlgMsGenSu+fA=
 		}
 
 		// dpop proof assertions
-		dt := *dpop
-		assert.Equal(t, "bXUGNpUfcRx3EhB34xP3y62aQZoGZS6j", dt["chal"].(string))
-		assert.Equal(t, "wireapp://%40alice_wire@wire.com", dt["handle"].(string))
-		assert.Equal(t, "POST", dt["htm"].(string))
-		assert.Equal(t, "http://wire.com:19983/clients/7a41cf5b79683410/access-token", dt["htu"].(string))
-		assert.Equal(t, "5e6684cb-6b48-468d-b091-ff04bed6ec2e", dt["jti"].(string))
-		assert.Equal(t, "UEJyR2dqOEhzZFJEYWJBaTkyODNEYTE2aEs0dHIxcEc", dt["nonce"].(string))
-		assert.Equal(t, "wireapp://guVX5xeFS3eTatmXBIyA4A!7a41cf5b79683410@wire.com", dt["sub"].(string))
-		assert.Equal(t, "wire", dt["team"].(string))
+		assert.Equal(t, "bXUGNpUfcRx3EhB34xP3y62aQZoGZS6j", dpop.Challenge)
+		assert.Equal(t, "wireapp://%40alice_wire@wire.com", dpop.Handle)
+		assert.Equal(t, "POST", dpop.Method)
+		assert.Equal(t, "http://wire.com:19983/clients/7a41cf5b79683410/access-token", dpop.URL)
+		assert.Equal(t, "5e6684cb-6b48-468d-b091-ff04bed6ec2e", dpop.ID)
+		assert.Equal(t, "UEJyR2dqOEhzZFJEYWJBaTkyODNEYTE2aEs0dHIxcEc", dpop.Nonce)
+		assert.Equal(t, "wireapp://guVX5xeFS3eTatmXBIyA4A!7a41cf5b79683410@wire.com", dpop.Subject)
+		assert.Equal(t, "wire", dpop.Team)
 	}
 }

--- a/acme/db.go
+++ b/acme/db.go
@@ -56,8 +56,8 @@ type DB interface {
 
 	// TODO(hs): put in a different interface
 	GetAllOrdersByAccountID(ctx context.Context, accountID string) ([]string, error)
-	CreateDpopToken(ctx context.Context, orderID string, dpop map[string]interface{}) error
-	GetDpopToken(ctx context.Context, orderID string) (map[string]interface{}, error)
+	CreateDpopToken(ctx context.Context, orderID string, dpop *WireDpopToken) error
+	GetDpopToken(ctx context.Context, orderID string) (*WireDpopToken, error)
 	CreateOidcToken(ctx context.Context, orderID string, idToken map[string]interface{}) error
 	GetOidcToken(ctx context.Context, orderID string) (map[string]interface{}, error)
 }
@@ -126,8 +126,8 @@ type MockDB struct {
 	MockUpdateOrder          func(ctx context.Context, o *Order) error
 
 	MockGetAllOrdersByAccountID func(ctx context.Context, accountID string) ([]string, error)
-	MockGetDpopToken            func(ctx context.Context, orderID string) (map[string]interface{}, error)
-	MockCreateDpopToken         func(ctx context.Context, orderID string, dpop map[string]interface{}) error
+	MockGetDpopToken            func(ctx context.Context, orderID string) (*WireDpopToken, error)
+	MockCreateDpopToken         func(ctx context.Context, orderID string, dpop *WireDpopToken) error
 	MockGetOidcToken            func(ctx context.Context, orderID string) (map[string]interface{}, error)
 	MockCreateOidcToken         func(ctx context.Context, orderID string, idToken map[string]interface{}) error
 
@@ -416,17 +416,17 @@ func (m *MockDB) GetAllOrdersByAccountID(ctx context.Context, accountID string) 
 }
 
 // GetDpop retrieves a DPoP from the database.
-func (m *MockDB) GetDpopToken(ctx context.Context, orderID string) (map[string]any, error) {
+func (m *MockDB) GetDpopToken(ctx context.Context, orderID string) (*WireDpopToken, error) {
 	if m.MockGetDpopToken != nil {
 		return m.MockGetDpopToken(ctx, orderID)
 	} else if m.MockError != nil {
 		return nil, m.MockError
 	}
-	return m.MockRet1.(map[string]any), m.MockError
+	return m.MockRet1.(*WireDpopToken), m.MockError
 }
 
 // CreateDpop creates DPoP resources and saves them to the DB.
-func (m *MockDB) CreateDpopToken(ctx context.Context, orderID string, dpop map[string]any) error {
+func (m *MockDB) CreateDpopToken(ctx context.Context, orderID string, dpop *WireDpopToken) error {
 	if m.MockCreateDpopToken != nil {
 		return m.MockCreateDpopToken(ctx, orderID, dpop)
 	}


### PR DESCRIPTION
@maraino this works, and I guess it _can_ be used for DPoPs in practice, because their format should be relatively stable. For OIDC ID tokens it may not be as nice, because those would depend on the IdP, and could contain custom claims too. The thing is that Wire would like to use data from the OIDC ID token (and possibly DPoP token) to put in the template, so you would end up with something like this:

```golang
{{
    "subject": {{
        "organization": "Org",
        "commonName": {{ toJson .Oidc.preferred_username }}
    }},
    "uris": [{{ toJson .Oidc.name }}, {{ toJson .Dpop.Subject }}],
    "keyUsage": ["digitalSignature"],
    "extKeyUsage": ["clientAuth"]
}}
```

Note the difference in capitalization: because for the DPoP we have a struct, it works with `.Dpop.Subject`; for the OIDC claims they would start with a lowercase character. But I think it's better to be consistent, given that they're both tokens, and to always use the lowercase names. Should make things slightly less confusing, I think.

Before this PR, the DPoP URI would be retrieved as `.Dpop.sub`, from the JWT `"sub"` claim. That's actually not that different from what we support with the `.Token`, so maybe it's OK to keep it as a `map[string]any`?

We could also choose to operate on structs for both OIDC and DPoP tokens internally, but to then set them in the template as `map[string]any`?