### PR TITLE
Migrate to `x509.RevocationListEntry` and add reason codes to CRL

### DIFF
--- a/authority/tls.go
+++ b/authority/tls.go
@@ -820,6 +820,7 @@ func (a *Authority) GenerateCertificateRevocationList() error {
 		revokedCertificateEntries = append(revokedCertificateEntries, x509.RevocationListEntry{
 			SerialNumber:   &sn,
 			RevocationTime: revokedCert.RevokedAt,
+			ReasonCode:     revokedCert.ReasonCode,
 		})
 	}
 


### PR DESCRIPTION
This PR migrates from the deprecated `RevokedCertificates` field to `RevokedCertificateEntries`, which allows including revocation reason codes in the CRL without having to add them via extensions.