### PR TITLE
Add sd_notify support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ccoveille/go-safecast v1.8.2
 	github.com/coreos/go-oidc/v3 v3.16.0
+	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/dgraph-io/badger v1.6.2
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/fxamacker/cbor/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-oidc/v3 v3.16.0 h1:qRQUCFstKpXwmEjDQTIbyY/5jF00+asXzSkmkoa/mow=
 github.com/coreos/go-oidc/v3 v3.16.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
+github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

sd_notify support

#### Pain or issue this feature alleviates:

Closes https://github.com/smallstep/certificates/issues/477

Allows a systemd service to use `Type=notify`, so it's only considered ready once all the listeners are up.
Additionally I also added sd_notify Reloading support, so systemd knows when step-ca is reloading the config.
See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Options and https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#Well-known%20assignments.

#### Why is this important to the project (if not answered above):

This allows systemd to be aware of when the service is actually started, so other services that depend on it can be started. Currently this is not the case and other services will fail to connect, if started too early.

#### Is there documentation on how to use this feature? If so, where?

Not sure if needed, but probably useful.

#### In what environments or workflows is this feature supported?

systemd

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

non-systemd