### PR TITLE
Add the certificate sans to the logs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -552,6 +552,7 @@ func LogCertificate(w http.ResponseWriter, cert *x509.Certificate) {
 			"serial":      cert.SerialNumber.String(),
 			"subject":     cert.Subject.CommonName,
 			"issuer":      cert.Issuer.CommonName,
+			"sans":        fmtSans(cert),
 			"valid-from":  cert.NotBefore.Format(time.RFC3339),
 			"valid-to":    cert.NotAfter.Format(time.RFC3339),
 			"public-key":  fmtPublicKey(cert),
@@ -623,6 +624,31 @@ func ParseCursor(r *http.Request) (cursor string, limit int, err error) {
 		}
 	}
 	return
+}
+
+func fmtSans(cert *x509.Certificate) map[string][]string {
+	sans := make(map[string][]string)
+	if len(cert.DNSNames) > 0 {
+		sans["dns"] = cert.DNSNames
+	}
+	if len(cert.EmailAddresses) > 0 {
+		sans["email"] = cert.EmailAddresses
+	}
+	if size := len(cert.IPAddresses); size > 0 {
+		ips := make([]string, size)
+		for i, ip := range cert.IPAddresses {
+			ips[i] = ip.String()
+		}
+		sans["ip"] = ips
+	}
+	if size := len(cert.URIs); size > 0 {
+		uris := make([]string, size)
+		for i, u := range cert.URIs {
+			uris[i] = u.String()
+		}
+		sans["uri"] = uris
+	}
+	return sans
 }
 
 func fmtPublicKey(cert *x509.Certificate) string {


### PR DESCRIPTION
### Description

This commit adds the default certificate SANs to the logs as a map. 