### PR TITLE
Allow to use private  IdPs with the OIDC provisioner

### DIFF
--- a/authority/http_client.go
+++ b/authority/http_client.go
@@ -1,0 +1,34 @@
+package authority
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+)
+
+// newHTTPClient returns an HTTP client that trusts the system cert pool and the
+// given roots.
+func newHTTPClient(roots ...*x509.Certificate) (*http.Client, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing http client: %w", err)
+	}
+	for _, crt := range roots {
+		pool.AddCert(crt)
+	}
+
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("error initializing http client: type is not *http.Transport")
+	}
+	tr = tr.Clone()
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+	}
+
+	return &http.Client{
+		Transport: tr,
+	}, nil
+}

--- a/authority/http_client_test.go
+++ b/authority/http_client_test.go
@@ -1,0 +1,105 @@
+package authority
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/smallstep/certificates/authority/provisioner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.step.sm/crypto/jose"
+	"go.step.sm/crypto/keyutil"
+	"go.step.sm/crypto/x509util"
+)
+
+func mustCertificate(t *testing.T, a *Authority, csr *x509.CertificateRequest) []*x509.Certificate {
+	t.Helper()
+
+	ctx := provisioner.NewContextWithMethod(context.Background(), provisioner.SignMethod)
+
+	now := time.Now()
+	signOpts := provisioner.SignOptions{
+		NotBefore: provisioner.NewTimeDuration(now),
+		NotAfter:  provisioner.NewTimeDuration(now.Add(5 * time.Minute)),
+		Backdate:  1 * time.Minute,
+	}
+
+	sans := []string{}
+	sans = append(sans, csr.DNSNames...)
+	sans = append(sans, csr.EmailAddresses...)
+	for _, s := range csr.IPAddresses {
+		sans = append(sans, s.String())
+	}
+	for _, s := range csr.URIs {
+		sans = append(sans, s.String())
+	}
+
+	key, err := jose.ReadKey("testdata/secrets/step_cli_key_priv.jwk", jose.WithPassword([]byte("pass")))
+	require.NoError(t, err)
+
+	token, err := generateToken(csr.Subject.CommonName, "step-cli", testAudiences.Sign[0], sans, now, key)
+	require.NoError(t, err)
+
+	extraOpts, err := a.Authorize(ctx, token)
+	require.NoError(t, err)
+
+	chain, err := a.SignWithContext(ctx, csr, signOpts, extraOpts...)
+	require.NoError(t, err)
+
+	return chain
+}
+
+func Test_newHTTPClient(t *testing.T) {
+	signer, err := keyutil.GenerateDefaultSigner()
+	require.NoError(t, err)
+
+	csr, err := x509util.CreateCertificateRequest("test", []string{"localhost", "127.0.0.1", "[::1]"}, signer)
+	require.NoError(t, err)
+
+	auth := testAuthority(t)
+	chain := mustCertificate(t, auth, csr)
+
+	t.Run("SystemCertPool", func(t *testing.T) {
+		resp, err := auth.httpClient.Get("https://smallstep.com")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		b, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, b)
+		assert.NoError(t, resp.Body.Close())
+	})
+
+	t.Run("LocalCertPool", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "ok")
+		}))
+		srv.TLS = &tls.Config{
+			Certificates: []tls.Certificate{
+				{Certificate: [][]byte{chain[0].Raw, chain[1].Raw}, PrivateKey: signer, Leaf: chain[0]},
+			},
+		}
+		srv.StartTLS()
+		defer srv.Close()
+
+		resp, err := auth.httpClient.Get(srv.URL)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		b, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("ok"), b)
+		assert.NoError(t, resp.Body.Close())
+
+		t.Run("DefaultClient", func(t *testing.T) {
+			client := &http.Client{}
+			_, err := client.Get(srv.URL)
+			assert.Error(t, err)
+		})
+	})
+}

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -251,14 +251,14 @@ func (p *Azure) Init(config Config) (err error) {
 	p.assertConfig()
 
 	// Decode and validate openid-configuration endpoint
-	if err = getAndDecode(p.config.oidcDiscoveryURL, &p.oidcConfig); err != nil {
+	if err = getAndDecode(http.DefaultClient, p.config.oidcDiscoveryURL, &p.oidcConfig); err != nil {
 		return
 	}
 	if err := p.oidcConfig.Validate(); err != nil {
 		return errors.Wrapf(err, "error parsing %s", p.config.oidcDiscoveryURL)
 	}
 	// Get JWK key set
-	if p.keyStore, err = newKeyStore(p.oidcConfig.JWKSetURI); err != nil {
+	if p.keyStore, err = newKeyStore(http.DefaultClient, p.oidcConfig.JWKSetURI); err != nil {
 		return
 	}
 

--- a/authority/provisioner/controller.go
+++ b/authority/provisioner/controller.go
@@ -26,6 +26,7 @@ type Controller struct {
 	policy                *policyEngine
 	webhookClient         *http.Client
 	webhooks              []*Webhook
+	httpClient            *http.Client
 }
 
 // NewController initializes a new provisioner controller.
@@ -48,7 +49,17 @@ func NewController(p Interface, claims *Claims, config Config, options *Options)
 		policy:                policy,
 		webhookClient:         config.WebhookClient,
 		webhooks:              options.GetWebhooks(),
+		httpClient:            config.HTTPClient,
 	}, nil
+}
+
+// GetHTTPClient returns the configured HTTP client or the default one if none
+// is configured.
+func (c *Controller) GetHTTPClient() *http.Client {
+	if c.httpClient != nil {
+		return c.httpClient
+	}
+	return &http.Client{}
 }
 
 // GetIdentity returns the identity for a given email.

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -212,7 +212,7 @@ func (p *GCP) Init(config Config) (err error) {
 	p.assertConfig()
 
 	// Initialize key store
-	if p.keyStore, err = newKeyStore(p.config.CertsURL); err != nil {
+	if p.keyStore, err = newKeyStore(http.DefaultClient, p.config.CertsURL); err != nil {
 		return
 	}
 

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -261,6 +261,9 @@ type Config struct {
 	WebhookClient *http.Client
 	// SCEPKeyManager, if defined, is the interface used by SCEP provisioners.
 	SCEPKeyManager SCEPKeyManager
+	// HTTPClient is an HTTP client that trust the system cert pool and the CA
+	// roots.
+	HTTPClient *http.Client
 }
 
 type provisioner struct {

--- a/authority/provisioners.go
+++ b/authority/provisioners.go
@@ -201,6 +201,7 @@ func (a *Authority) generateProvisionerConfig(ctx context.Context) (provisioner.
 		AuthorizeRenewFunc:    a.authorizeRenewFunc,
 		AuthorizeSSHRenewFunc: a.authorizeSSHRenewFunc,
 		WebhookClient:         a.webhookClient,
+		HTTPClient:            a.httpClient,
 		SCEPKeyManager:        a.scepKeyManager,
 	}, nil
 }


### PR DESCRIPTION
This commit allows the OIDC provisioner to be used with private identity providers using a certificate from step-ca.

Fixes #1909

cc: @tashian 
