### PR TITLE
Warn when ACME provisioner is configured without database

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -988,6 +988,16 @@ func (a *Authority) GetSCEP() *scep.Authority {
 	return a.scepAuthority
 }
 
+// HasACMEProvisioner returns true if at least one ACME provisioner is configured.
+func (a *Authority) HasACMEProvisioner() bool {
+	for _, p := range a.config.AuthorityConfig.Provisioners {
+		if p.GetType() == provisioner.TypeACME {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *Authority) startCRLGenerator() error {
 	if !a.config.CRL.IsEnabled() {
 		return nil

--- a/ca/ca.go
+++ b/ca/ca.go
@@ -262,6 +262,9 @@ func (ca *CA) Init(cfg *config.Config) (*CA, error) {
 	// ACME Router is only available if we have a database.
 	var acmeDB acme.DB
 	var acmeLinker acme.Linker
+	if cfg.DB == nil && auth.HasACMEProvisioner() {
+		log.Println("WARNING: No database is configured. ACME provisioners are disabled.")
+	}
 	if cfg.DB != nil {
 		acmeDB, err = acmeNoSQL.New(auth.GetDatabase().(nosql.DB))
 		if err != nil {


### PR DESCRIPTION
When an ACME provisioner is configured but the database is not set up, ACME endpoints silently fail with 404 errors. This change adds a warning at startup to inform users that ACME functionality will not be available without a database configuration.

Fixes #2102
