### PR TITLE
Memory improvements

### DIFF
--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestMain(m *testing.M) {
 	if err := initializeSystemCertPool(); err != nil {
-		fmt.Fprintln(os.Stderr, "failed to initialize system cert pool:", err)
-		fmt.Fprintln(os.Stderr, "See https://pkg.go.dev/github.com/tjfoc/gmsm/x509#SystemCertPool\n", err)
+		fmt.Fprintf(os.Stderr, "failed to initialize system cert pool: %v\n", err)
+		fmt.Fprintln(os.Stderr, "See https://pkg.go.dev/crypto/x509#SystemCertPool")
 		os.Exit(2)
 	}
 

--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -24,6 +25,16 @@ import (
 	"go.step.sm/crypto/minica"
 	"go.step.sm/crypto/pemutil"
 )
+
+func TestMain(m *testing.M) {
+	if err := initializeSystemCertPool(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to initialize system cert pool:", err)
+		fmt.Fprintln(os.Stderr, "See https://pkg.go.dev/github.com/tjfoc/gmsm/x509#SystemCertPool\n", err)
+		os.Exit(2)
+	}
+
+	os.Exit(m.Run())
+}
 
 func testAuthority(t *testing.T, opts ...Option) *Authority {
 	maxjwk, err := jose.ReadKey("testdata/secrets/max_pub.jwk")

--- a/authority/http_client.go
+++ b/authority/http_client.go
@@ -3,36 +3,54 @@ package authority
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"net/http"
+	"sync/atomic"
 
+	"github.com/smallstep/certificates/authority/poolhttp"
+	"github.com/smallstep/certificates/authority/provisioner"
 	"github.com/smallstep/certificates/internal/httptransport"
 )
 
+// systemCertPool holds a copy of the system cert pool. This cert pool must be
+// initialized when the authority is created and we should always get a clone of
+// this pool.
+var systemCertPool atomic.Pointer[x509.CertPool]
+
+// initializeSystemCertPool initializes the system cert pool if necessary.
+func initializeSystemCertPool() error {
+	if systemCertPool.Load() == nil {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			return err
+		}
+		systemCertPool.Store(pool)
+	}
+	return nil
+}
+
 // newHTTPClient will return an HTTP client that trusts the system cert pool and
 // the given roots.
-func newHTTPClient(wt httptransport.Wrapper, roots ...*x509.Certificate) (*http.Client, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("error initializing http client: %w", err)
-	}
-	for _, crt := range roots {
-		pool.AddCert(crt)
-	}
+func newHTTPClient(wt httptransport.Wrapper, roots ...*x509.Certificate) provisioner.HTTPClient {
+	return poolhttp.New(func() *http.Client {
+		pool := systemCertPool.Load().Clone()
+		for _, crt := range roots {
+			pool.AddCert(crt)
+		}
 
-	tr, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		tr = httptransport.New()
-	} else {
-		tr = tr.Clone()
-	}
+		tr, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			tr = httptransport.New()
+		} else {
+			tr = tr.Clone()
+		}
 
-	tr.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    pool,
-	}
+		tr.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    pool,
+		}
 
-	return &http.Client{
-		Transport: wt(tr),
-	}, nil
+		rr := wt(tr)
+
+		return &http.Client{Transport: rr}
+	})
 }

--- a/authority/http_client_test.go
+++ b/authority/http_client_test.go
@@ -114,8 +114,7 @@ func Test_newHTTPClient(t *testing.T) {
 		}{http.DefaultTransport}
 		http.DefaultTransport = transport
 
-		client, err := newHTTPClient(httptransport.NoopWrapper(), auth.rootX509Certs...)
-		assert.NoError(t, err)
+		client := newHTTPClient(httptransport.NoopWrapper(), auth.rootX509Certs...)
 		assert.NotNil(t, client)
 	})
 }

--- a/authority/options.go
+++ b/authority/options.go
@@ -5,7 +5,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -97,7 +96,7 @@ func WithQuietInit() Option {
 }
 
 // WithWebhookClient sets the http.Client to be used for outbound requests.
-func WithWebhookClient(c *http.Client) Option {
+func WithWebhookClient(c provisioner.HTTPClient) Option {
 	return func(a *Authority) error {
 		a.webhookClient = c
 		return nil

--- a/authority/poolhttp/poolhttp.go
+++ b/authority/poolhttp/poolhttp.go
@@ -17,6 +17,7 @@ type Transporter interface {
 // clients. It implements the [provisioner.HTTPClient] and [Transporter]
 // interfaces. This is the HTTP client used by the provisioners.
 type Client struct {
+	rw   sync.RWMutex
 	pool sync.Pool
 }
 
@@ -31,18 +32,31 @@ func New(fn func() *http.Client) *Client {
 }
 
 // SetNew replaces the inner pool with a new [sync.Pool] with the given New
-// function. This method should not be used concurrently with other methods.
+// function. This method can be use concurrently with other methods of this
+// package.
 func (c *Client) SetNew(fn func() *http.Client) {
+	c.rw.Lock()
 	c.pool = sync.Pool{
 		New: func() any { return fn() },
 	}
+	c.rw.Unlock()
+}
+
+// getClient gets a client from the pool.
+func (c *Client) getClient() *http.Client {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
+	if hc, ok := c.pool.Get().(*http.Client); ok && hc != nil {
+		return hc
+	}
+	return nil
 }
 
 // Get issues a GET request to the specified URL. If the response is one of the
 // following redirect codes, Get follows the redirect after calling the
 // [Client.CheckRedirect] function:
 func (c *Client) Get(u string) (resp *http.Response, err error) {
-	if hc, ok := c.pool.Get().(*http.Client); ok && hc != nil {
+	if hc := c.getClient(); hc != nil {
 		resp, err = hc.Get(u)
 		c.pool.Put(hc)
 	} else {
@@ -55,7 +69,7 @@ func (c *Client) Get(u string) (resp *http.Response, err error) {
 // Do sends an HTTP request and returns an HTTP response, following policy (such
 // as redirects, cookies, auth) as configured on the client.
 func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
-	if hc, ok := c.pool.Get().(*http.Client); ok && hc != nil {
+	if hc := c.getClient(); hc != nil {
 		resp, err = hc.Do(req)
 		c.pool.Put(hc)
 	} else {
@@ -68,7 +82,7 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 // Transport() returns a clone of the http.Client Transport or returns the
 // default transport.
 func (c *Client) Transport() *http.Transport {
-	if hc, ok := c.pool.Get().(*http.Client); ok && hc != nil {
+	if hc := c.getClient(); hc != nil {
 		tr, ok := hc.Transport.(*http.Transport)
 		c.pool.Put(hc)
 		if ok {

--- a/authority/poolhttp/poolhttp.go
+++ b/authority/poolhttp/poolhttp.go
@@ -7,14 +7,14 @@ import (
 	"github.com/smallstep/certificates/internal/httptransport"
 )
 
-// Transporter is the implemented by custom HTTP clients with a method that
+// Transporter is implemented by custom HTTP clients with a method that
 // returns an [*http.Transport].
 type Transporter interface {
 	Transport() *http.Transport
 }
 
-// Client returns an HTTP client that uses a [sync.Pool] to create new HTTP
-// client. It implements the [provisioner.HTTPClient] and [Transporter]
+// Client is an HTTP client that uses a [sync.Pool] to create new and reuse HTTP
+// clients. It implements the [provisioner.HTTPClient] and [Transporter]
 // interfaces. This is the HTTP client used by the provisioners.
 type Client struct {
 	pool sync.Pool
@@ -38,7 +38,7 @@ func (c *Client) SetNew(fn func() *http.Client) {
 	}
 }
 
-// Get issues a GET to the specified URL. If the response is one of the
+// Get issues a GET request to the specified URL. If the response is one of the
 // following redirect codes, Get follows the redirect after calling the
 // [Client.CheckRedirect] function:
 func (c *Client) Get(u string) (resp *http.Response, err error) {

--- a/authority/poolhttp/poolhttp_test.go
+++ b/authority/poolhttp/poolhttp_test.go
@@ -1,0 +1,124 @@
+package poolhttp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireBody(t *testing.T, want string, r io.ReadCloser) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, r.Close())
+	})
+
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, want, string(b))
+}
+
+func TestClient(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World")
+	}))
+	t.Cleanup(httpSrv.Close)
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World")
+	}))
+	t.Cleanup(tlsSrv.Close)
+
+	tests := []struct {
+		name   string
+		client *Client
+		srv    *httptest.Server
+	}{
+		{"http", New(func() *http.Client { return httpSrv.Client() }), httpSrv},
+		{"tls", New(func() *http.Client { return tlsSrv.Client() }), tlsSrv},
+		{"nil", New(func() *http.Client { return nil }), httpSrv},
+		{"empty", &Client{}, httpSrv},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := tc.client.Get(tc.srv.URL)
+			require.NoError(t, err)
+			requireBody(t, "Hello World\n", resp.Body)
+
+			req, err := http.NewRequest("GET", tc.srv.URL, http.NoBody)
+			require.NoError(t, err)
+
+			resp, err = tc.client.Do(req)
+			require.NoError(t, err)
+			requireBody(t, "Hello World\n", resp.Body)
+
+			client := &http.Client{
+				Transport: tc.client.Transport(),
+			}
+			resp, err = client.Get(tc.srv.URL)
+			require.NoError(t, err)
+			requireBody(t, "Hello World\n", resp.Body)
+		})
+	}
+}
+
+func TestClient_SetNew(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World")
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(func() *http.Client {
+		return srv.Client()
+	})
+
+	tests := []struct {
+		name      string
+		client    *http.Client
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", srv.Client(), assert.NoError},
+		{"fail", http.DefaultClient, assert.Error},
+		{"ok again", srv.Client(), assert.NoError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c.SetNew(func() *http.Client {
+				return tc.client
+			})
+			_, err := c.Get(srv.URL)
+			tc.assertion(t, err)
+
+		})
+	}
+}
+
+func TestClient_parallel(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World")
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(func() *http.Client {
+		return srv.Client()
+	})
+	req, err := http.NewRequest("GET", srv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	for i := range 10 {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			resp, err := c.Get(srv.URL)
+			require.NoError(t, err)
+			requireBody(t, "Hello World\n", resp.Body)
+
+			resp, err = c.Do(req)
+			require.NoError(t, err)
+			requireBody(t, "Hello World\n", resp.Body)
+		})
+	}
+}

--- a/authority/poolhttp/poolhttp_test.go
+++ b/authority/poolhttp/poolhttp_test.go
@@ -98,6 +98,8 @@ func TestClient_SetNew(t *testing.T) {
 }
 
 func TestClient_parallel(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello World")
 	}))

--- a/authority/provisioner/controller.go
+++ b/authority/provisioner/controller.go
@@ -28,9 +28,9 @@ type Controller struct {
 	AuthorizeRenewFunc    AuthorizeRenewFunc
 	AuthorizeSSHRenewFunc AuthorizeSSHRenewFunc
 	policy                *policyEngine
-	webhookClient         *http.Client
+	httpClient            HTTPClient
+	webhookClient         HTTPClient
 	webhooks              []*Webhook
-	httpClient            *http.Client
 	wrapTransport         httptransport.Wrapper
 }
 
@@ -48,6 +48,7 @@ func NewController(p Interface, claims *Claims, config Config, options *Options)
 	if wt == nil {
 		wt = httptransport.NoopWrapper()
 	}
+
 	return &Controller{
 		Interface:             p,
 		Audiences:             &config.Audiences,
@@ -65,7 +66,7 @@ func NewController(p Interface, claims *Claims, config Config, options *Options)
 
 // GetHTTPClient returns the configured HTTP client or the default one if none
 // is configured.
-func (c *Controller) GetHTTPClient() *http.Client {
+func (c *Controller) GetHTTPClient() HTTPClient {
 	if c.httpClient != nil {
 		return c.httpClient
 	}

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -485,7 +485,7 @@ func (o *OIDC) AuthorizeSSHRevoke(_ context.Context, token string) error {
 	return errs.Unauthorized("oidc.AuthorizeSSHRevoke; cannot revoke with non-admin oidc token")
 }
 
-func getAndDecode(client *http.Client, uri string, v interface{}) error {
+func getAndDecode(client HTTPClient, uri string, v interface{}) error {
 	resp, err := client.Get(uri)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect to %s", uri)

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -258,16 +258,6 @@ type Config struct {
 	// GetIdentityFunc is a function that returns an identity that will be
 	// used by the provisioner to populate certificate attributes.
 	GetIdentityFunc GetIdentityFunc
-	/*
-		// GetHttpClientFunc is a function that returns an HTTP client that trusts
-		// the system cert pool and the CA roots.
-		GetHttpClientFunc func() *http.Client
-		// GetWebhookClientFunc ris a function that returns the HTTP client used
-		// when performing webhook requests, this is an HTTP client that trusts the
-		// system cert pool, the CA roots and uses the CA certificate as a client
-		// certificate.
-		GetWebhookClientFunc func() *http.Client
-	*/
 	// AuthorizeRenewFunc is a function that returns nil if a given X.509
 	// certificate can be renewed.
 	AuthorizeRenewFunc AuthorizeRenewFunc

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -34,6 +34,13 @@ type Interface interface {
 	AuthorizeSSHRekey(ctx context.Context, token string) (*ssh.Certificate, []SignOption, error)
 }
 
+// HTTPClient is the interface implemented by the HTTP clients used by the
+// provisioners.
+type HTTPClient interface {
+	Get(string) (*http.Response, error)
+	Do(*http.Request) (*http.Response, error)
+}
+
 // Uninitialized represents a disabled provisioner. Uninitialized provisioners
 // are created when the Init methods fails.
 type Uninitialized struct {
@@ -251,6 +258,16 @@ type Config struct {
 	// GetIdentityFunc is a function that returns an identity that will be
 	// used by the provisioner to populate certificate attributes.
 	GetIdentityFunc GetIdentityFunc
+	/*
+		// GetHttpClientFunc is a function that returns an HTTP client that trusts
+		// the system cert pool and the CA roots.
+		GetHttpClientFunc func() *http.Client
+		// GetWebhookClientFunc ris a function that returns the HTTP client used
+		// when performing webhook requests, this is an HTTP client that trusts the
+		// system cert pool, the CA roots and uses the CA certificate as a client
+		// certificate.
+		GetWebhookClientFunc func() *http.Client
+	*/
 	// AuthorizeRenewFunc is a function that returns nil if a given X.509
 	// certificate can be renewed.
 	AuthorizeRenewFunc AuthorizeRenewFunc
@@ -258,12 +275,12 @@ type Config struct {
 	// certificate can be renewed.
 	AuthorizeSSHRenewFunc AuthorizeSSHRenewFunc
 	// WebhookClient is an HTTP client used when performing webhook requests.
-	WebhookClient *http.Client
+	WebhookClient HTTPClient
 	// SCEPKeyManager, if defined, is the interface used by SCEP provisioners.
 	SCEPKeyManager SCEPKeyManager
 	// HTTPClient is an HTTP client that trusts the system cert pool and the CA
 	// roots.
-	HTTPClient *http.Client
+	HTTPClient HTTPClient
 	// WrapTransport references the function that should wrap any [http.Transport] initialized
 	// down the Config's chain.
 	WrapTransport TransportWrapper

--- a/authority/provisioner/scep.go
+++ b/authority/provisioner/scep.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -113,14 +112,14 @@ func (s *SCEP) DefaultTLSCertDuration() time.Duration {
 }
 
 type challengeValidationController struct {
-	client        *http.Client
+	client        HTTPClient
 	wrapTransport httptransport.Wrapper
 	webhooks      []*Webhook
 }
 
 // newChallengeValidationController creates a new challengeValidationController
 // that performs challenge validation through webhooks.
-func newChallengeValidationController(client *http.Client, tw httptransport.Wrapper, webhooks []*Webhook) *challengeValidationController {
+func newChallengeValidationController(client HTTPClient, tw httptransport.Wrapper, webhooks []*Webhook) *challengeValidationController {
 	scepHooks := []*Webhook{}
 	for _, wh := range webhooks {
 		if wh.Kind != linkedca.Webhook_SCEPCHALLENGE.String() {
@@ -179,14 +178,14 @@ func (c *challengeValidationController) Validate(ctx context.Context, csr *x509.
 }
 
 type notificationController struct {
-	client        *http.Client
+	client        HTTPClient
 	wrapTransport httptransport.Wrapper
 	webhooks      []*Webhook
 }
 
 // newNotificationController creates a new notificationController
 // that performs SCEP notifications through webhooks.
-func newNotificationController(client *http.Client, tw httptransport.Wrapper, webhooks []*Webhook) *notificationController {
+func newNotificationController(client HTTPClient, tw httptransport.Wrapper, webhooks []*Webhook) *notificationController {
 	scepHooks := []*Webhook{}
 	for _, wh := range webhooks {
 		if wh.Kind != linkedca.Webhook_NOTIFYING.String() {


### PR DESCRIPTION
This commit replaces the client in provisioners and webhooks with an interface. Then it implements the interface using the new poolhttp package. This package implements the HTTPClient interface but it is backed by a sync.Pool, this improves memory, allowing the GC to clean more memory. It also removes the timer in the keystore to avoid having extra goroutines if a provisioner goes away. This commit avoids creating the templates func multiple times, reducing some memory in the heap.
