### PR TITLE
Change file extension suggested for DER format CRL downloads

### DIFF
--- a/api/crl.go
+++ b/api/crl.go
@@ -40,7 +40,7 @@ func CRL(w http.ResponseWriter, r *http.Request) {
 		})
 	} else {
 		w.Header().Add("Content-Type", "application/pkix-crl")
-		w.Header().Add("Content-Disposition", "attachment; filename=\"crl.der\"")
+		w.Header().Add("Content-Disposition", "attachment; filename=\"crl.crl\"")
 		w.Write(crlInfo.Data)
 	}
 }


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Change CRL file extension to `.crl` by default for DER format (default)

#### Pain or issue this feature alleviates:

- Issue #2535 : when opening `.der` files through Windows, Windows default certificate viewer app expects file to be a certificate file, not CRL. This causes error `This file is invalid for use as the following: Security Certificate.`. User should disable _(default)_ hiding of registered extensions, change file extension to .crl (if user knows about it) and open again.

#### Why is this important to the project (if not answered above):

- Bringing to standard.

#### Is there documentation on how to use this feature? If so, where?

- CRL file in DER format with type application/pkix-crl should have .CRL extension, as [registered by IANA](https://www.iana.org/assignments/media-types/application/pkix-crl)

#### In what environments or workflows is this feature supported?

- Windows Desktop clients (default and only windows file association for `application/pkix-crl` is `.CRL` ). Any http client that respects `Content-Disposition` response header.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

- Any http client that overrides or does not respect `Content-Disposition` response header.

#### Supporting links/other PRs/issues:

* [IANA `application/pkix-crl`](https://www.iana.org/assignments/media-types/application/pkix-crl)

💔Thank you!
