### PR TITLE
fix: enforce termsOfServiceAgreed when termsOfService is configured

### DIFF
--- a/acme/api/account.go
+++ b/acme/api/account.go
@@ -102,6 +102,12 @@ func NewAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if prov.TermsOfService != "" && !nar.TermsOfServiceAgreed {
+		render.Error(w, r, acme.NewError(acme.ErrorUserActionRequiredType,
+			"terms of service must be agreed to; see %s", prov.TermsOfService))
+		return
+	}
+
 	httpStatus := http.StatusCreated
 	acc, err := accountFromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Per [RFC 8555 §7.3.3](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.3), when an ACME provisioner has `termsOfService` configured, the server should reject `newAccount` requests that do not set `termsOfServiceAgreed` to `true`.

Previously, the server advertised `termsOfService` in the directory metadata but did not enforce that clients agree to it before creating an account.

## Changes

- Added a check in `NewAccount` handler (`acme/api/account.go`) that returns an `ErrorUserActionRequiredType` ACME error when `termsOfService` is configured on the provisioner but the request does not include `termsOfServiceAgreed: true`.
- The error message includes the terms of service URL, as recommended by the RFC.

## Testing

The fix follows the existing error handling pattern used for other ACME validation checks (e.g., `onlyReturnExisting`). The `acmeProvisionerFromContext` returns `*provisioner.ACME` which exposes the `TermsOfService` field, consistent with how it's accessed in `handler.go` for directory metadata.

Closes #2539