### PR TITLE
Update cosign command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -120,9 +120,12 @@ checksum:
 
 signs:
 - cmd: cosign
-  signature: "${artifact}.sig"
-  certificate: "${artifact}.pem"
-  args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
+  signature: "${artifact}.sigstore.json"
+  args:
+    - "sign-blob"
+    - "--bundle=${signature}"
+    - "${artifact}"
+    - "--yes"
   artifacts: all
 
 publishers:


### PR DESCRIPTION
This commit updates the cosign command according to https://goreleaser.com/blog/cosign-v3/

Test release worked, see https://github.com/smallstep/certificates/releases/tag/v0.30.0-rc2

The docker images are failing because they depend on a new releases with Debian Trixie of step-kms-plugin and step-cli. This error is expected.