### PR TITLE
Fix HTTP01 challenge url when --acme-http-host is used

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -117,7 +117,9 @@ func http01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSONWeb
 	// Append insecure port if set.
 	// Only used for testing purposes.
 	if InsecurePortHTTP01 != 0 {
-		u.Host += ":" + strconv.Itoa(InsecurePortHTTP01)
+		insecurePort := strconv.Itoa(InsecurePortHTTP01)
+		u.Host += ":" + insecurePort
+		challengeURL.Host += ":" + insecurePort
 	}
 
 	vc := MustClientFromContext(ctx)


### PR DESCRIPTION
This commit fixes an issue with the HTTP-01 challenge URL not having the insecure port.
