### PR TITLE
Add changelog entry for smallstep/certificates#2493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Use errgroup to shutdown services concurrently (smallstep/certificates#2343)
+- Upgrade HSM-enabled Docker images from Debian Bookworm (12) to Debian Trixie
+  (13) (smallstep/certificates#2493)
+- Use JSON array format for Dockerfile's `CMD` instruction. This prevents shell
+  interpolation of environment variables like `CONFIGPATH` and `PWDPATH`,
+  ensuring consistent command execution. Commands can still be overridden via
+  Kubernetes or Docker configuration when needed (smallstep/certificates#2493)
 
 ### Deprecated
 


### PR DESCRIPTION
This commit adds an entry in the changelog related to the changes in smallstep/certificates#2493.
