### PR TITLE
Update entrypoint.sh to add /docker-entrypoint-initdb.d

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -76,6 +76,17 @@ function step_ca_init () {
     echo "🤫 This will only be displayed once."
     shred -u $STEPPATH/provisioner_password
     mv $STEPPATH/password $PWDPATH
+
+    # Run scripts in /docker-entrypoint-initdb.d
+    if [ -d /docker-entrypoint-initdb.d ]; then
+        for f in /docker-entrypoint-initdb.d/*; do
+            case "$f" in
+                *.sh)  echo "$0: running $f"; . "$f" ;;
+                *)     echo "$0: ignoring $f" ;;
+            esac
+            echo
+        done
+    fi
 }
 
 if [ -f /usr/sbin/pcscd ]; then


### PR DESCRIPTION

#### Name of feature:

Add /docker-entrypoint-initdb.d support like most other images.

#### Pain or issue this feature alleviates:

This will only run these on init and allows adding scripts that modify the setup just after first init, for example you could use it to modify ca.json and add/change datasource.

#### Why is this important to the project (if not answered above):

Instead of having to create/override the default entrypoint this allows to extend functionality like most other docker images

#### Supporting links/other PRs/issues:

May help with items like https://github.com/smallstep/certificates/issues/1875, https://github.com/smallstep/certificates/issues/807 as these could be added as init scripts.
