### PR TITLE
Prevent exposing any internal details in SCEP failure message

### DIFF
--- a/scep/authority.go
+++ b/scep/authority.go
@@ -308,7 +308,7 @@ func (a *Authority) SignCSR(ctx context.Context, csr *x509.CertificateRequest, m
 
 	certChain, err := a.signAuth.SignWithContext(ctx, csr, opts, signOps...)
 	if err != nil {
-		return nil, fmt.Errorf("error generating certificate for order: %w", err)
+		return nil, fmt.Errorf("error generating certificate: %w", err)
 	}
 
 	// take the issued certificate (only); https://tools.ietf.org/html/rfc8894#section-3.3.2


### PR DESCRIPTION
To be on the safe side, block errors from signing operations from being returned to the client. We should revisit, and make it return a more informative error, but with high assurance that no sensitive information is added to the message.
