### PR TITLE
fix(acme): wrap order list response in {"orders": [...]} per RFC 8555

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -250,6 +250,12 @@ func GetOrdersByAccountID(w http.ResponseWriter, r *http.Request) {
 
 	linker.LinkOrdersByAccountID(ctx, orders)
 
-	render.JSON(w, r, orders)
+	// RFC 8555 § 7.1.2.1: response must be {"orders": [...]}
+	if orders == nil {
+		orders = []string{}
+	}
+	render.JSON(w, r, struct {
+		Orders []string `json:"orders"`
+	}{Orders: orders})
 	logOrdersByAccount(w, orders)
 }

--- a/acme/api/account_test.go
+++ b/acme/api/account_test.go
@@ -401,7 +401,9 @@ func TestHandler_GetOrdersByAccountID(t *testing.T) {
 				assert.Equals(t, ae.Subproblems, tc.err.Subproblems)
 				assert.Equals(t, res.Header["Content-Type"], []string{"application/problem+json"})
 			} else {
-				expB, err := json.Marshal(oidURLs)
+				expB, err := json.Marshal(struct {
+					Orders []string `json:"orders"`
+				}{Orders: oidURLs})
 				assert.FatalError(t, err)
 				assert.Equals(t, bytes.TrimSpace(body), expB)
 				assert.Equals(t, res.Header["Content-Type"], []string{"application/json"})


### PR DESCRIPTION
Fixes #2629

## Problem

`GetOrdersByAccountID` returns a bare JSON array:
```json
[]
```

RFC 8555 §7.1.2.1 requires:
```json
{"orders": []}
```

## Fix

Wrap the response in a struct with an `"orders"` field. Guard against nil slices to ensure empty responses are `{"orders":[]}` not `{"orders":null}`.

Tests updated and passing.