### PR TITLE
Fix the `id-scep-failInfoText` OID

### DIFF
--- a/scep/scep.go
+++ b/scep/scep.go
@@ -29,7 +29,7 @@ var (
 	oidSCEPsenderNonce    = asn1.ObjectIdentifier{2, 16, 840, 1, 113733, 1, 9, 5}
 	oidSCEPrecipientNonce = asn1.ObjectIdentifier{2, 16, 840, 1, 113733, 1, 9, 6}
 	oidSCEPtransactionID  = asn1.ObjectIdentifier{2, 16, 840, 1, 113733, 1, 9, 7}
-	oidSCEPfailInfoText   = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 24}
+	oidSCEPfailInfoText   = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 24, 1}
 	//oidChallengePassword  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 7}
 )
 


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc8894.html#section-6 and http://oid-info.com/get/1.3.6.1.5.5.7.24.1

When reporting an error message to the client as part of the SCEP protocol, the client will look for this OID to print the error text. Currently it would only print the the `failInfo` correctly (e.g. 2 for a bad request), but not the actual error message that we send.