### PR TITLE
Add a flag to enable strict DNS resolution

### DIFF
--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -63,6 +63,11 @@ var (
 	//
 	// This variable can be used for testing purposes.
 	InsecurePortTLSALPN01 int
+
+	// StrictFQDN allows to enforce a fully qualified domain name in the DNS
+	// resolution. By default it allows domain resolution using a search list
+	// defined in the resolv.conf or similar configuration.
+	StrictFQDN bool
 )
 
 // Challenge represents an ACME response Challenge type.
@@ -163,8 +168,10 @@ func http01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose.JSONWeb
 
 // rootedName adds a trailing "." to a given domain name.
 func rootedName(name string) string {
-	if name == "" || name[len(name)-1] != '.' {
-		return name + "."
+	if StrictFQDN {
+		if name == "" || name[len(name)-1] != '.' {
+			return name + "."
+		}
 	}
 	return name
 }

--- a/commands/app.go
+++ b/commands/app.go
@@ -83,6 +83,10 @@ Requires **--insecure** flag.`,
 			Usage: `the <port> used on tls-alpn-01 challenges. It can be changed for testing purposes.
 Requires **--insecure** flag.`,
 		},
+		cli.BoolFlag{
+			Name:  "acme-strict-fqdn",
+			Usage: `enable strict DNS resolution using a fully qualified domain name.`,
+		},
 		cli.StringFlag{
 			Name:  "pidfile",
 			Usage: "the path to the <file> to write the process ID.",
@@ -125,6 +129,9 @@ func appAction(ctx *cli.Context) error {
 			return fmt.Errorf("flag '--acme-tls-port' requires the '--insecure' flag")
 		}
 	}
+
+	// Set the strict DNS resolution on ACME challenges. Defaults to false.
+	acme.StrictFQDN = ctx.Bool("acme-strict-fqdn")
 
 	// Allow custom contexts.
 	if caCtx := ctx.String("context"); caCtx != "" {


### PR DESCRIPTION
This commit adds a flag to enable strict DNS resolution on ACME challenges.

Starting the server with `step-ca --acme-strict-fqdn` will not expand the DNS lookup to the `resolv.conf` search list. By default, it will.
