### PR TITLE
Fix enforcing termsOfServiceAgreed in ACME server

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -119,6 +119,12 @@ func NewAccount(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if prov.TermsOfService != "" && !nar.TermsOfServiceAgreed {
+			render.Error(w, r, acme.NewError(acme.ErrorUserActionRequiredType,
+				"terms of service must be agreed to: %s", prov.TermsOfService))
+			return
+		}
+
 		jwk, err := jwkFromContext(ctx)
 		if err != nil {
 			render.Error(w, r, err)

--- a/acme/api/account_test.go
+++ b/acme/api/account_test.go
@@ -480,6 +480,23 @@ func TestHandler_NewAccount(t *testing.T) {
 				err:        acme.NewError(acme.ErrorAccountDoesNotExistType, "account does not exist"),
 			}
 		},
+		"fail/terms-of-service-not-agreed": func(t *testing.T) test {
+			nar := &NewAccountRequest{
+				Contact: []string{"foo", "bar"},
+			}
+			b, err := json.Marshal(nar)
+			assert.FatalError(t, err)
+			p := newACMEProv(t)
+			p.TermsOfService = "https://terms.ca.local/"
+			ctx := context.WithValue(context.Background(), payloadContextKey, &payloadInfo{value: b})
+			ctx = acme.NewProvisionerContext(ctx, p)
+			return test{
+				db:         &acme.MockDB{},
+				ctx:        ctx,
+				statusCode: 400,
+				err:        acme.NewError(acme.ErrorUserActionRequiredType, "terms of service must be agreed to: https://terms.ca.local/"),
+			}
+		},
 		"fail/no-jwk": func(t *testing.T) test {
 			nar := &NewAccountRequest{
 				Contact: []string{"foo", "bar"},


### PR DESCRIPTION
Fixes #2539

When an ACME provisioner has `termsOfService` configured, `NewAccount` in `acme/api/account.go` was creating accounts regardless of the `termsOfServiceAgreed` field in the request, violating RFC 8555 §7.3.3. Adds a check before account creation that returns an `ErrorUserActionRequiredType` error if `termsOfServiceAgreed` is not `true`.