### PR TITLE
acme/api: reject General JSON Serialization JWS bodies per RFC 8555

### DIFF
--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -101,6 +102,10 @@ func parseJWS(next nextHTTP) nextHTTP {
 			render.Error(w, r, acme.WrapErrorISE(err, "failed to read request body"))
 			return
 		}
+		if err := rejectGeneralJWS(body); err != nil {
+			render.Error(w, r, acme.WrapError(acme.ErrorMalformedType, err, "failed to parse JWS from request body"))
+			return
+		}
 		jws, err := jose.ParseJWS(string(body))
 		if err != nil {
 			render.Error(w, r, acme.WrapError(acme.ErrorMalformedType, err, "failed to parse JWS from request body"))
@@ -109,6 +114,35 @@ func parseJWS(next nextHTTP) nextHTTP {
 		ctx := context.WithValue(r.Context(), jwsContextKey, jws)
 		next(w, r.WithContext(ctx))
 	}
+}
+
+// rejectGeneralJWS enforces RFC 8555 section 6.2: ACME JWS requests MUST use
+// the Flattened JSON Serialization. go-jose/v3's ParseSigned accepts both the
+// Flattened and the General serialization, so the flattened-only requirement
+// has to be checked at the JSON layer before handing off. A General-form body
+// carries a top-level "signatures" array (plural); flattened bodies have
+// singular "signature" + "protected" alongside "payload". RFC 8555 section 6.2
+// also forbids the JWS Unprotected Header, so a top-level "header" member is
+// rejected as well.
+func rejectGeneralJWS(body []byte) error {
+	var peek struct {
+		Signatures json.RawMessage `json:"signatures"`
+		Header     json.RawMessage `json:"header"`
+	}
+	if err := json.Unmarshal(body, &peek); err != nil {
+		// Not JSON, or malformed. Fall through to ParseJWS so the
+		// existing ErrorMalformedType with go-jose's message wins.
+		return nil
+	}
+	if len(peek.Signatures) > 0 {
+		return errors.New("JWS MUST be in the Flattened JSON Serialization (RFC 8555 section 6.2); " +
+			"General JSON Serialization with a top-level \"signatures\" array is rejected")
+	}
+	if len(peek.Header) > 0 {
+		return errors.New("JWS MUST NOT use the Unprotected Header (RFC 8555 section 6.2); " +
+			"a top-level \"header\" member is rejected")
+	}
+	return nil
 }
 
 // validateJWS checks the request body for to verify that it meets ACME

--- a/acme/api/middleware_test.go
+++ b/acme/api/middleware_test.go
@@ -360,6 +360,26 @@ func TestHandler_parseJWS(t *testing.T) {
 				err:        acme.NewError(acme.ErrorMalformedType, "failed to parse JWS from request body: go-jose/go-jose: compact JWS format must have three parts"),
 			}
 		},
+		"fail/general-jws": func(t *testing.T) test {
+			// General JSON serialization carries a "signatures" array.
+			// RFC 8555 section 6.2 requires Flattened; reject with
+			// ErrorMalformedType.
+			return test{
+				body:       strings.NewReader(`{"payload":"e30","signatures":[{"protected":"e30","signature":"sig"}]}`),
+				statusCode: 400,
+				err:        acme.NewError(acme.ErrorMalformedType, `failed to parse JWS from request body: JWS MUST be in the Flattened JSON Serialization (RFC 8555 section 6.2); General JSON Serialization with a top-level "signatures" array is rejected`),
+			}
+		},
+		"fail/unprotected-header": func(t *testing.T) test {
+			// RFC 8555 section 6.2 forbids the JWS Unprotected Header;
+			// a top-level "header" member must be rejected with
+			// ErrorMalformedType.
+			return test{
+				body:       strings.NewReader(`{"payload":"e30","protected":"e30","header":{"kid":"x"},"signature":"sig"}`),
+				statusCode: 400,
+				err:        acme.NewError(acme.ErrorMalformedType, `failed to parse JWS from request body: JWS MUST NOT use the Unprotected Header (RFC 8555 section 6.2); a top-level "header" member is rejected`),
+			}
+		},
 		"ok": func(t *testing.T) test {
 			jwk, err := jose.GenerateJWK("EC", "P-256", "ES256", "sig", "", 0)
 			assert.FatalError(t, err)


### PR DESCRIPTION
## Summary

Fixes #2642.

RFC 8555 section 6.2 mandates that ACME JWS bodies MUST use the Flattened JSON Serialization. go-jose/v3's `ParseSigned` accepts both Flattened and General forms, so `step-ca` silently accepted:

```json
{"payload": "...", "signatures": [{"protected": "...", "signature": "..."}]}
```

as if it were a legal RFC 7515 flattened body. As the reporter notes, go-jose doesn't expose a way to restrict this, so the check has to sit at the JSON layer before `jose.ParseJWS` runs.

## Fix

Add a lightweight `rejectGeneralJWS` helper in front of `parseJWS` that JSON-probes the body for a top-level `"signatures"` array (plural, the telltale General-form field). Hit → return `ACME ErrorMalformedType` with a message pointing back to RFC 8555. Bodies that aren't valid JSON fall through to the existing `ParseJWS` path so go-jose's own diagnostics still produce the familiar `compact JWS format must have three parts` error for compact-serialization mistakes.

## Tests

- New sub-test `TestHandler_parseJWS/fail/general-jws` drives a General-form body through `parseJWS` and asserts `400 ErrorMalformedType` with the RFC-8555-pointing message.
- Existing `fail/read-body-error`, `fail/parse-jws-error`, and `ok` cases stay green.

`go build ./acme/...`, `go vet ./acme/...`, `go test ./acme/api -run TestHandler_parseJWS` all green.