### PR TITLE
Disable polkit in pcscd

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -97,7 +97,7 @@ function step_ca_init () {
 }
 
 if [ -f /usr/sbin/pcscd ]; then
-    /usr/sbin/pcscd
+    /usr/sbin/pcscd --disable-polkit
 fi
 
 if [ ! -f "${STEPPATH}/config/ca.json" ]; then


### PR DESCRIPTION
There's no use of polkit inside a container and it makes step-ca connections to pcscd fail, so just disable the use of polkit in pcscd.

fixes: smallstep/certificates#2607

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Disable use of polkit in pcscd when running in a container.

#### Pain or issue this feature alleviates:
#2607 

#### Why is this important to the project (if not answered above):
Configurations that were working before are now crashing

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?
Only in containers

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Not containers

#### Supporting links/other PRs/issues:
