### PR TITLE
make integration tests less flaky

### DIFF
--- a/test/integration/requestid_test.go
+++ b/test/integration/requestid_test.go
@@ -135,11 +135,13 @@ func Test_reflectRequestID(t *testing.T) {
 
 	// require OK health response as the baseline
 	ctx := context.Background()
-	healthResponse, err := caClient.HealthWithContext(ctx)
-	require.NoError(t, err)
-	if assert.NotNil(t, healthResponse) {
-		require.Equal(t, "ok", healthResponse.Status)
-	}
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		healthResponse, err := caClient.HealthWithContext(ctx)
+		require.NoError(c, err)
+		if assert.NotNil(c, healthResponse) {
+			require.Equal(c, "ok", healthResponse.Status)
+		}
+	}, 5*time.Second, time.Second)
 
 	// expect an error when retrieving an invalid root
 	rootResponse, err := caClient.RootWithContext(ctx, "invalid")

--- a/test/integration/scep/common_test.go
+++ b/test/integration/scep/common_test.go
@@ -40,11 +40,13 @@ func newCAClient(t *testing.T, caURL, rootFilepath string) *ca.Client {
 
 func requireHealthyCA(t *testing.T, caClient *ca.Client) {
 	ctx := context.Background()
-	healthResponse, err := caClient.HealthWithContext(ctx)
-	require.NoError(t, err)
-	if assert.NotNil(t, healthResponse) {
-		require.Equal(t, "ok", healthResponse.Status)
-	}
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		healthResponse, err := caClient.HealthWithContext(ctx)
+		require.NoError(c, err)
+		if assert.NotNil(c, healthResponse) {
+			require.Equal(c, "ok", healthResponse.Status)
+		}
+	}, 5*time.Second, time.Second)
 }
 
 // reservePort "reserves" a TCP port by opening a listener on a random


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
make the integration tests less flaky on checking the health of running step-ca instance

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):
it sometimes happens that the server is not started before checking the health of the running server, this is caused by starting the server in a separate goroutine and there is no synchronization before testing the health of the server, it usually passes due to race condition

#### Is there documentation on how to use this feature? If so, where?
no

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
