### PR TITLE
Enable zizmor GitHub Advanced Security upload

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -19,4 +19,6 @@ jobs:
       contents: read
       security-events: write
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
+    with:
+      zizmor-advanced-security: true
     secrets: inherit


### PR DESCRIPTION
## Summary
- Explicitly enable `zizmor-advanced-security: true` for this public repo
- Required because the actionci.yml default is being changed to `false` in smallstep/workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)