### PR TITLE
Fix sshagentkms

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -532,6 +532,13 @@ func (a *Authority) init() error {
 			switch s := signer.(type) {
 			case *sshagentkms.WrappedSSHSigner:
 				a.sshCAHostCertSignKey = s.Signer
+			case *instrumentedKMSSigner:
+				switch is := s.Signer.(type) {
+				case *sshagentkms.WrappedSSHSigner:
+					a.sshCAHostCertSignKey = is.Signer
+				default:
+					a.sshCAHostCertSignKey, err = ssh.NewSignerFromSigner(s)
+				}
 			case crypto.Signer:
 				a.sshCAHostCertSignKey, err = ssh.NewSignerFromSigner(s)
 			default:
@@ -558,6 +565,13 @@ func (a *Authority) init() error {
 			switch s := signer.(type) {
 			case *sshagentkms.WrappedSSHSigner:
 				a.sshCAUserCertSignKey = s.Signer
+			case *instrumentedKMSSigner:
+				switch is := s.Signer.(type) {
+				case *sshagentkms.WrappedSSHSigner:
+					a.sshCAUserCertSignKey = is.Signer
+				default:
+					a.sshCAUserCertSignKey, err = ssh.NewSignerFromSigner(s)
+				}
 			case crypto.Signer:
 				a.sshCAUserCertSignKey, err = ssh.NewSignerFromSigner(s)
 			default:


### PR DESCRIPTION
#### Name of feature:
Fix sshagentkms

#### Pain or issue this feature alleviates:
sshagentkms not working after "Implementation of the Prometheus endpoint (#1669)" (dd1ff9c15b0f8ca5920dac6a0ff080b7f0cfb8be).

#### Why is this important to the project (if not answered above):
Currently, sshagentkms doesn't work in anything after v0.25.2

#### Is there documentation on how to use this feature? If so, where?
Yes, this feature already exists, and this just makes it work again.

#### In what environments or workflows is this feature supported?
When one already has a ssh-certificate signing infrastructure based on ssh-agent and would like to expose that via step, or when one would like to use a HSM which exposes the access to the key via a ssh-agent interface and would like to expose that via step.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Any old step versions between dd1ff9c15b0f8ca5920dac6a0ff080b7f0cfb8be and master.

#### Supporting links/other PRs/issues:
None. This is both bug report and PR with fix.

💔Thank you!
