### PR TITLE
Fix backdate support for ACME provisioner

### DIFF
--- a/acme/api/revoke_test.go
+++ b/acme/api/revoke_test.go
@@ -279,6 +279,7 @@ type mockCA struct {
 	MockIsRevoked      func(sn string) (bool, error)
 	MockRevoke         func(ctx context.Context, opts *authority.RevokeOptions) error
 	MockAreSANsallowed func(ctx context.Context, sans []string) error
+	MockGetBackdate    func() *time.Duration
 }
 
 func (m *mockCA) SignWithContext(context.Context, *x509.CertificateRequest, provisioner.SignOptions, ...provisioner.SignOption) ([]*x509.Certificate, error) {
@@ -308,6 +309,13 @@ func (m *mockCA) Revoke(ctx context.Context, opts *authority.RevokeOptions) erro
 
 func (m *mockCA) LoadProvisionerByName(string) (provisioner.Interface, error) {
 	return nil, nil
+}
+
+func (m *mockCA) GetBackdate() *time.Duration {
+	if m.MockGetBackdate != nil {
+		return m.MockGetBackdate()
+	}
+	return nil
 }
 
 func Test_validateReasonCode(t *testing.T) {

--- a/acme/api/wire_integration_test.go
+++ b/acme/api/wire_integration_test.go
@@ -613,3 +613,7 @@ func (m *mockCASigner) Revoke(ctx context.Context, opts *authority.RevokeOptions
 func (m *mockCASigner) LoadProvisionerByName(string) (provisioner.Interface, error) {
 	return nil, nil
 }
+
+func (m *mockCASigner) GetBackdate() *time.Duration {
+	return nil
+}

--- a/acme/common.go
+++ b/acme/common.go
@@ -26,6 +26,7 @@ type CertificateAuthority interface {
 	IsRevoked(sn string) (bool, error)
 	Revoke(context.Context, *authority.RevokeOptions) error
 	LoadProvisionerByName(string) (provisioner.Interface, error)
+	GetBackdate() *time.Duration
 }
 
 // NewContext adds the given acme components to the context.

--- a/acme/order_test.go
+++ b/acme/order_test.go
@@ -311,6 +311,10 @@ func (m *mockSignAuth) Revoke(context.Context, *authority.RevokeOptions) error {
 	return nil
 }
 
+func (m *mockSignAuth) GetBackdate() *time.Duration {
+	return nil
+}
+
 func TestOrder_Finalize(t *testing.T) {
 	mustSigner := func(kty, crv string, size int) crypto.Signer {
 		s, err := keyutil.GenerateSigner(kty, crv, size)

--- a/authority/authority.go
+++ b/authority/authority.go
@@ -882,6 +882,17 @@ func (a *Authority) GetConfig() *config.Config {
 	return a.config
 }
 
+// GetBackdate returns the [time.Duration] representing the
+// amount of time that is to be subtracted from the current
+// time when issuing a new certificate.
+func (a *Authority) GetBackdate() *time.Duration {
+	if a.config == nil || a.config.AuthorityConfig == nil || a.config.AuthorityConfig.Backdate == nil {
+		return nil
+	}
+
+	return &a.config.AuthorityConfig.Backdate.Duration
+}
+
 // GetInfo returns information about the authority.
 func (a *Authority) GetInfo() Info {
 	ai := Info{


### PR DESCRIPTION
Other provisioners did take into account the authority-wide certificate backdate configuration already, but the ACME provisioner did not. This commit adds `authority.GetBackdate`, so that the ACME provisioner can use it if set.

This will result in slightly different behavior for users that had the backdate set before, and are using both ACME and other provisioners, but it generally shouldn't cause issues.

Fixes: #927
