### PR TITLE
Add SSH certificate type to metrics

### DIFF
--- a/authority/meter.go
+++ b/authority/meter.go
@@ -2,10 +2,12 @@ package authority
 
 import (
 	"crypto"
+	"crypto/x509"
 	"io"
 
 	"go.step.sm/crypto/kms"
 	kmsapi "go.step.sm/crypto/kms/apiv1"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/smallstep/certificates/authority/provisioner"
 )
@@ -13,13 +15,13 @@ import (
 // Meter wraps the set of defined callbacks for metrics gatherers.
 type Meter interface {
 	// X509Signed is called whenever an X509 certificate is signed.
-	X509Signed(provisioner.Interface, error)
+	X509Signed([]*x509.Certificate, provisioner.Interface, error)
 
 	// X509Renewed is called whenever an X509 certificate is renewed.
-	X509Renewed(provisioner.Interface, error)
+	X509Renewed([]*x509.Certificate, provisioner.Interface, error)
 
 	// X509Rekeyed is called whenever an X509 certificate is rekeyed.
-	X509Rekeyed(provisioner.Interface, error)
+	X509Rekeyed([]*x509.Certificate, provisioner.Interface, error)
 
 	// X509WebhookAuthorized is called whenever an X509 authoring webhook is called.
 	X509WebhookAuthorized(provisioner.Interface, error)
@@ -28,13 +30,13 @@ type Meter interface {
 	X509WebhookEnriched(provisioner.Interface, error)
 
 	// SSHSigned is called whenever an SSH certificate is signed.
-	SSHSigned(provisioner.Interface, error)
+	SSHSigned(*ssh.Certificate, provisioner.Interface, error)
 
 	// SSHRenewed is called whenever an SSH certificate is renewed.
-	SSHRenewed(provisioner.Interface, error)
+	SSHRenewed(*ssh.Certificate, provisioner.Interface, error)
 
 	// SSHRekeyed is called whenever an SSH certificate is rekeyed.
-	SSHRekeyed(provisioner.Interface, error)
+	SSHRekeyed(*ssh.Certificate, provisioner.Interface, error)
 
 	// SSHWebhookAuthorized is called whenever an SSH authoring webhook is called.
 	SSHWebhookAuthorized(provisioner.Interface, error)
@@ -49,17 +51,17 @@ type Meter interface {
 // noopMeter implements a noop [Meter].
 type noopMeter struct{}
 
-func (noopMeter) SSHRekeyed(provisioner.Interface, error)            {}
-func (noopMeter) SSHRenewed(provisioner.Interface, error)            {}
-func (noopMeter) SSHSigned(provisioner.Interface, error)             {}
-func (noopMeter) SSHWebhookAuthorized(provisioner.Interface, error)  {}
-func (noopMeter) SSHWebhookEnriched(provisioner.Interface, error)    {}
-func (noopMeter) X509Rekeyed(provisioner.Interface, error)           {}
-func (noopMeter) X509Renewed(provisioner.Interface, error)           {}
-func (noopMeter) X509Signed(provisioner.Interface, error)            {}
-func (noopMeter) X509WebhookAuthorized(provisioner.Interface, error) {}
-func (noopMeter) X509WebhookEnriched(provisioner.Interface, error)   {}
-func (noopMeter) KMSSigned(error)                                    {}
+func (noopMeter) SSHRekeyed(*ssh.Certificate, provisioner.Interface, error)     {}
+func (noopMeter) SSHRenewed(*ssh.Certificate, provisioner.Interface, error)     {}
+func (noopMeter) SSHSigned(*ssh.Certificate, provisioner.Interface, error)      {}
+func (noopMeter) SSHWebhookAuthorized(provisioner.Interface, error)             {}
+func (noopMeter) SSHWebhookEnriched(provisioner.Interface, error)               {}
+func (noopMeter) X509Rekeyed([]*x509.Certificate, provisioner.Interface, error) {}
+func (noopMeter) X509Renewed([]*x509.Certificate, provisioner.Interface, error) {}
+func (noopMeter) X509Signed([]*x509.Certificate, provisioner.Interface, error)  {}
+func (noopMeter) X509WebhookAuthorized(provisioner.Interface, error)            {}
+func (noopMeter) X509WebhookEnriched(provisioner.Interface, error)              {}
+func (noopMeter) KMSSigned(error)                                               {}
 
 type instrumentedKeyManager struct {
 	kms.KeyManager

--- a/authority/ssh.go
+++ b/authority/ssh.go
@@ -149,7 +149,7 @@ func (a *Authority) GetSSHBastion(ctx context.Context, user, hostname string) (*
 // SignSSH creates a signed SSH certificate with the given public key and options.
 func (a *Authority) SignSSH(ctx context.Context, key ssh.PublicKey, opts provisioner.SignSSHOptions, signOpts ...provisioner.SignOption) (*ssh.Certificate, error) {
 	cert, prov, err := a.signSSH(ctx, key, opts, signOpts...)
-	a.meter.SSHSigned(prov, err)
+	a.meter.SSHSigned(cert, prov, err)
 	return cert, err
 }
 
@@ -337,7 +337,7 @@ func (a *Authority) isAllowedToSignSSHCertificate(cert *ssh.Certificate) error {
 // RenewSSH creates a signed SSH certificate using the old SSH certificate as a template.
 func (a *Authority) RenewSSH(ctx context.Context, oldCert *ssh.Certificate) (*ssh.Certificate, error) {
 	cert, prov, err := a.renewSSH(ctx, oldCert)
-	a.meter.SSHRenewed(prov, err)
+	a.meter.SSHRenewed(cert, prov, err)
 	return cert, err
 }
 
@@ -408,7 +408,7 @@ func (a *Authority) renewSSH(ctx context.Context, oldCert *ssh.Certificate) (*ss
 // RekeySSH creates a signed SSH certificate using the old SSH certificate as a template.
 func (a *Authority) RekeySSH(ctx context.Context, oldCert *ssh.Certificate, pub ssh.PublicKey, signOpts ...provisioner.SignOption) (*ssh.Certificate, error) {
 	cert, prov, err := a.rekeySSH(ctx, oldCert, pub, signOpts...)
-	a.meter.SSHRekeyed(prov, err)
+	a.meter.SSHRekeyed(cert, prov, err)
 	return cert, err
 }
 

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -118,7 +118,7 @@ func (a *Authority) Sign(csr *x509.CertificateRequest, signOpts provisioner.Sign
 // request, taking the provided context.Context.
 func (a *Authority) SignWithContext(ctx context.Context, csr *x509.CertificateRequest, signOpts provisioner.SignOptions, extraOpts ...provisioner.SignOption) ([]*x509.Certificate, error) {
 	chain, prov, err := a.signX509(ctx, csr, signOpts, extraOpts...)
-	a.meter.X509Signed(prov, err)
+	a.meter.X509Signed(chain, prov, err)
 	return chain, err
 }
 
@@ -372,9 +372,9 @@ func (a *Authority) Rekey(oldCert *x509.Certificate, pk crypto.PublicKey) ([]*x5
 func (a *Authority) RenewContext(ctx context.Context, oldCert *x509.Certificate, pk crypto.PublicKey) ([]*x509.Certificate, error) {
 	chain, prov, err := a.renewContext(ctx, oldCert, pk)
 	if pk == nil {
-		a.meter.X509Renewed(prov, err)
+		a.meter.X509Renewed(chain, prov, err)
 	} else {
-		a.meter.X509Rekeyed(prov, err)
+		a.meter.X509Rekeyed(chain, prov, err)
 	}
 	return chain, err
 }


### PR DESCRIPTION
### Description

This commit passes the commit updates the Meter interface with SSH certificates and X.509 certificate chains. This allows us to add certificate specific things into the metrics. In this PR we are adding the SSH certificate type, user, or host.
