### PR TITLE
fix: allow active revocation on http revoke endpoint

### DIFF
--- a/api/revoke.go
+++ b/api/revoke.go
@@ -42,9 +42,6 @@ func (r *RevokeRequest) Validate() (err error) {
 	if r.ReasonCode < ocsp.Unspecified || r.ReasonCode > ocsp.AACompromise {
 		return errs.BadRequest("reasonCode out of bounds")
 	}
-	if !r.Passive {
-		return errs.NotImplemented("non-passive revocation not implemented")
-	}
 
 	return
 }


### PR DESCRIPTION
#### Name of feature: Allow active revocation via http endpoint

#### Pain or issue this feature alleviates: active revocation was already possible via cli but not via http
