### PR TITLE
Active revocation via HTTP API

### DIFF
--- a/api/revoke.go
+++ b/api/revoke.go
@@ -42,9 +42,6 @@ func (r *RevokeRequest) Validate() (err error) {
 	if r.ReasonCode < ocsp.Unspecified || r.ReasonCode > ocsp.AACompromise {
 		return errs.BadRequest("reasonCode out of bounds")
 	}
-	if !r.Passive {
-		return errs.NotImplemented("non-passive revocation not implemented")
-	}
 
 	return
 }

--- a/api/revoke_test.go
+++ b/api/revoke_test.go
@@ -43,19 +43,18 @@ func TestRevokeRequestValidate(t *testing.T) {
 			},
 			err: &errs.Error{Err: errors.New("reasonCode out of bounds"), Status: http.StatusBadRequest},
 		},
-		"error/non-passive not implemented": {
-			rr: &RevokeRequest{
-				Serial:     "10",
-				ReasonCode: 8,
-				Passive:    false,
-			},
-			err: &errs.Error{Err: errors.New("non-passive revocation not implemented"), Status: http.StatusNotImplemented},
-		},
-		"ok": {
+		"ok/passive": {
 			rr: &RevokeRequest{
 				Serial:     "10",
 				ReasonCode: 9,
 				Passive:    true,
+			},
+		},
+		"ok/active": {
+			rr: &RevokeRequest{
+				Serial:     "10",
+				ReasonCode: 9,
+				Passive:    false,
 			},
 		},
 	}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Allow for active revocation via HTTP API.

#### Pain or issue this feature alleviates:

Active revocation being rejected by the API.

#### Why is this important to the project (if not answered above):

Above.

#### Is there documentation on how to use this feature? If so, where?

Not any less documented than the existing HTTP API but will be reflected in Go docs.

#### In what environments or workflows is this feature supported?

n/a

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

n/a

#### Supporting links/other PRs/issues:

This picks the commit from https://github.com/smallstep/certificates/pull/2085 and adds another with the suggested improvements. As written in the commit message, the `Passive` boolean is kept as it still seems to be needed for preventing active revocation of SSH certificates.

💔Thank you!
