### PR TITLE
Use dnsNamesSubsetValidator for IID provisioners

### DIFF
--- a/authority/provisioner/aws.go
+++ b/authority/provisioner/aws.go
@@ -358,7 +358,7 @@ func (p *AWS) AuthorizeSign(ctx context.Context, token string) ([]SignOption, er
 	if p.DisableCustomSANs {
 		dnsName := fmt.Sprintf("ip-%s.%s.compute.internal", strings.ReplaceAll(doc.PrivateIP, ".", "-"), doc.Region)
 		so = append(so,
-			dnsNamesValidator([]string{dnsName}),
+			dnsNamesSubsetValidator([]string{dnsName}),
 			ipAddressesValidator([]net.IP{
 				net.ParseIP(doc.PrivateIP),
 			}),

--- a/authority/provisioner/aws_test.go
+++ b/authority/provisioner/aws_test.go
@@ -698,7 +698,7 @@ func TestAWS_AuthorizeSign(t *testing.T) {
 					case *urisValidator:
 						assert.Equals(t, v.uris, nil)
 						assert.Equals(t, MethodFromContext(v.ctx), SignMethod)
-					case dnsNamesValidator:
+					case dnsNamesSubsetValidator:
 						assert.Equals(t, []string(v), []string{"ip-127-0-0-1.us-west-1.compute.internal"})
 					case *x509NamePolicyValidator:
 						assert.Equals(t, nil, v.policyEngine)

--- a/authority/provisioner/azure.go
+++ b/authority/provisioner/azure.go
@@ -379,7 +379,7 @@ func (p *Azure) AuthorizeSign(ctx context.Context, token string) ([]SignOption, 
 		// name will work only inside the virtual network
 		so = append(so,
 			commonNameValidator(name),
-			dnsNamesValidator([]string{name}),
+			dnsNamesSubsetValidator([]string{name}),
 			ipAddressesValidator(nil),
 			emailAddressesValidator(nil),
 			newURIsValidator(ctx, nil),

--- a/authority/provisioner/azure_test.go
+++ b/authority/provisioner/azure_test.go
@@ -563,7 +563,7 @@ func TestAzure_AuthorizeSign(t *testing.T) {
 					case *urisValidator:
 						assert.Equals(t, v.uris, nil)
 						assert.Equals(t, MethodFromContext(v.ctx), SignMethod)
-					case dnsNamesValidator:
+					case dnsNamesSubsetValidator:
 						assert.Equals(t, []string(v), []string{"virtualMachine"})
 					case *x509NamePolicyValidator:
 						assert.Equals(t, nil, v.policyEngine)

--- a/authority/provisioner/gcp.go
+++ b/authority/provisioner/gcp.go
@@ -265,7 +265,7 @@ func (p *GCP) AuthorizeSign(ctx context.Context, token string) ([]SignOption, er
 			commonNameSliceValidator([]string{
 				ce.InstanceName, ce.InstanceID, dnsName1, dnsName2,
 			}),
-			dnsNamesValidator([]string{
+			dnsNamesSubsetValidator([]string{
 				dnsName1, dnsName2,
 			}),
 			ipAddressesValidator(nil),

--- a/authority/provisioner/gcp_test.go
+++ b/authority/provisioner/gcp_test.go
@@ -579,7 +579,7 @@ func TestGCP_AuthorizeSign(t *testing.T) {
 					case *urisValidator:
 						assert.Equals(t, v.uris, nil)
 						assert.Equals(t, MethodFromContext(v.ctx), SignMethod)
-					case dnsNamesValidator:
+					case dnsNamesSubsetValidator:
 						assert.Equals(t, []string(v), []string{"instance-name.c.project-id.internal", "instance-name.zone.c.project-id.internal"})
 					case *x509NamePolicyValidator:
 						assert.Equals(t, nil, v.policyEngine)

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -190,6 +190,27 @@ func (v dnsNamesValidator) Valid(req *x509.CertificateRequest) error {
 	return nil
 }
 
+// dnsNamesSubsetValidator validates the DNS names SAN of a certificate request.
+type dnsNamesSubsetValidator []string
+
+// Valid checks that all DNS Names in the certificate request are present in
+// the allowed list of DNS names.
+func (v dnsNamesSubsetValidator) Valid(req *x509.CertificateRequest) error {
+	if len(req.DNSNames) == 0 {
+		return nil
+	}
+	allowed := make(map[string]bool)
+	for _, s := range v {
+		allowed[s] = true
+	}
+	for _, s := range req.DNSNames {
+		if _, ok := allowed[s]; !ok {
+			return errs.Forbidden("certificate request contains unauthorized DNS names - got %v, allowed %v", req.DNSNames, v)
+		}
+	}
+	return nil
+}
+
 // ipAddressesValidator validates the IP addresses SAN of a certificate request.
 type ipAddressesValidator []net.IP
 

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -199,9 +199,9 @@ func (v dnsNamesSubsetValidator) Valid(req *x509.CertificateRequest) error {
 	if len(req.DNSNames) == 0 {
 		return nil
 	}
-	allowed := make(map[string]bool)
+	allowed := make(map[string]struct{}, len(v))
 	for _, s := range v {
-		allowed[s] = true
+		allowed[s] = struct{}{}
 	}
 	for _, s := range req.DNSNames {
 		if _, ok := allowed[s]; !ok {

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -193,7 +193,7 @@ func (v dnsNamesValidator) Valid(req *x509.CertificateRequest) error {
 // dnsNamesSubsetValidator validates the DNS name SANs of a certificate request.
 type dnsNamesSubsetValidator []string
 
-// Valid checks that all DNS Names in the certificate request are present in
+// Valid checks that all DNS name SANs in the certificate request are present in
 // the allowed list of DNS names.
 func (v dnsNamesSubsetValidator) Valid(req *x509.CertificateRequest) error {
 	if len(req.DNSNames) == 0 {

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -190,7 +190,7 @@ func (v dnsNamesValidator) Valid(req *x509.CertificateRequest) error {
 	return nil
 }
 
-// dnsNamesSubsetValidator validates the DNS names SAN of a certificate request.
+// dnsNamesSubsetValidator validates the DNS name SANs of a certificate request.
 type dnsNamesSubsetValidator []string
 
 // Valid checks that all DNS Names in the certificate request are present in


### PR DESCRIPTION
... when disableCustomSANs is set to 'true'.

The DNS names in the certificate request must be a subset of the authorized set of DNS names (from the IID token). The previous functionality required that the DNS names in the certificate request exactly matched the authorized DNS names.

