### PR TITLE
Add actions and security-events permissions to release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   ci:
     permissions:
       contents: read
+      actions: read
+      security-events: write
     uses: smallstep/certificates/.github/workflows/ci.yml@master
     secrets: inherit
 


### PR DESCRIPTION
The release workflow's CI job was missing `actions: read` and `security-events: write` permissions, which are required for certain CI steps (e.g. uploading SARIF results or reading workflow artifacts).


See https://github.com/smallstep/certificates/actions/runs/22986475944 for the failed `v0.30.0-rc4` release.

Change-Type: ci
Release-Note: no
Audience: internal
Impact: low
Breaking: false