### PR TITLE
Validate webhooks

### DIFF
--- a/acme/linker.go
+++ b/acme/linker.go
@@ -200,9 +200,15 @@ func (l *linker) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		acmeProv, ok := p.(*provisioner.ACME)
-		if !ok {
-			render.Error(w, r, NewError(ErrorAccountDoesNotExistType, "provisioner must be of type ACME"))
+		var acmeProv *provisioner.ACME
+		switch prov := p.(type) {
+		case *provisioner.ACME:
+			acmeProv = prov
+		case provisioner.Uninitialized:
+			render.Error(w, r, NewDetailedError(ErrorUnauthorizedType, "provisioner is disabled due to an initialization error"))
+			return
+		default:
+			render.Error(w, r, NewDetailedError(ErrorUnauthorizedType, "provisioner must be of type ACME"))
 			return
 		}
 

--- a/authority/provisioner/controller.go
+++ b/authority/provisioner/controller.go
@@ -48,6 +48,11 @@ func NewController(p Interface, claims *Claims, config Config, options *Options)
 	if wt == nil {
 		wt = httptransport.NoopWrapper()
 	}
+	for _, wh := range options.GetWebhooks() {
+		if err := wh.Validate(); err != nil {
+			return nil, err
+		}
+	}
 
 	return &Controller{
 		Interface:             p,

--- a/authority/provisioner/scep_test.go
+++ b/authority/provisioner/scep_test.go
@@ -279,6 +279,8 @@ func Test_selectValidationMethod(t *testing.T) {
 			Options: &Options{
 				Webhooks: []*Webhook{
 					{
+						Name: "challenge",
+						URL:  "https://scep.challenge",
 						Kind: linkedca.Webhook_SCEPCHALLENGE.String(),
 					},
 				},
@@ -295,6 +297,8 @@ func Test_selectValidationMethod(t *testing.T) {
 			Options: &Options{
 				Webhooks: []*Webhook{
 					{
+						Name: "authorizing",
+						URL:  "https://scep.authorizing",
 						Kind: linkedca.Webhook_AUTHORIZING.String(),
 					},
 				},
@@ -311,6 +315,8 @@ func Test_selectValidationMethod(t *testing.T) {
 			Options: &Options{
 				Webhooks: []*Webhook{
 					{
+						Name: "authorizing",
+						URL:  "https://scep.authorizing",
 						Kind: linkedca.Webhook_AUTHORIZING.String(),
 					},
 				},
@@ -341,7 +347,7 @@ func TestSCEP_ValidateChallenge(t *testing.T) {
 		Allow bool `json:"allow"`
 		Data  any  `json:"data"`
 	}
-	okServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	okServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := &request{}
 		err := json.NewDecoder(r.Body).Decode(req)
 		require.NoError(t, err)
@@ -363,6 +369,7 @@ func TestSCEP_ValidateChallenge(t *testing.T) {
 		w.WriteHeader(200)
 		w.Write(b)
 	}))
+	httpclient := okServer.Client()
 	t.Cleanup(okServer.Close)
 	type args struct {
 		challenge     string
@@ -471,7 +478,7 @@ func TestSCEP_ValidateChallenge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Init(Config{Claims: globalProvisionerClaims, WebhookClient: http.DefaultClient})
+			err := tt.p.Init(Config{Claims: globalProvisionerClaims, WebhookClient: httpclient})
 			require.NoError(t, err)
 			ctx := context.Background()
 


### PR DESCRIPTION
This commit validates the webhooks when they are configured on the ca.json

Note that this PR will not address the linter errors caused by the new golangci-lint version.