### PR TITLE
Propagate human errors from webhooks

### DIFF
--- a/authority/provisioner/webhook.go
+++ b/authority/provisioner/webhook.go
@@ -65,6 +65,9 @@ func (wc *WebhookController) Enrich(ctx context.Context, req *webhook.RequestBod
 			return err
 		}
 		if !resp.Allow {
+			if resp.Error != nil {
+				return resp.Error
+			}
 			return ErrWebhookDenied
 		}
 		wc.TemplateData.SetWebhook(wh.Name, resp.Data)
@@ -101,6 +104,9 @@ func (wc *WebhookController) Authorize(ctx context.Context, req *webhook.Request
 			return err
 		}
 		if !resp.Allow {
+			if resp.Error != nil {
+				return resp.Error
+			}
 			return ErrWebhookDenied
 		}
 	}

--- a/errs/error.go
+++ b/errs/error.go
@@ -62,6 +62,11 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// Unwrap implements the Unwrap interface and returns the original error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
 // Cause implements the errors.Causer interface and returns the original error.
 func (e *Error) Cause() error {
 	return e.Err

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"fmt"
 	"time"
 
 	"go.step.sm/crypto/sshutil"
@@ -9,8 +10,19 @@ import (
 
 // ResponseBody is the body returned by webhook servers.
 type ResponseBody struct {
-	Data  any  `json:"data"`
-	Allow bool `json:"allow"`
+	Data  any    `json:"data"`
+	Allow bool   `json:"allow"`
+	Error *Error `json:"error,omitempty"`
+}
+
+// Error provides details explaining why the webhook was not permitted.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 
 // X509CertificateRequest is the certificate request sent to webhook servers for


### PR DESCRIPTION
### Description

This commit adds a new field error to the webhook response that allows errors to propagate to the client. With ACME, webhook errors are a new subproblem.

cc: @joshdrake 