### PR TITLE
Wait and retry connection to test CA server instead of failing (immediately)

### DIFF
--- a/test/integration/requestid_test.go
+++ b/test/integration/requestid_test.go
@@ -293,6 +293,9 @@ func newAuthorizingServer(t *testing.T, mca *minica.CA) *httptest.Server {
 	return srv
 }
 
+// requireCAServerToBeAvailable tries to connect to address to check a server
+// is available. It will retry the connection every ~100ms, until timeout occurs.
+// If no connection can be made, the test is failed.
 func requireCAServerToBeAvailable(t *testing.T, address string, timeout time.Duration) {
 	t.Helper()
 
@@ -309,7 +312,7 @@ func requireCAServerToBeAvailable(t *testing.T, address string, timeout time.Dur
 }
 
 func canConnect(ctx context.Context, address string) bool {
-	d := net.Dialer{Timeout: 5 * time.Second}
+	d := net.Dialer{}
 	conn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return false


### PR DESCRIPTION
The integration test checking for request IDs to be reflected depends on a test CA server to be started and running. At times (see [this case](https://github.com/smallstep/certificates/actions/runs/12642283670/job/35226696954?pr=2129) with a few attempts) the CA healthcheck would fail the test, presumably because the CA server was not running yet. This PR checks the connection a few times before failing the test.