### PR TITLE
squashing commits

### DIFF
--- a/acme/authorization.go
+++ b/acme/authorization.go
@@ -18,6 +18,7 @@ type Authorization struct {
 	Wildcard    bool         `json:"wildcard"`
 	ExpiresAt   time.Time    `json:"expires"`
 	Error       *Error       `json:"error,omitempty"`
+	ExtraIdentifiers []string `json:"extraIdentifiers,omitempty"`
 }
 
 // ToLog enables response logging.

--- a/acme/challenge.go
+++ b/acme/challenge.go
@@ -868,7 +868,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 		// identifiers.
 		//
 		// Note: We might want to use an external service for this.
-		if data.UDID != ch.Value && data.SerialNumber != ch.Value {
+		if !SkipPermanentIdentiferValidation && (data.UDID != ch.Value) && (data.SerialNumber != ch.Value) {
 			subproblem := NewSubproblemWithIdentifier(
 				ErrorRejectedIdentifierType,
 				Identifier{Type: "permanent-identifier", Value: ch.Value},
@@ -896,7 +896,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 		// certificate with the challenged Order value.
 		//
 		// Note: We might want to use an external service for this.
-		if data.SerialNumber != ch.Value {
+		if !SkipPermanentIdentiferValidation && (data.SerialNumber != ch.Value) {
 			subproblem := NewSubproblemWithIdentifier(
 				ErrorRejectedIdentifierType,
 				Identifier{Type: "permanent-identifier", Value: ch.Value},
@@ -907,6 +907,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 
 		// Update attestation key fingerprint to compare against the CSR
 		az.Fingerprint = data.Fingerprint
+		az.ExtraIdentifiers = []string{data.SerialNumber, p.AttObj}
 
 	case "tpm":
 		data, err := doTPMAttestationFormat(ctx, prov, ch, jwk, &att)
@@ -926,7 +927,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 		// haven't implemented a way for AK certs requested by the CLI to always contain the requested
 		// PermanentIdentifier. Omitting the check below doesn't allow just any request, as the Order can
 		// still fail if the challenge value isn't equal to the CSR subject.
-		if len(data.PermanentIdentifiers) > 0 && !slices.Contains(data.PermanentIdentifiers, ch.Value) { // TODO(hs): add support for HardwareModuleName
+		if (!SkipPermanentIdentiferValidation) && (len(data.PermanentIdentifiers) > 0) && (!slices.Contains(data.PermanentIdentifiers, ch.Value)) { // TODO(hs): add support for HardwareModuleName
 			subproblem := NewSubproblemWithIdentifier(
 				ErrorRejectedIdentifierType,
 				Identifier{Type: "permanent-identifier", Value: ch.Value},
@@ -937,6 +938,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 
 		// Update attestation key fingerprint to compare against the CSR
 		az.Fingerprint = data.Fingerprint
+
 	default:
 		return storeError(ctx, db, ch, true, NewDetailedError(ErrorBadAttestationStatementType, "unsupported attestation object format %q", format))
 	}
@@ -951,7 +953,7 @@ func deviceAttest01Validate(ctx context.Context, ch *Challenge, db DB, jwk *jose
 	// Store the fingerprint in the authorization.
 	//
 	// TODO: add method to update authorization and challenge atomically.
-	if az.Fingerprint != "" {
+	if az.Fingerprint != "" || az.ExtraIdentifiers != nil {
 		if err := db.UpdateAuthorization(ctx, az); err != nil {
 			return WrapErrorISE(err, "error updating authorization")
 		}

--- a/acme/common.go
+++ b/acme/common.go
@@ -40,6 +40,13 @@ func NewContext(ctx context.Context, db DB, client Client, linker Linker, fn Pre
 	return ctx
 }
 
+// SkipPermanentIdentiferValidation allows one to bypass the code which validates
+// that a) that the attested UUID or serial for "device-attest-01" request match
+// the permanent identifier and b) that the CN presented in the final CSRs match the permanent
+// identifier. The logic to bypass this is to allow external CAs to control the validation temporarily
+// Setting this at true at this global level is extremely discouraged (unless you know what you are doing)
+var SkipPermanentIdentiferValidation bool
+
 // PrerequisitesChecker is a function that checks if all prerequisites for
 // serving ACME are met by the CA configuration.
 type PrerequisitesChecker func(ctx context.Context) (bool, error)

--- a/acme/db/nosql/authz.go
+++ b/acme/db/nosql/authz.go
@@ -23,6 +23,7 @@ type dbAuthz struct {
 	CreatedAt    time.Time       `json:"createdAt"`
 	ExpiresAt    time.Time       `json:"expiresAt"`
 	Error        *acme.Error     `json:"error"`
+	ExtraIdentifiers []string 	  `json:"extraIdentifiers,omitempty"`
 }
 
 func (ba *dbAuthz) clone() *dbAuthz {
@@ -71,6 +72,7 @@ func (db *DB) GetAuthorization(ctx context.Context, id string) (*acme.Authorizat
 		ExpiresAt:   dbaz.ExpiresAt,
 		Token:       dbaz.Token,
 		Fingerprint: dbaz.Fingerprint,
+		ExtraIdentifiers: dbaz.ExtraIdentifiers,
 		Error:       dbaz.Error,
 	}, nil
 }
@@ -101,6 +103,7 @@ func (db *DB) CreateAuthorization(ctx context.Context, az *acme.Authorization) e
 		Token:        az.Token,
 		Fingerprint:  az.Fingerprint,
 		Wildcard:     az.Wildcard,
+		ExtraIdentifiers: nil,
 	}
 
 	return db.save(ctx, az.ID, dbaz, nil, "authz", authzTable)
@@ -116,6 +119,7 @@ func (db *DB) UpdateAuthorization(ctx context.Context, az *acme.Authorization) e
 	nu := old.clone()
 	nu.Status = az.Status
 	nu.Fingerprint = az.Fingerprint
+	nu.ExtraIdentifiers = az.ExtraIdentifiers
 	nu.Error = az.Error
 	return db.save(ctx, old.ID, nu, old, "authz", authzTable)
 }
@@ -149,6 +153,7 @@ func (db *DB) GetAuthorizationsByAccountID(_ context.Context, accountID string) 
 			Token:       dbaz.Token,
 			Fingerprint: dbaz.Fingerprint,
 			Error:       dbaz.Error,
+			ExtraIdentifiers: dbaz.ExtraIdentifiers,
 		})
 	}
 

--- a/acme/order.go
+++ b/acme/order.go
@@ -161,6 +161,21 @@ func (o *Order) getAuthorizationFingerprint(ctx context.Context, db DB) (string,
 	return "", nil
 }
 
+func (o *Order) getAuthorizationExtraIdentifiers(ctx context.Context, db DB) ([]string, error) {
+	for _, azID := range o.AuthorizationIDs {
+		az, err := db.GetAuthorization(ctx, azID)
+		if err != nil {
+			return nil, WrapErrorISE(err, "error getting authorization %q", azID)
+		}
+		// There's no point on reading all the authorizations as there will
+		// be only one for a permanent identifier.
+		if az.ExtraIdentifiers != nil {
+			return az.ExtraIdentifiers, nil
+		}
+	}
+	return nil, nil
+}
+
 // Finalize signs a certificate if the necessary conditions for Order completion
 // have been met.
 //
@@ -202,6 +217,11 @@ func (o *Order) Finalize(ctx context.Context, db DB, csr *x509.CertificateReques
 		if subtle.ConstantTimeCompare([]byte(fingerprint), []byte(fp)) == 0 {
 			return NewError(ErrorUnauthorizedType, "order %s csr does not match the attested key", o.ID)
 		}
+	}
+
+	extraIdentifiers, err := o.getAuthorizationExtraIdentifiers(ctx, db)
+	if err != nil {
+		return err
 	}
 
 	// canonicalize the CSR to allow for comparison
@@ -249,7 +269,7 @@ func (o *Order) Finalize(ctx context.Context, db DB, csr *x509.CertificateReques
 			// is rejected, because the Common Name hasn't been challenged in that case. This
 			// could result in unauthorized access if a relying system relies on the Common
 			// Name in its authorization logic.
-			if csr.Subject.CommonName != "" && csr.Subject.CommonName != permanentIdentifier {
+			if !SkipPermanentIdentiferValidation && (csr.Subject.CommonName != "") && (csr.Subject.CommonName != permanentIdentifier) {
 				return NewError(ErrorBadCSRType, "CSR Subject Common Name does not match identifiers exactly: "+
 					"CSR Subject Common Name = %s, Order Permanent Identifier = %s", csr.Subject.CommonName, permanentIdentifier)
 			}
@@ -266,6 +286,7 @@ func (o *Order) Finalize(ctx context.Context, db DB, csr *x509.CertificateReques
 		})
 		extraOptions = append(extraOptions, provisioner.AttestationData{
 			PermanentIdentifier: permanentIdentifier,
+			ExtraIdentifiers: extraIdentifiers,
 		})
 	} else {
 		defaultTemplate = x509util.DefaultLeafTemplate

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -84,7 +84,8 @@ func (fn CertificateEnforcerFunc) Enforce(cert *x509.Certificate) error {
 // AttestationData is a SignOption used to pass attestation information to the
 // sign methods.
 type AttestationData struct {
-	PermanentIdentifier string
+	PermanentIdentifier string //
+	ExtraIdentifiers	[]string
 }
 
 // defaultPublicKeyValidator validates the public key of a certificate request.

--- a/authority/tls.go
+++ b/authority/tls.go
@@ -296,6 +296,17 @@ func (a *Authority) signX509(ctx context.Context, csr *x509.CertificateRequest, 
 		)
 	}
 
+	var clientIdentifier string
+	var extraIdentifiers []string
+	if attData != nil {
+		if attData.PermanentIdentifier != "" {
+			clientIdentifier = attData.PermanentIdentifier
+		}
+		if attData.ExtraIdentifiers != nil {
+			extraIdentifiers = attData.ExtraIdentifiers
+		}
+	}
+
 	// Sign certificate
 	lifetime := leaf.NotAfter.Sub(leaf.NotBefore.Add(signOpts.Backdate))
 
@@ -305,6 +316,8 @@ func (a *Authority) signX509(ctx context.Context, csr *x509.CertificateRequest, 
 		Lifetime:    lifetime,
 		Backdate:    signOpts.Backdate,
 		Provisioner: pInfo,
+		ClientIdentifier: clientIdentifier,
+		ExtraIdentifiers: extraIdentifiers,
 	})
 	if err != nil {
 		return nil, prov, errs.Wrap(http.StatusInternalServerError, err, "authority.Sign; error creating certificate", opts...)

--- a/cas/apiv1/requests.go
+++ b/cas/apiv1/requests.go
@@ -59,6 +59,8 @@ type CreateCertificateRequest struct {
 	RequestID      string
 	Provisioner    *ProvisionerInfo
 	IsCAServerCert bool
+	ClientIdentifier  string // any identifier token (can be any arbitrary token/blob interpretable by the CA)
+	ExtraIdentifiers []string // any additional identifier ( interpretable by the CA such as serial, UDID of device)
 }
 
 // ProvisionerInfo contains information of the provisioner used to authorize a


### PR DESCRIPTION
author Venky Gopal <vnktshgopalg@gmail.com> 1693934844 -0400 committer mishaslavin <63741893+mishaslavin@users.noreply.github.com> 1749672251 -0700

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
(Duplicate of #1525) 

Propagate attested client identifiers (serial and attestation object) to CA interface & allow global API level bypass of a) Client Identitifer to UUID/Serial association b) CSR CN to Client Identifier association.
This allows organizations to specify arbitrary values in Apple's ClientIdentifier field as part of the MDM ACME payload and defer validation of that identifier to the Certificate Authority.

The API level global bypass is not great, but I created to add more concreteness to the ask.

#### Pain or issue this feature alleviates:

Allows us to specify any arbitrary values (such as a one time token like JWT, etc in the ClientIdentifier field in the [MDM payload](https://support.apple.com/guide/deployment/automated-certificate-management-environment-depb95c66a07/1/web/1.0). This is crucial for organizations to be able to use this payload for different types of attested certificates having different user authentication requirements.

#### Why is this important to the project (if not answered above):

Allows adoption of device-attest-01 in ACME for different types of Attested certificates in Enterprises.

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:
(duplicate of #1525)
💔Thank you!

## up-to-date test outputs:
```
mslavin@mslavin-wsl:~/certificates$ make test
✓  api/log (7ms) (coverage: 66.7% of statements)
✓  api/render (9ms) (coverage: 83.7% of statements)
∅  authority/admin (10ms) (coverage: 0.0% of statements)
∅  api/models (13ms) (coverage: 0.0% of statements)
✓  acme/wire (15ms) (coverage: 96.0% of statements)
✓  api/read (19ms) (coverage: 100.0% of statements)
✓  authority/config (30ms) (coverage: 67.0% of statements)
∅  authority/administrator (30ms) (coverage: 0.0% of statements)
✓  authority/admin/db/nosql (33ms) (coverage: 94.8% of statements)
✓  authority/admin/api (78ms) (coverage: 88.3% of statements)
✓  authority/internal/constraints (21ms) (coverage: 81.6% of statements)
✓  authority/policy (30ms) (coverage: 41.7% of statements)
✓  acme/db/nosql (695ms) (coverage: 96.7% of statements)
✓  acme/api (750ms) (coverage: 91.9% of statements)
✓  authority/provisioner/wire (65ms) (coverage: 90.4% of statements)
∅  ca/client (5ms) (coverage: 0.0% of statements)
✓  cas/apiv1 (6ms) (coverage: 97.6% of statements)
✓  cas (19ms) (coverage: 95.0% of statements)
✓  ca/identity (45ms) (coverage: 93.3% of statements)
✓  cas/cloudcas (185ms) (coverage: 96.4% of statements)
✓  authority (2.188s) (coverage: 47.5% of statements)
∅  cmd/step-ca (6ms) (coverage: 0.0% of statements)
✓  cas/vaultcas/auth/approle (9ms) (coverage: 86.4% of statements)
∅  commands (9ms) (coverage: 0.0% of statements)
✓  cas/vaultcas/auth/kubernetes (19ms) (coverage: 87.5% of statements)
✓  cas/vaultcas/auth/aws (25ms) (coverage: 82.8% of statements)
✓  cas/vaultcas (57ms) (coverage: 79.2% of statements)
✓  cas/softcas (872ms) (coverage: 91.6% of statements)
∅  examples/basic-federation/client (4ms) (coverage: 0.0% of statements)
∅  examples/basic-client (5ms) (coverage: 0.0% of statements)
∅  internal/metrix (5ms) (coverage: 0.0% of statements)
∅  examples/bootstrap-mtls-server (6ms) (coverage: 0.0% of statements)
∅  examples/bootstrap-tls-server (6ms) (coverage: 0.0% of statements)
∅  examples/bootstrap-client (6ms) (coverage: 0.0% of statements)
∅  examples/basic-federation/server (7ms) (coverage: 0.0% of statements)
✓  internal/cast (6ms) (coverage: 100.0% of statements)
∅  internal/httptransport (8ms) (coverage: 0.0% of statements)
∅  internal/userid (6ms) (coverage: 0.0% of statements)
✓  errs (11ms) (coverage: 36.4% of statements)
✓  db (19ms) (coverage: 26.5% of statements)
✓  middleware/requestid (4ms) (coverage: 95.2% of statements)
✓  logging (12ms) (coverage: 45.9% of statements)
∅  monitoring (40ms) (coverage: 0.0% of statements)
✓  api (3.428s) (coverage: 78.5% of statements)
∅  server (17ms) (coverage: 0.0% of statements)
✓  scep/api (17ms) (coverage: 26.8% of statements)
✓  templates (19ms) (coverage: 93.5% of statements)
✓  policy (24ms) (coverage: 93.0% of statements)
∅  scripts/badger-migration (33ms) (coverage: 0.0% of statements)
✓  pki (373ms) (coverage: 33.8% of statements)
✓  webhook (7ms) (coverage: 69.6% of statements)
∅  test/integration/scep/internal/x509 (8ms) (coverage: 0.0% of statements)
✓  scep (1.827s) (coverage: 36.6% of statements)
✓  test/integration (1.889s)
✓  acme (7.201s) (coverage: 68.3% of statements)
✓  cas/stepcas (9.893s) (coverage: 93.9% of statements)
✓  test/integration/scep (13.531s)
✓  authority/provisioner (24.883s) (coverage: 82.3% of statements)
✓  ca (29.187s) (coverage: 43.3% of statements)

=== Skipped
=== SKIP: acme Test_parseAndVerifyWireAccessToken (0.00s)
    challenge_wire_test.go:2126: skip until we can retrieve public key from e2e test, so that we can actually verify the token

DONE 4773 tests, 1 skipped in 31.102s
✓  acme (13.696s) (coverage: 75.1% of statements)

=== Skipped
=== SKIP: acme Test_parseAndVerifyWireAccessToken (0.00s)
    challenge_wire_test.go:2126: skip until we can retrieve public key from e2e test, so that we can actually verify the token

DONE 366 tests, 1 skipped in 13.696s
```