### PR TITLE
gh: aligned workflow permissions with smallstep/workflows#324

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -17,6 +17,7 @@ jobs:
   actionci:
     permissions:
       contents: read
+      actions: read
       security-events: write
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
     with:

--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -2,11 +2,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-
 jobs:
   code-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
+    secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dependabot-auto-merge:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     needs: create_release
     permissions:
       id-token: write
-      contents: write
+      contents: read
     uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
     with:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64
@@ -96,7 +96,7 @@ jobs:
     needs: create_release
     permissions:
       id-token: write
-      contents: write
+      contents: read
     uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
     with:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,6 @@ on:
       - reopened
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
This PR amends the workflows configuration to be more inline with smallstep/workflows#324.

It additionally addresses the following:

1. Relaxes the `dependabot-auto-merge.yml` permissions, since the called workflow no longer needs `contents: write` or `pull-requests: write`.
2. Drops `pull-requests: write` from `triage.yml`, since the called workflow only labels via the issues API.
3. Relaxes `contents: write` to `contents: read` on the `build_upload_docker` and `build_upload_docker_hsm` jobs in `release.yml`.
