### PR TITLE
Use GoReleaser `v2` in `make bootstrap`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ bootstra%:
 	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin latest
 	$Q go install golang.org/x/vuln/cmd/govulncheck@latest
 	$Q go install gotest.tools/gotestsum@latest
-	$Q go install github.com/goreleaser/goreleaser@latest
+	$Q go install github.com/goreleaser/goreleaser/v2@latest
 	$Q go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 
 .PHONY: bootstra%


### PR DESCRIPTION
Fixes: #2396
