### PR TITLE
Transport wrappers

### DIFF
--- a/authority/http_client.go
+++ b/authority/http_client.go
@@ -5,30 +5,34 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+
+	"github.com/smallstep/certificates/internal/httptransport"
 )
 
 // newHTTPClient will return an HTTP client that trusts the system cert pool and
-// the given roots, but only if the http.DefaultTransport is an *http.Transport.
-// If not, it will return the default HTTP client.
-func newHTTPClient(roots ...*x509.Certificate) (*http.Client, error) {
-	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("error initializing http client: %w", err)
-		}
-		for _, crt := range roots {
-			pool.AddCert(crt)
-		}
-
-		tr = tr.Clone()
-		tr.TLSClientConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			RootCAs:    pool,
-		}
-		return &http.Client{
-			Transport: tr,
-		}, nil
+// the given roots.
+func newHTTPClient(wt httptransport.Wrapper, roots ...*x509.Certificate) (*http.Client, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing http client: %w", err)
+	}
+	for _, crt := range roots {
+		pool.AddCert(crt)
 	}
 
-	return &http.Client{}, nil
+	tr, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		tr = httptransport.New()
+	} else {
+		tr = tr.Clone()
+	}
+
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+	}
+
+	return &http.Client{
+		Transport: wt(tr),
+	}, nil
 }

--- a/authority/http_client_test.go
+++ b/authority/http_client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/smallstep/certificates/authority/provisioner"
+	"github.com/smallstep/certificates/internal/httptransport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.step.sm/crypto/jose"
@@ -113,8 +114,8 @@ func Test_newHTTPClient(t *testing.T) {
 		}{http.DefaultTransport}
 		http.DefaultTransport = transport
 
-		client, err := newHTTPClient(auth.rootX509Certs...)
+		client, err := newHTTPClient(httptransport.NoopWrapper(), auth.rootX509Certs...)
 		assert.NoError(t, err)
-		assert.Equal(t, &http.Client{}, client)
+		assert.NotNil(t, client)
 	})
 }

--- a/authority/options.go
+++ b/authority/options.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smallstep/certificates/cas"
 	casapi "github.com/smallstep/certificates/cas/apiv1"
 	"github.com/smallstep/certificates/db"
+	"github.com/smallstep/certificates/internal/httptransport"
 	"github.com/smallstep/certificates/scep"
 )
 
@@ -99,6 +100,22 @@ func WithQuietInit() Option {
 func WithWebhookClient(c *http.Client) Option {
 	return func(a *Authority) error {
 		a.webhookClient = c
+		return nil
+	}
+}
+
+// Wrapper wraps the set of functions mapping [http.Transport] references to [http.RoundTripper].
+type TransportWrapper = httptransport.Wrapper
+
+// WithTransportWrapper sets the transport wrapper of the authority to the provided one or, in case
+// that one is nil, to a noop one.
+func WithTransportWrapper(tw httptransport.Wrapper) Option {
+	if tw == nil {
+		tw = httptransport.NoopWrapper()
+	}
+
+	return func(a *Authority) error {
+		a.wrapTransport = tw
 		return nil
 	}
 }

--- a/authority/provisioner/controller_test.go
+++ b/authority/provisioner/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/smallstep/certificates/authority/policy"
+	"github.com/smallstep/certificates/internal/httptransport"
 	"github.com/smallstep/certificates/webhook"
 	"github.com/stretchr/testify/assert"
 	"go.step.sm/crypto/pemutil"
@@ -512,11 +513,18 @@ func Test_newWebhookController(t *testing.T) {
 			options:      opts,
 		}},
 	}
+
 	for _, tt := range tests {
-		c := &Controller{}
-		got := c.newWebhookController(tt.args.templateData, tt.args.certType, tt.args.opts...)
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("newWebhookController() = %v, want %v", got, tt.want)
+		c := Controller{
+			webhookClient: new(http.Client),
+			wrapTransport: httptransport.NoopWrapper(),
 		}
+		got := c.newWebhookController(tt.args.templateData, tt.args.certType, tt.args.opts...)
+
+		assert.Equal(t, tt.args.templateData, got.TemplateData)
+		assert.Same(t, c.webhookClient, got.client)
+		assert.Equal(t, c.webhooks, got.webhooks)
+		assert.Equal(t, tt.args.opts, got.options)
+		assert.Equal(t, tt.args.certType, got.certType)
 	}
 }

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -264,6 +264,9 @@ type Config struct {
 	// HTTPClient is an HTTP client that trusts the system cert pool and the CA
 	// roots.
 	HTTPClient *http.Client
+	// WrapTransport references the function that should wrap any [http.Transport] initialized
+	// down the Config's chain.
+	WrapTransport func(*http.Transport) http.RoundTripper
 }
 
 type provisioner struct {

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -266,7 +266,7 @@ type Config struct {
 	HTTPClient *http.Client
 	// WrapTransport references the function that should wrap any [http.Transport] initialized
 	// down the Config's chain.
-	WrapTransport func(*http.Transport) http.RoundTripper
+	WrapTransport TransportWrapper
 }
 
 type provisioner struct {

--- a/authority/provisioner/scep_test.go
+++ b/authority/provisioner/scep_test.go
@@ -201,7 +201,7 @@ func Test_challengeValidationController_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := newChallengeValidationController(tt.fields.client, tt.fields.webhooks)
+			c := newChallengeValidationController(tt.fields.client, nil, tt.fields.webhooks)
 			ctx := context.Background()
 			got, err := c.Validate(ctx, dummyCSR, tt.args.provisionerName, tt.args.challenge, tt.args.transactionID)
 			if tt.expErr != nil {

--- a/authority/provisioner/webhook_test.go
+++ b/authority/provisioner/webhook_test.go
@@ -627,7 +627,7 @@ func TestWebhook_Do(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()
 
-			got, err := tc.webhook.DoWithContext(ctx, http.DefaultClient, reqBody, tc.dataArg)
+			got, err := tc.webhook.DoWithContext(ctx, http.DefaultClient, httptransport.NoopWrapper(), reqBody, tc.dataArg)
 			if tc.expectErr != nil {
 				assert.Equal(t, tc.expectErr.Error(), err.Error())
 				return
@@ -663,14 +663,14 @@ func TestWebhook_Do(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
 
-		_, err = wh.DoWithContext(ctx, client, reqBody, nil)
+		_, err = wh.DoWithContext(ctx, client, httptransport.NoopWrapper(), reqBody, nil)
 		require.NoError(t, err)
 
 		ctx, cancel = context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
 
 		wh.DisableTLSClientAuth = true
-		_, err = wh.DoWithContext(ctx, client, reqBody, nil)
+		_, err = wh.DoWithContext(ctx, client, httptransport.NoopWrapper(), reqBody, nil)
 		require.Error(t, err)
 	})
 }

--- a/authority/provisioners.go
+++ b/authority/provisioners.go
@@ -202,6 +202,7 @@ func (a *Authority) generateProvisionerConfig(ctx context.Context) (provisioner.
 		AuthorizeSSHRenewFunc: a.authorizeSSHRenewFunc,
 		WebhookClient:         a.webhookClient,
 		HTTPClient:            a.httpClient,
+		WrapTransport:         a.wrapTransport,
 		SCEPKeyManager:        a.scepKeyManager,
 	}, nil
 }

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -198,7 +198,9 @@ func (ca *CA) Init(cfg *config.Config) (*CA, error) {
 	}
 
 	webhookTransport := httptransport.New()
-	opts = append(opts, authority.WithWebhookClient(&http.Client{Transport: webhookTransport}))
+	opts = append(opts,
+		authority.WithWebhookClient(&http.Client{Transport: webhookTransport}),
+	)
 
 	auth, err := authority.New(cfg, opts...)
 	if err != nil {

--- a/internal/httptransport/httptransport.go
+++ b/internal/httptransport/httptransport.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+// Wrapper wraps the set of functions mapping [http.Transport] references to [http.RoundTripper].
+type Wrapper func(*http.Transport) http.RoundTripper
+
+// NoopWrapper returns a [Wrapper] that simply casts its provided [http.Transport] to an
+// [http.RoundTripper].
+func NoopWrapper() Wrapper {
+	return func(t *http.Transport) http.RoundTripper {
+		return t
+	}
+}
+
 // New returns a reference to an [http.Transport] that's initialized just like the
 // [http.DefaultTransport] is by the standard library.
 func New() *http.Transport {


### PR DESCRIPTION
This PR adds references to a transport wrapper that callers may pass in order to inject their own dependecies to references of HTTP clients that the internal packages generate.