### PR TITLE
Add option to specify a client timeout

### DIFF
--- a/ca/acmeClient.go
+++ b/ca/acmeClient.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"go.step.sm/crypto/jose"
+
 	"github.com/smallstep/certificates/acme"
 	acmeAPI "github.com/smallstep/certificates/acme/api"
-	"go.step.sm/crypto/jose"
 )
 
 // ACMEClient implements an HTTP client to an ACME API.
@@ -29,7 +31,7 @@ type ACMEClient struct {
 // NewACMEClient initializes a new ACMEClient.
 func NewACMEClient(endpoint string, contact []string, opts ...ClientOption) (*ACMEClient, error) {
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	if err := o.apply(opts); err != nil {
 		return nil, err
 	}

--- a/ca/acmeClient_test.go
+++ b/ca/acmeClient_test.go
@@ -12,12 +12,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/smallstep/assert"
+	"go.step.sm/crypto/jose"
+	"go.step.sm/crypto/pemutil"
+
 	"github.com/smallstep/certificates/acme"
 	acmeAPI "github.com/smallstep/certificates/acme/api"
 	"github.com/smallstep/certificates/api/render"
-	"go.step.sm/crypto/jose"
-	"go.step.sm/crypto/pemutil"
 )
 
 func TestNewACMEClient(t *testing.T) {
@@ -169,7 +171,7 @@ func TestACMEClient_GetNonce(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -241,7 +243,7 @@ func TestACMEClient_post(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -372,7 +374,7 @@ func TestACMEClient_NewOrder(t *testing.T) {
 		NewOrder: srv.URL + "/bar",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -507,7 +509,7 @@ func TestACMEClient_GetOrder(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -629,7 +631,7 @@ func TestACMEClient_GetAuthz(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -751,7 +753,7 @@ func TestACMEClient_GetChallenge(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -874,7 +876,7 @@ func TestACMEClient_ValidateChallenge(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -1087,7 +1089,7 @@ func TestACMEClient_FinalizeOrder(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -1214,7 +1216,7 @@ func TestACMEClient_GetAccountOrders(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)
@@ -1347,7 +1349,7 @@ func TestACMEClient_GetCertificate(t *testing.T) {
 		NewNonce: srv.URL + "/foo",
 	}
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	assert.FatalError(t, o.apply([]ClientOption{WithTransport(http.DefaultTransport)}))
 	tr, err := o.getTransport(srv.URL)
 	assert.FatalError(t, err)

--- a/ca/adminClient.go
+++ b/ca/adminClient.go
@@ -60,14 +60,23 @@ func (e *AdminClientError) Error() string {
 	return e.Message
 }
 
+// defaultClientOptions returns a new [clientOptions] with a
+// default timeout set.
+func defaultClientOptions() clientOptions {
+	return clientOptions{
+		timeout: 15 * time.Second,
+	}
+}
+
 // NewAdminClient creates a new AdminClient with the given endpoint and options.
 func NewAdminClient(endpoint string, opts ...ClientOption) (*AdminClient, error) {
 	u, err := parseEndpoint(endpoint)
 	if err != nil {
 		return nil, err
 	}
+
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	if err := o.apply(opts); err != nil {
 		return nil, err
 	}
@@ -124,7 +133,7 @@ func (c *AdminClient) generateAdminToken(aud *url.URL) (string, error) {
 func (c *AdminClient) retryOnError(r *http.Response) bool {
 	if c.retryFunc != nil {
 		if c.retryFunc(r.StatusCode) {
-			o := new(clientOptions)
+			o := defaultClientOptions()
 			if err := o.apply(c.opts); err != nil {
 				return false
 			}

--- a/ca/adminClient.go
+++ b/ca/adminClient.go
@@ -77,7 +77,7 @@ func NewAdminClient(endpoint string, opts ...ClientOption) (*AdminClient, error)
 	}
 
 	return &AdminClient{
-		client:      newClient(tr),
+		client:      newClient(tr, o.timeout),
 		endpoint:    u,
 		retryFunc:   o.retryFunc,
 		opts:        opts,

--- a/ca/client.go
+++ b/ca/client.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/http2"
@@ -53,10 +54,11 @@ type uaClient struct {
 	Client *http.Client
 }
 
-func newClient(transport http.RoundTripper) *uaClient {
+func newClient(transport http.RoundTripper, timeout time.Duration) *uaClient {
 	return &uaClient{
 		Client: &http.Client{
 			Transport: transport,
+			Timeout:   timeout,
 		},
 	}
 }
@@ -149,6 +151,7 @@ type ClientOption func(o *clientOptions) error
 
 type clientOptions struct {
 	transport            http.RoundTripper
+	timeout              time.Duration
 	rootSHA256           string
 	rootFilename         string
 	rootBundle           []byte
@@ -388,6 +391,16 @@ func WithRetryFunc(fn RetryFunc) ClientOption {
 	}
 }
 
+// WithTimeout defines the time limit for requests made by this client. The
+// timeout includes connection time, any redirects, and reading the response
+// body.
+func WithTimeout(d time.Duration) ClientOption {
+	return func(o *clientOptions) error {
+		o.timeout = d
+		return nil
+	}
+}
+
 func getTransportFromFile(filename string) (http.RoundTripper, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -548,6 +561,7 @@ type Client struct {
 	client    *uaClient
 	endpoint  *url.URL
 	retryFunc RetryFunc
+	timeout   time.Duration
 	opts      []ClientOption
 }
 
@@ -568,9 +582,10 @@ func NewClient(endpoint string, opts ...ClientOption) (*Client, error) {
 	}
 
 	return &Client{
-		client:    newClient(tr),
+		client:    newClient(tr, o.timeout),
 		endpoint:  u,
 		retryFunc: o.retryFunc,
+		timeout:   o.timeout,
 		opts:      opts,
 	}, nil
 }
@@ -890,7 +905,7 @@ func (c *Client) RevokeWithContext(ctx context.Context, req *api.RevokeRequest, 
 	var uaClient *uaClient
 retry:
 	if tr != nil {
-		uaClient = newClient(tr)
+		uaClient = newClient(tr, c.timeout)
 	} else {
 		uaClient = c.client
 	}

--- a/ca/client.go
+++ b/ca/client.go
@@ -571,8 +571,9 @@ func NewClient(endpoint string, opts ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// Retrieve transport from options.
-	o := new(clientOptions)
+	o := defaultClientOptions()
 	if err := o.apply(opts); err != nil {
 		return nil, err
 	}
@@ -593,7 +594,7 @@ func NewClient(endpoint string, opts ...ClientOption) (*Client, error) {
 func (c *Client) retryOnError(r *http.Response) bool {
 	if c.retryFunc != nil {
 		if c.retryFunc(r.StatusCode) {
-			o := new(clientOptions)
+			o := defaultClientOptions()
 			if err := o.apply(c.opts); err != nil {
 				return false
 			}

--- a/ca/client_test.go
+++ b/ca/client_test.go
@@ -1038,11 +1038,11 @@ func TestClient_WithTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewClient(srv.URL, tt.options...)
 			require.NoError(t, err)
+			assert.NotZero(t, c.timeout)
 			_, err = c.Health()
 			tt.assertion(t, err)
 		})
 	}
-
 }
 
 func Test_enforceRequestID(t *testing.T) {

--- a/ca/client_test.go
+++ b/ca/client_test.go
@@ -1017,6 +1017,34 @@ func TestClient_GetCaURL(t *testing.T) {
 	}
 }
 
+func TestClient_WithTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		render.JSONStatus(w, r, api.HealthResponse{Status: "ok"}, 200)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name      string
+		options   []ClientOption
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", []ClientOption{WithTransport(http.DefaultTransport)}, assert.NoError},
+		{"ok with timeout", []ClientOption{WithTransport(http.DefaultTransport), WithTimeout(time.Second)}, assert.NoError},
+		{"fail with timeout", []ClientOption{WithTransport(http.DefaultTransport), WithTimeout(100 * time.Millisecond)}, assert.Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(srv.URL, tt.options...)
+			require.NoError(t, err)
+			_, err = c.Health()
+			tt.assertion(t, err)
+		})
+	}
+
+}
+
 func Test_enforceRequestID(t *testing.T) {
 	set := httptest.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	set.Header.Set("X-Request-Id", "already-set")


### PR DESCRIPTION
### Description 

This commit adds a new option to specify the client timeout to the CA client.

Fixes #2176
