### PR TITLE
fix: Also instrument webhooks that do not reach the wire

### DIFF
--- a/authority/ssh.go
+++ b/authority/ssh.go
@@ -675,14 +675,13 @@ func (a *Authority) callEnrichingWebhooksSSH(ctx context.Context, prov provision
 	if webhookCtl == nil {
 		return
 	}
+	defer func() { a.meter.SSHWebhookEnriched(prov, err) }()
 
 	var whEnrichReq *webhook.RequestBody
 	if whEnrichReq, err = webhook.NewRequestBody(
 		webhook.WithSSHCertificateRequest(cr),
 	); err == nil {
 		err = webhookCtl.Enrich(ctx, whEnrichReq)
-
-		a.meter.SSHWebhookEnriched(prov, err)
 	}
 
 	return
@@ -692,14 +691,13 @@ func (a *Authority) callAuthorizingWebhooksSSH(ctx context.Context, prov provisi
 	if webhookCtl == nil {
 		return
 	}
+	defer func() { a.meter.SSHWebhookAuthorized(prov, err) }()
 
 	var whAuthBody *webhook.RequestBody
 	if whAuthBody, err = webhook.NewRequestBody(
 		webhook.WithSSHCertificate(cert, certTpl),
 	); err == nil {
 		err = webhookCtl.Authorize(ctx, whAuthBody)
-
-		a.meter.SSHWebhookAuthorized(prov, err)
 	}
 
 	return

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -999,6 +999,7 @@ func (a *Authority) callEnrichingWebhooksX509(ctx context.Context, prov provisio
 	if webhookCtl == nil {
 		return
 	}
+	defer func() { a.meter.X509WebhookEnriched(prov, err) }()
 
 	var attested *webhook.AttestationData
 	if attData != nil {
@@ -1013,8 +1014,6 @@ func (a *Authority) callEnrichingWebhooksX509(ctx context.Context, prov provisio
 		webhook.WithAttestationData(attested),
 	); err == nil {
 		err = webhookCtl.Enrich(ctx, whEnrichReq)
-
-		a.meter.X509WebhookEnriched(prov, err)
 	}
 
 	return
@@ -1024,6 +1023,7 @@ func (a *Authority) callAuthorizingWebhooksX509(ctx context.Context, prov provis
 	if webhookCtl == nil {
 		return
 	}
+	defer func() { a.meter.X509WebhookAuthorized(prov, err) }()
 
 	var attested *webhook.AttestationData
 	if attData != nil {
@@ -1038,8 +1038,6 @@ func (a *Authority) callAuthorizingWebhooksX509(ctx context.Context, prov provis
 		webhook.WithAttestationData(attested),
 	); err == nil {
 		err = webhookCtl.Authorize(ctx, whAuthBody)
-
-		a.meter.X509WebhookAuthorized(prov, err)
 	}
 
 	return

--- a/internal/metrix/meter.go
+++ b/internal/metrix/meter.go
@@ -42,9 +42,13 @@ func New() (m *Meter) {
 		m.ssh.rekeyed,
 		m.ssh.renewed,
 		m.ssh.signed,
+		m.ssh.webhookAuthorized,
+		m.ssh.webhookEnriched,
 		m.x509.rekeyed,
 		m.x509.renewed,
 		m.x509.signed,
+		m.x509.webhookAuthorized,
+		m.x509.webhookEnriched,
 		m.kms.signed,
 		m.kms.errors,
 	)


### PR DESCRIPTION
This PR refactors the webhook-related instrumentation so that it captures errors in cases where the request's body does not end up hitting the wire. It also registers the forgotten webhook-related instruments to the Prometheus endpoint.