### PR TITLE
Use always acme.IsErrNotFound

### DIFF
--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -247,7 +247,7 @@ func extractJWK(next nextHTTP) nextHTTP {
 		// Get Account OR continue to generate a new one OR continue Revoke with certificate private key
 		acc, err := db.GetAccountByKeyID(ctx, jwk.KeyID)
 		switch {
-		case errors.Is(err, acme.ErrNotFound):
+		case acme.IsErrNotFound(err):
 			// For NewAccount and Revoke requests ...
 			break
 		case err != nil:

--- a/authority/admin/api/middleware.go
+++ b/authority/admin/api/middleware.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -125,7 +124,7 @@ func loadExternalAccountKey(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		if err != nil {
-			if errors.Is(err, acme.ErrNotFound) {
+			if acme.IsErrNotFound(err) {
 				render.Error(w, admin.NewError(admin.ErrorNotFoundType, "ACME External Account Key not found"))
 				return
 			}


### PR DESCRIPTION
This commit replaces the comparisons with acme.ErrNotFound and always uses acme.IsErrNotFound.
