### PR TITLE
Add ca-certificates to Dockerfile.hsm

### DIFF
--- a/docker/Dockerfile.hsm
+++ b/docker/Dockerfile.hsm
@@ -18,7 +18,8 @@ COPY --from=kms /usr/local/bin/step-kms-plugin /usr/local/bin/step-kms-plugin
 
 USER root
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends pcscd libpcsclite1
+RUN apt-get install -y --no-install-recommends pcscd libpcsclite1 ca-certificates
+RUN update-ca-certificates
 RUN mkdir -p /run/pcscd
 RUN chown step:step /run/pcscd
 USER step


### PR DESCRIPTION
This addition is necessary if you want to run the `smallstep/step-ca:hsm` container in linked mode. Without `ca-certificates`, the container is unable to verify https certificates of and connect to `smallstep.com`

#### Name of feature:
Adds `ca-certificates` package to `smallstep/step-ca:hsm` docker image. 

#### Pain or issue this feature alleviates:
As of time of pull request, the `smallstep/step-ca:hsm` docker image cannot run `step-ca` in linked mode, because it cannot verify the https certificate of and connect to `smallstep.com`. This change will add the typical public root CAs to the container's truststore.  

#### Why is this important to the project (if not answered above):
I want to run the container in linked mode

#### Is there documentation on how to use this feature? If so, where?
N/A

#### In what environments or workflows is this feature supported?
N/A

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A

#### Supporting links/other PRs/issues:

💔Thank you!
