### PR TITLE
internal/httptransport: initial implementation of the package

### DIFF
--- a/authority/provisioner/webhook_test.go
+++ b/authority/provisioner/webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"go.step.sm/crypto/x509util"
 	"go.step.sm/linkedca"
 
+	"github.com/smallstep/certificates/internal/httptransport"
 	"github.com/smallstep/certificates/middleware/requestid"
 	"github.com/smallstep/certificates/webhook"
 )
@@ -647,7 +648,8 @@ func TestWebhook_Do(t *testing.T) {
 		}
 		cert, err := tls.LoadX509KeyPair("testdata/certs/foo.crt", "testdata/secrets/foo.key")
 		require.NoError(t, err)
-		transport := http.DefaultTransport.(*http.Transport).Clone()
+
+		transport := httptransport.New()
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 			Certificates:       []tls.Certificate{cert},

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -33,6 +33,7 @@ import (
 	"github.com/smallstep/certificates/authority/config"
 	"github.com/smallstep/certificates/cas/apiv1"
 	"github.com/smallstep/certificates/db"
+	"github.com/smallstep/certificates/internal/httptransport"
 	"github.com/smallstep/certificates/internal/metrix"
 	"github.com/smallstep/certificates/logging"
 	"github.com/smallstep/certificates/middleware/requestid"
@@ -196,7 +197,7 @@ func (ca *CA) Init(cfg *config.Config) (*CA, error) {
 		opts = append(opts, authority.WithMeter(meter))
 	}
 
-	webhookTransport := http.DefaultTransport.(*http.Transport).Clone()
+	webhookTransport := httptransport.New()
 	opts = append(opts, authority.WithWebhookClient(&http.Client{Transport: webhookTransport}))
 
 	auth, err := authority.New(cfg, opts...)

--- a/ca/identity/client.go
+++ b/ca/identity/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/internal/httptransport"
 )
 
 // Client wraps http.Client with a transport using the step root and identity.
@@ -60,7 +61,7 @@ func LoadClient() (*Client, error) {
 	}
 
 	// Prepare transport with information in defaults.json and identity.json
-	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr := httptransport.New()
 	tr.TLSClientConfig = &tls.Config{
 		MinVersion:           tls.VersionTLS12,
 		GetClientCertificate: identity.GetClientCertificateFunc(),

--- a/ca/identity/client_test.go
+++ b/ca/identity/client_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/smallstep/certificates/internal/httptransport"
 )
 
 func returnInput(val string) func() string {
@@ -129,7 +131,7 @@ func TestLoadClient(t *testing.T) {
 	pool := x509.NewCertPool()
 	pool.AppendCertsFromPEM(b)
 
-	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr := httptransport.New()
 	tr.TLSClientConfig = &tls.Config{
 		Certificates: []tls.Certificate{crt},
 		RootCAs:      pool,

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -19,6 +19,7 @@ import (
 	"go.step.sm/crypto/pemutil"
 
 	"github.com/smallstep/certificates/api"
+	"github.com/smallstep/certificates/internal/httptransport"
 )
 
 // Type represents the different types of identity files.
@@ -295,7 +296,7 @@ func (i *Identity) Renew(client Renewer) error {
 			return err
 		}
 
-		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr := httptransport.New()
 		tr.TLSClientConfig = &tls.Config{
 			Certificates:             []tls.Certificate{cert},
 			RootCAs:                  client.GetRootCAs(),

--- a/internal/httptransport/httptransport.go
+++ b/internal/httptransport/httptransport.go
@@ -1,0 +1,26 @@
+// Package httptransport implements initialization of [http.Transport] instances and related
+// functionality.
+package httptransport
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// New returns a reference to an [http.Transport] that's initialized just like the
+// [http.DefaultTransport] is by the standard library.
+func New() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/test/integration/scep/common_test.go
+++ b/test/integration/scep/common_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/smallstep/certificates/authority/provisioner"
 	"github.com/smallstep/certificates/ca"
 	"github.com/smallstep/certificates/cas/apiv1"
+	"github.com/smallstep/certificates/internal/httptransport"
 )
 
 func newCAClient(t *testing.T, caURL, rootFilepath string) *ca.Client {
@@ -170,7 +171,7 @@ func createSCEPClient(t *testing.T, caURL string, root *x509.Certificate) *clien
 	t.Helper()
 	trustedRoots := x509.NewCertPool()
 	trustedRoots.AddCert(root)
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := httptransport.New()
 	transport.TLSClientConfig = &tls.Config{
 		RootCAs: trustedRoots,
 	}


### PR DESCRIPTION
Currently, there's extensive cloning of what's stored in `http.DefaultTransport`, under the assumption that what's stored there is an `http.Transport` reference.

There are many reasons why that might not be the case, especially since the type of `http.DefaultTransport` is `http.RoundTripper` and _not_ `http.Transport`.

To that end, this PR introduces the `internal/httptransport` package and refactors the `authority`, `ca` & `test` packages to use it.

