### PR TITLE
Support executable provisioner password files in RA install script

### DIFF
--- a/scripts/install-step-ra.sh
+++ b/scripts/install-step-ra.sh
@@ -188,7 +188,7 @@ CA_VERSION=$(curl -s https://api.github.com/repos/smallstep/certificates/release
 
 curl -sLO https://github.com/smallstep/certificates/releases/download/$CA_VERSION/step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 tar -xf step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
-install -m 0755 -t /usr/bin step-ca_${CA_VERSION:1}/step-ca
+install -m 0755 -t /usr/bin ./step-ca
 setcap CAP_NET_BIND_SERVICE=+eip $(which step-ca)
 rm step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 rm -rf step-ca_${CA_VERSION:1}

--- a/scripts/install-step-ra.sh
+++ b/scripts/install-step-ra.sh
@@ -181,6 +181,9 @@ fi
 if [ -z "$CA_PROVISIONER_JWK_PASSWORD_FILE" ]; then
     read -s -p "Enter the CA Provisioner Password: " CA_PROVISIONER_JWK_PASSWORD < /dev/tty
     printf "%b" "\n"
+elif [ -x "$CA_PROVISIONER_JWK_PASSWORD_FILE" ]; then
+    echo "Running executable password file: ${CA_PROVISIONER_JWK_PASSWORD_FILE}"
+    CA_PROVISIONER_JWK_PASSWORD=$(/bin/bash ${CA_PROVISIONER_JWK_PASSWORD_FILE})
 fi
 
 echo "Installing 'step-ca' in /usr/bin..."

--- a/scripts/install-step-ra.sh
+++ b/scripts/install-step-ra.sh
@@ -191,7 +191,7 @@ CA_VERSION=$(curl -s https://api.github.com/repos/smallstep/certificates/release
 
 curl -sLO https://github.com/smallstep/certificates/releases/download/$CA_VERSION/step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 tar -xf step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
-install -m 0755 -t /usr/bin ./step-ca
+install -m 0755 -t /usr/bin step-ca_${CA_VERSION:1}/step-ca
 setcap CAP_NET_BIND_SERVICE=+eip $(which step-ca)
 rm step-ca_linux_${CA_VERSION:1}_$arch.tar.gz
 rm -rf step-ca_${CA_VERSION:1}


### PR DESCRIPTION
#### Name of feature:
Fixing install source of step-ca in setup script

#### Pain or issue this feature alleviates:
Following the guide on: https://smallstep.com/docs/registration-authorities/acme-for-certificate-manager/index.html?fingerprint=41363fbbc3b4c23a38b1ad6120da34a7876e0480bebd8aa72c12d7a7dbe75d29&caUrl=https://home.edholm.ca.smallstep.com&#1-create-your-ra leads me to download a setup script. Most of the script works as intended, but after the extraction of `step-ca`, the install looks for the `step-ca` in the wrong directory. This PR adjusts the source dir to where `step-ca` actually ends up.