### PR TITLE
Add option for the logging middleware to log real IP

### DIFF
--- a/logging/handler.go
+++ b/logging/handler.go
@@ -14,6 +14,14 @@ import (
 	"github.com/smallstep/certificates/middleware/requestid"
 )
 
+// Common headers used for identifying the originating IP address of a client
+// connecting to a web server through a proxy server
+var (
+	trueClientIP  = http.CanonicalHeaderKey("True-Client-IP")
+	xRealIP       = http.CanonicalHeaderKey("X-Real-IP")
+	xForwardedFor = http.CanonicalHeaderKey("X-Forwarded-For")
+)
+
 // LoggerHandler creates a logger handler
 type LoggerHandler struct {
 	name    string
@@ -28,16 +36,23 @@ type options struct {
 	// endpoint should only be logged at the TRACE level in the (expected) HTTP
 	// 200 case
 	onlyTraceHealthEndpoint bool
+
+	// logRealIP determines if the real IP address of the client should be logged
+	// instead of the IP address of the proxy
+	logRealIP bool
 }
 
 // NewLoggerHandler returns the given http.Handler with the logger integrated.
 func NewLoggerHandler(name string, logger *Logger, next http.Handler) http.Handler {
 	onlyTraceHealthEndpoint, _ := strconv.ParseBool(os.Getenv("STEP_LOGGER_ONLY_TRACE_HEALTH_ENDPOINT"))
+	logRealIP, _ := strconv.ParseBool(os.Getenv("STEP_LOGGER_LOG_REAL_IP"))
+
 	return &LoggerHandler{
 		name:   name,
 		logger: logger.GetImpl(),
 		options: options{
 			onlyTraceHealthEndpoint: onlyTraceHealthEndpoint,
+			logRealIP:               logRealIP,
 		},
 		next: next,
 	}
@@ -67,9 +82,12 @@ func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Tim
 	}
 
 	// Remote hostname
-	addr, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		addr = r.RemoteAddr
+	addr := r.RemoteAddr
+	if l.options.logRealIP {
+		addr = realIP(r)
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
 	}
 
 	// From https://github.com/gorilla/handlers
@@ -124,4 +142,28 @@ func (l *LoggerHandler) writeEntry(w ResponseLogger, r *http.Request, t time.Tim
 func sanitizeLogEntry(s string) string {
 	escaped := strings.ReplaceAll(s, "\n", "")
 	return strings.ReplaceAll(escaped, "\r", "")
+}
+
+// realIP returns the real IP address of the client connecting to the server by
+// parsing either the True-Client-IP, X-Real-IP or the X-Forwarded-For headers
+// (in that order). If the headers are not set or set to an invalid IP, it
+// returns the RemoteAddr of the request.
+func realIP(r *http.Request) string {
+	var ip string
+
+	if tcip := r.Header.Get(trueClientIP); tcip != "" {
+		ip = tcip
+	} else if xrip := r.Header.Get(xRealIP); xrip != "" {
+		ip = xrip
+	} else if xff := r.Header.Get(xForwardedFor); xff != "" {
+		i := strings.Index(xff, ",")
+		if i == -1 {
+			i = len(xff)
+		}
+		ip = xff[:i]
+	}
+	if ip == "" || net.ParseIP(ip) == nil {
+		return r.RemoteAddr
+	}
+	return ip
 }


### PR DESCRIPTION
Implements #1995

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:

Please refer to #1995.

#### Why is this important to the project (if not answered above):

N/A

#### Is there documentation on how to use this feature? If so, where?

N/A

#### In what environments or workflows is this feature supported?

When step-ca is sitting behind a reverse proxy, e.g. AWS ALB, Cloudflare and so on.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

N/A

It is worth noting that this feature is best not to be turned on when you can't trust the headers used, see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#security_and_privacy_concerns) for more info,

#### Supporting links/other PRs/issues:

- https://github.com/smallstep/certificates/issues/1995
- The `realIP` function is mostly borrowed from [chi's realip middleware](https://github.com/go-chi/chi/blob/master/middleware/realip.go). 

💔Thank you!
