### PR TITLE
Fix missing version number while building step-ca from source archive

### DIFF
--- a/.version.sh
+++ b/.version.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env sh
 read -r firstline < .VERSION
 last_half="${firstline##*tag: }"
-if [[ ${last_half::1} == "v" ]]; then
-    version_string="${last_half%%[,)]*}"
-fi
+case "$last_half" in
+    v*)
+        version_string="${last_half%%[,)]*}"
+        ;;
+esac
 echo "${version_string:-v0.0.0}"


### PR DESCRIPTION
The .version.sh file fails at line 4 with the following error:
`./.version.sh: 4: Bad substitution ' out of the ' make build GOFLAGS=""`

The above error results in 'step-ca --version' not including the version number after the build:
Smallstep CA/ (linux/arm64)
Release Date: 2026-01-02 16:32 UTC

Modern *nix-like operating systems symlink the `sh` shell to bash/dash/etc.
Because of this, the output of `.version.sh` is not consistent across different operating systems.
The goal of this change is to make the code POSIX-neutral so that it executes correctly in bash/dash/sh shells.
Tested on Ubuntu 24.04 (amd64), Debian 13 (arm64), and MacOS 15.7.1 (arm).

Fixes #2013

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
N/A

#### Pain or issue this feature alleviates:
This should significantly reduce comments about a missing version number from the output of `step-ca --version`.
It also removes the error/warning (./.version.sh: 4: Bad substitution ' out of the ' make build GOFLAGS="") while building from source.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?
Please let me know what to put here.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:
Issue #2013  

💔Thank you!
