### PR TITLE
Create SkipSCEPValidation option in authority config

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -711,8 +711,9 @@ func (a *Authority) init() error {
 	case a.requiresSCEP() && a.GetSCEP() == nil:
 		if a.scepOptions == nil {
 			options := &scep.Options{
-				Roots:         a.rootX509Certs,
-				Intermediates: a.intermediateX509Certs,
+				Roots:          a.rootX509Certs,
+				Intermediates:  a.intermediateX509Certs,
+				SkipValidation: a.config.SkipSCEPValidation,
 			}
 
 			// intermediate certificates can be empty in RA mode

--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -65,26 +65,27 @@ var (
 
 // Config represents the CA configuration and it's mapped to a JSON object.
 type Config struct {
-	Root             multiString          `json:"root"`
-	FederatedRoots   []string             `json:"federatedRoots"`
-	IntermediateCert string               `json:"crt"`
-	IntermediateKey  string               `json:"key"`
-	Address          string               `json:"address"`
-	InsecureAddress  string               `json:"insecureAddress"`
-	DNSNames         []string             `json:"dnsNames"`
-	KMS              *kms.Options         `json:"kms,omitempty"`
-	SSH              *SSHConfig           `json:"ssh,omitempty"`
-	Logger           json.RawMessage      `json:"logger,omitempty"`
-	DB               *db.Config           `json:"db,omitempty"`
-	Monitoring       json.RawMessage      `json:"monitoring,omitempty"`
-	AuthorityConfig  *AuthConfig          `json:"authority,omitempty"`
-	TLS              *TLSOptions          `json:"tls,omitempty"`
-	Password         string               `json:"password,omitempty"`
-	Templates        *templates.Templates `json:"templates,omitempty"`
-	CommonName       string               `json:"commonName,omitempty"`
-	CRL              *CRLConfig           `json:"crl,omitempty"`
-	MetricsAddress   string               `json:"metricsAddress,omitempty"`
-	SkipValidation   bool                 `json:"-"`
+	Root               multiString          `json:"root"`
+	FederatedRoots     []string             `json:"federatedRoots"`
+	IntermediateCert   string               `json:"crt"`
+	IntermediateKey    string               `json:"key"`
+	Address            string               `json:"address"`
+	InsecureAddress    string               `json:"insecureAddress"`
+	DNSNames           []string             `json:"dnsNames"`
+	KMS                *kms.Options         `json:"kms,omitempty"`
+	SSH                *SSHConfig           `json:"ssh,omitempty"`
+	Logger             json.RawMessage      `json:"logger,omitempty"`
+	DB                 *db.Config           `json:"db,omitempty"`
+	Monitoring         json.RawMessage      `json:"monitoring,omitempty"`
+	AuthorityConfig    *AuthConfig          `json:"authority,omitempty"`
+	TLS                *TLSOptions          `json:"tls,omitempty"`
+	Password           string               `json:"password,omitempty"`
+	Templates          *templates.Templates `json:"templates,omitempty"`
+	CommonName         string               `json:"commonName,omitempty"`
+	CRL                *CRLConfig           `json:"crl,omitempty"`
+	MetricsAddress     string               `json:"metricsAddress,omitempty"`
+	SkipValidation     bool                 `json:"-"`
+	SkipSCEPValidation bool                 `json:"-"`
 
 	// Keeps record of the filename the Config is read from
 	loadedFromFilepath string

--- a/scep/options.go
+++ b/scep/options.go
@@ -26,6 +26,8 @@ type Options struct {
 	// are used to be able to load the provisioners when the SCEP authority is being
 	// validated.
 	SCEPProvisionerNames []string
+	// SkipValidation is used to skip the validation of the SCEP options.
+	SkipValidation       bool
 }
 
 type comparablePublicKey interface {
@@ -35,6 +37,8 @@ type comparablePublicKey interface {
 // Validate checks the fields in Options.
 func (o *Options) Validate() error {
 	switch {
+	case o.SkipValidation:
+	        return nil
 	case len(o.Intermediates) == 0:
 		return errors.New("no intermediate certificate available for SCEP authority")
 	case o.SignerCert == nil:


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
(duplicate of #1991  ) An option to skip validation of the SCEP configuration 

#### Pain or issue this feature alleviates:
When writing custom integrations, some of the validations don't apply, which unintentionally prevents the provisioner from starting up.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?
No additional docs provided, should not be very common to use

#### In what environments or workflows is this feature supported?
Custom integrations which create their own provisioner/authority objects using the CAS API

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Most default configurations will not benefit from this option

#### Supporting links/other PRs/issues:

💔Thank you!
