### PR TITLE
create option to return all certs from signer in SCEP response

### DIFF
--- a/authority/provisioner/scep.go
+++ b/authority/provisioner/scep.go
@@ -41,6 +41,10 @@ type SCEP struct {
 	// GetCACerts response
 	ExcludeIntermediate bool `json:"excludeIntermediate,omitempty"`
 
+	// ReturnEntireCertChain makes the provisioner return the full certificate chain
+	// provided by the CA rather than just the leaf certificate
+	ReturnEntireCertChain bool `json:"returnEntireCertChain,omitempty"`
+
 	// MinimumPublicKeyLength is the minimum length for public keys in CSRs
 	MinimumPublicKeyLength int `json:"minimumPublicKeyLength,omitempty"`
 
@@ -445,6 +449,13 @@ func (s *SCEP) ShouldIncludeRootInChain() bool {
 // don't pick the right recipient.
 func (s *SCEP) ShouldIncludeIntermediateInChain() bool {
 	return !s.ExcludeIntermediate
+}
+
+// ShouldReturnEntireCertChain indicates if the
+// CA should return the entire chain of certificates in the SCEP
+// PKIOperation response rather than just the leaf certificate.
+func (s *SCEP) ShouldReturnEntireCertChain() bool {
+	return s.ReturnEntireCertChain
 }
 
 // GetContentEncryptionAlgorithm returns the numeric identifier

--- a/scep/authority.go
+++ b/scep/authority.go
@@ -363,10 +363,16 @@ func (a *Authority) SignCSR(ctx context.Context, csr *x509.CertificateRequest, m
 		return nil, err
 	}
 
-	// add the certificate into the signed data type
-	// this cert must be added before the signedData because the recipient will expect it
-	// as the first certificate in the array
-	signedData.AddCertificate(cert)
+	// add the certificate chain into the signed data type if specified
+	// otherwise just return the leaf cert. the ordering of the added signed data is important
+	// because the recipient will expect the leaf as the first certificate
+	if p.ShouldReturnEntireCertChain() {
+		for _, c := range certChain {
+			signedData.AddCertificate(c)
+		}
+	} else {
+		signedData.AddCertificate(cert)
+	}
 
 	signerCert, signer, err := a.selectSigner(ctx)
 	if err != nil {

--- a/scep/provisioner.go
+++ b/scep/provisioner.go
@@ -17,6 +17,7 @@ type Provisioner interface {
 	GetCapabilities() []string
 	ShouldIncludeRootInChain() bool
 	ShouldIncludeIntermediateInChain() bool
+	ShouldReturnEntireCertChain() bool
 	GetDecrypter() (*x509.Certificate, crypto.Decrypter)
 	GetSigner() (*x509.Certificate, crypto.Signer)
 	GetContentEncryptionAlgorithm() int


### PR DESCRIPTION
creation of ReturnEntireCertChain option for SCEP provisioner which controls whether to use the current default behavior of just returning the leaf cert or to return all certificates that we get from the signer response

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: `ReturnEntireCertChain`

#### Pain or issue this feature alleviates:
Currently, the SCEP response does not contain the entire intermediate chain that the CA provides in response to the CSR. The CA may return the leaf certificate in addition to intermediate certificates from which it is signed in order to build a chain of trust to the common root which is in both server and client stores.

#### Why is this important to the project (if not answered above):
Without this feature, clients must have the intermediate certificates manually managed in their trust stores which introduces failure points for administration and can cause outages during rotations

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
