### PR TITLE
fix: reject CA startup when commonName collides with issuer certificate CN

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -450,6 +450,16 @@ func (a *Authority) init() error {
 			if len(a.intermediateX509Certs) == 0 {
 				a.intermediateX509Certs = append(a.intermediateX509Certs, options.CertificateChain...)
 			}
+
+			// Validate that neither config.commonName nor authority.template.commonName
+			// collides with the issuing CA's CommonName. If they match, issued
+			// certificates (or the CA's own TLS certificate) will have Subject == Issuer
+			// and be incorrectly treated as self-signed by TLS stacks and validators.
+			if len(a.intermediateX509Certs) > 0 {
+				if err := a.validateCommonNames(a.intermediateX509Certs[0].Subject.CommonName); err != nil {
+					return err
+				}
+			}
 		}
 		a.x509CAService, err = cas.New(ctx, options)
 		if err != nil {
@@ -873,6 +883,28 @@ func (a *Authority) initLogf(format string, v ...any) {
 	if !a.quietInit {
 		log.Printf(format, v...)
 	}
+}
+
+// validateCommonNames returns an error if config.commonName or
+// authority.template.commonName equals the issuing CA certificate's CommonName.
+// When Subject.CommonName equals Issuer.CommonName the certificate looks
+// self-signed to TLS stacks and certificate validators, which causes
+// handshake failures and trust errors.
+func (a *Authority) validateCommonNames(issuerCN string) error {
+	if issuerCN == "" {
+		return nil
+	}
+	if a.config.CommonName == issuerCN {
+		return fmt.Errorf("config commonName %q must not be equal to the issuing CA "+
+			"certificate's CommonName; the CA's own TLS certificate would appear "+
+			"self-signed — use a distinct name or leave commonName empty to use the default", issuerCN)
+	}
+	if tmpl := a.config.AuthorityConfig.Template; tmpl != nil && tmpl.CommonName == issuerCN {
+		return fmt.Errorf("authority.template.commonName %q must not be equal to the "+
+			"issuing CA certificate's CommonName; issued leaf certificates would appear "+
+			"self-signed — use a distinct name or remove authority.template.commonName", issuerCN)
+	}
+	return nil
 }
 
 // GetID returns the define authority id or a zero uuid.

--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -158,6 +158,31 @@ func TestAuthorityNew(t *testing.T) {
 				err:    errors.New(`error reading "wrong": no such file or directory`),
 			}
 		},
+		"fail config commonName equals issuer CN": func(t *testing.T) *newTest {
+			c, err := LoadConfiguration("../ca/testdata/ca.json")
+			assert.FatalError(t, err)
+			// Intermediate CA in testdata has CN "smallstep Intermediate CA".
+			// Setting Config.CommonName to the same value would make the CA's
+			// own TLS certificate appear self-signed.
+			c.CommonName = "smallstep Intermediate CA"
+			return &newTest{
+				config: c,
+				err: errors.New(`config commonName "smallstep Intermediate CA" must not be equal to the issuing CA certificate's CommonName`),
+			}
+		},
+		"fail template commonName equals issuer CN": func(t *testing.T) *newTest {
+			c, err := LoadConfiguration("../ca/testdata/ca.json")
+			assert.FatalError(t, err)
+			// Setting authority.template.commonName to the intermediate CA's CN
+			// would make every issued leaf certificate appear self-signed.
+			c.AuthorityConfig.Template = &ASN1DN{
+				CommonName: "smallstep Intermediate CA",
+			}
+			return &newTest{
+				config: c,
+				err: errors.New(`authority.template.commonName "smallstep Intermediate CA" must not be equal to the issuing CA certificate's CommonName`),
+			}
+		},
 	}
 
 	for name, genTestCase := range tests {


### PR DESCRIPTION
# Name of feature:
Startup validation: reject configuration when commonName or authority.template.commonName collides with the issuing CA certificate's CommonName

# Pain or issue this feature alleviates:
When config.commonName or authority.template.commonName in ca.json is set to the same value as the intermediate CA certificate's CommonName, all affected certificates will have Subject == Issuer. TLS stacks and certificate validators interpret this as a self-signed certificate, causing handshake failures and trust errors — even though the certificate chain is technically correct. The root cause is difficult to diagnose because the error appears on the client side (e.g. PowerShell: "Could not establish trust relationship for the SSL/TLS secure channel") and nothing in the CA log indicates a misconfiguration.

# Why is this important to the project:
The misconfiguration is easy to make (especially when setting up step-ca manually without step ca init) and produces a silent, hard-to-diagnose failure. A clear startup error pointing directly to the problematic field saves significant debugging time.

# Is there documentation on how to use this feature? If so, where?
No documentation needed — the feature is a startup guard that emits a self-explanatory error message and exits. The error message itself contains the corrective action:

"use a distinct name or leave commonName empty to use the default"
"use a distinct name or remove authority.template.commonName"
In what environments or workflows is this feature supported?
All SoftCAS deployments (default step ca init setup). Validation runs during authority.init() after the intermediate certificate chain is loaded.

# In what environments or workflows is this feature explicitly NOT supported (if any)?
External CAS deployments (CloudCAS, StepCAS/RA mode) — in those cases the intermediate certificate is not loaded locally, so the check is skipped.

The PR and the commit was created using Claude AI.