### PR TITLE
Allow Tokens for Renewing Certificates

### DIFF
--- a/ca/provisioner.go
+++ b/ca/provisioner.go
@@ -118,6 +118,7 @@ func (p *Provisioner) Token(subject string, sans ...string) (string, error) {
 	return tok.SignedString(p.jwk.Algorithm, p.jwk.Key)
 }
 
+// RenewalToken generates a token for use with renewing certificates
 func (p *Provisioner) RenewalToken(subject string, sans ...string) (string, error) {
 	oldAudience := p.audience
 	u := p.endpoint.ResolveReference(&url.URL{Path: "/1.0/renew"}).String()

--- a/ca/provisioner.go
+++ b/ca/provisioner.go
@@ -85,6 +85,7 @@ func (p *Provisioner) SetFingerprint(sum string) {
 
 // Token generates a bootstrap token for a subject.
 func (p *Provisioner) Token(subject string, sans ...string) (string, error) {
+	p.endpoint.ResolveReference(&url.URL{Path: "/1.0/renew"})
 	if len(sans) == 0 {
 		sans = []string{subject}
 	}
@@ -116,6 +117,15 @@ func (p *Provisioner) Token(subject string, sans ...string) (string, error) {
 	}
 
 	return tok.SignedString(p.jwk.Algorithm, p.jwk.Key)
+}
+
+func (p *Provisioner) RenewalToken(subject string, sans ...string) (string, error) {
+	oldAudience := p.audience
+	u := p.endpoint.ResolveReference(&url.URL{Path: "/1.0/renew"}).String()
+	p.audience = u
+	response, err := p.Token(subject, sans...)
+	p.audience = oldAudience
+	return response, err
 }
 
 // SSHToken generates a SSH token.

--- a/ca/provisioner.go
+++ b/ca/provisioner.go
@@ -85,7 +85,6 @@ func (p *Provisioner) SetFingerprint(sum string) {
 
 // Token generates a bootstrap token for a subject.
 func (p *Provisioner) Token(subject string, sans ...string) (string, error) {
-	p.endpoint.ResolveReference(&url.URL{Path: "/1.0/renew"})
 	if len(sans) == 0 {
 		sans = []string{subject}
 	}

--- a/ca/provisioner_test.go
+++ b/ca/provisioner_test.go
@@ -296,6 +296,204 @@ func TestProvisioner_IPv6Token(t *testing.T) {
 	}
 }
 
+func TestProvisioner_RenewalToken(t *testing.T) {
+	p := getTestProvisioner(t, "https://127.0.0.1:9000")
+	sha := "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7"
+
+	type fields struct {
+		name          string
+		kid           string
+		fingerprint   string
+		jwk           *jose.JSONWebKey
+		tokenLifetime time.Duration
+	}
+	type args struct {
+		subject string
+		sans    []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{"ok", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", nil}, false},
+		{"ok-with-san", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", []string{"foo.smallstep.com"}}, false},
+		{"ok-with-sans", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", []string{"foo.smallstep.com", "127.0.0.1"}}, false},
+		{"fail-no-subject", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"", []string{"foo.smallstep.com"}}, true},
+		{"fail-no-key", fields{p.name, p.kid, sha, &jose.JSONWebKey{}, p.tokenLifetime}, args{"subject", nil}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provisioner{
+				name:          tt.fields.name,
+				kid:           tt.fields.kid,
+				audience:      "https://127.0.0.1:9000/1.0/sign",
+				fingerprint:   tt.fields.fingerprint,
+				jwk:           tt.fields.jwk,
+				tokenLifetime: tt.fields.tokenLifetime,
+			}
+			got, err := p.RenewalToken(tt.args.subject, tt.args.sans...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Provisioner.Token() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == false {
+				jwt, err := jose.ParseSigned(got)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				var claims jose.Claims
+				if err := jwt.Claims(tt.fields.jwk.Public(), &claims); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := claims.ValidateWithLeeway(jose.Expected{
+					Audience: []string{"https://127.0.0.1:9000/1.0/renew"},
+					Issuer:   tt.fields.name,
+					Subject:  tt.args.subject,
+					Time:     time.Now().UTC(),
+				}, time.Minute); err != nil {
+					t.Error(err)
+					return
+				}
+				lifetime := claims.Expiry.Time().Sub(claims.NotBefore.Time())
+				if lifetime != tt.fields.tokenLifetime {
+					t.Errorf("Claims token life time = %s, want %s", lifetime, tt.fields.tokenLifetime)
+				}
+				allClaims := make(map[string]interface{})
+				if err := jwt.Claims(tt.fields.jwk.Public(), &allClaims); err != nil {
+					t.Error(err)
+					return
+				}
+				if v, ok := allClaims["sha"].(string); !ok || v != sha {
+					t.Errorf("Claim sha = %s, want %s", v, sha)
+				}
+				if len(tt.args.sans) == 0 {
+					if v, ok := allClaims["sans"].([]interface{}); !ok || !reflect.DeepEqual(v, []interface{}{tt.args.subject}) {
+						t.Errorf("Claim sans = %s, want %s", v, []interface{}{tt.args.subject})
+					}
+				} else {
+					want := []interface{}{}
+					for _, s := range tt.args.sans {
+						want = append(want, s)
+					}
+					if v, ok := allClaims["sans"].([]interface{}); !ok || !reflect.DeepEqual(v, want) {
+						t.Errorf("Claim sans = %s, want %s", v, want)
+					}
+				}
+				if v, ok := allClaims["jti"].(string); !ok || v == "" {
+					t.Errorf("Claim jti = %s, want not blank", v)
+				}
+				if p.audience != "https://127.0.0.1:9000/1.0/sign" {
+					t.Errorf("Provisioner audience = %s, want %s", p.audience, "https://127.0.0.1:9000/1.0/sign")
+				}
+			}
+		})
+	}
+}
+
+func TestProvisioner_RenewalIPv6Token(t *testing.T) {
+	p := getTestProvisioner(t, "https://[::1]:9000")
+	sha := "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7"
+
+	type fields struct {
+		name          string
+		kid           string
+		fingerprint   string
+		jwk           *jose.JSONWebKey
+		tokenLifetime time.Duration
+	}
+	type args struct {
+		subject string
+		sans    []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{"ok", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", nil}, false},
+		{"ok-with-san", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", []string{"foo.smallstep.com"}}, false},
+		{"ok-with-sans", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"subject", []string{"foo.smallstep.com", "127.0.0.1"}}, false},
+		{"fail-no-subject", fields{p.name, p.kid, sha, p.jwk, p.tokenLifetime}, args{"", []string{"foo.smallstep.com"}}, true},
+		{"fail-no-key", fields{p.name, p.kid, sha, &jose.JSONWebKey{}, p.tokenLifetime}, args{"subject", nil}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provisioner{
+				name:          tt.fields.name,
+				kid:           tt.fields.kid,
+				audience:      "https://[::1]:9000/1.0/sign",
+				fingerprint:   tt.fields.fingerprint,
+				jwk:           tt.fields.jwk,
+				tokenLifetime: tt.fields.tokenLifetime,
+			}
+			got, err := p.RenewalToken(tt.args.subject, tt.args.sans...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Provisioner.Token() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == false {
+				jwt, err := jose.ParseSigned(got)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				var claims jose.Claims
+				if err := jwt.Claims(tt.fields.jwk.Public(), &claims); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := claims.ValidateWithLeeway(jose.Expected{
+					Audience: []string{"https://[::1]:9000/1.0/renew"},
+					Issuer:   tt.fields.name,
+					Subject:  tt.args.subject,
+					Time:     time.Now().UTC(),
+				}, time.Minute); err != nil {
+					t.Error(err)
+					return
+				}
+				lifetime := claims.Expiry.Time().Sub(claims.NotBefore.Time())
+				if lifetime != tt.fields.tokenLifetime {
+					t.Errorf("Claims token life time = %s, want %s", lifetime, tt.fields.tokenLifetime)
+				}
+				allClaims := make(map[string]interface{})
+				if err := jwt.Claims(tt.fields.jwk.Public(), &allClaims); err != nil {
+					t.Error(err)
+					return
+				}
+				if v, ok := allClaims["sha"].(string); !ok || v != sha {
+					t.Errorf("Claim sha = %s, want %s", v, sha)
+				}
+				if len(tt.args.sans) == 0 {
+					if v, ok := allClaims["sans"].([]interface{}); !ok || !reflect.DeepEqual(v, []interface{}{tt.args.subject}) {
+						t.Errorf("Claim sans = %s, want %s", v, []interface{}{tt.args.subject})
+					}
+				} else {
+					want := []interface{}{}
+					for _, s := range tt.args.sans {
+						want = append(want, s)
+					}
+					if v, ok := allClaims["sans"].([]interface{}); !ok || !reflect.DeepEqual(v, want) {
+						t.Errorf("Claim sans = %s, want %s", v, want)
+					}
+				}
+				if v, ok := allClaims["jti"].(string); !ok || v == "" {
+					t.Errorf("Claim jti = %s, want not blank", v)
+				}
+				if p.audience != "https://[::1]:9000/1.0/sign" {
+					t.Errorf("Provisioner audience = %s, want %s", p.audience, "https://[::1]:9000/1.0/sign")
+				}
+			}
+		})
+	}
+}
+
 func TestProvisioner_SSHToken(t *testing.T) {
 	p := getTestProvisioner(t, "https://127.0.0.1:9000")
 	sha := "ef742f95dc0d8aa82d3cca4017af6dac3fce84290344159891952d18c53eefe7"


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: Provide Functionality for Tokens to be Used for Renewing Certificates

#### Pain or issue this feature alleviates: Currently, a provisioner doesn't allow for tokens to be used in the `provisioner.RenewWithToken` function as the audience is set to use `/1.0/sign`, which makes the token invalid for renewing certificates.

#### Why is this important to the project (if not answered above): Renewal of certificates via tokens issued with a provisioner is required for planned application usage.

#### Is there documentation on how to use this feature? If so, where?
None that I am aware of.

#### In what environments or workflows is this feature supported?
Any environments where this usage is planned or expected.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
None

#### Supporting links/other PRs/issues: N/A

💔Thank you!
