### PR TITLE
Add scopes to OIDC configuration

### DIFF
--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -92,6 +92,7 @@ type OIDC struct {
 	Groups                []string `json:"groups,omitempty"`
 	ListenAddress         string   `json:"listenAddress,omitempty"`
 	Claims                *Claims  `json:"claims,omitempty"`
+	Scopes                []string `json:"scopes,omitempty"`
 	Options               *Options `json:"options,omitempty"`
 	configuration         openIDConfiguration
 	keyStore              *keyStore


### PR DESCRIPTION
This allows the CLI to retrieve custom scopes from the provider for use when performing the oauth exchange to generate a token. Custom scopes are useful, for example, when using the OIDC provider with Dex and Github in that it allows the preferred_username or federated_claims.user_id fields to be returned with the token for use in SSH certificate templates (ie. to identify a Github user via `extensions:login@github.com`).

Example usage: 
`ca.json`:
```
{
    "type": "OIDC",
    ...
    "scopes": ["openid","email","profile","federated:id"]
}
```

SSH template:
```
	"extensions": {
	  "id@github.com": {{ toJson .Token.federated_claims.user_id }}
	}
```

This will be followed up with a corresponding PR for `smallstep/cli` that makes use of the feature... update: https://github.com/smallstep/cli/pull/1150

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Custom scopes for OIDC providers.

#### Pain or issue this feature alleviates:

The inability to use step-ca for generating [ssh certificates for github](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities#issuing-certificates) when using Dex as an OIDC provider (Dex is configured to use the [Github connector](https://dexidp.io/docs/connectors/github/)).

#### Why is this important to the project (if not answered above):

Answered above.

#### Is there documentation on how to use this feature? If so, where?

No, because I could not find where to update https://smallstep.com/docs/step-ca. If you point me in the right direction, I will happily update the docs.

#### In what environments or workflows is this feature supported?

OIDC providers.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Non-OIDC providers.

#### Supporting links/other PRs/issues:
PR that makes use of the feature in the step CLI: https://github.com/smallstep/cli/pull/1150
