### PR TITLE
Fix bootstrap target by using canonical golangci-lint install URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ci: testcgo build
 #########################################
 
 bootstra%:
-	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin latest
+	$Q curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin latest
 	$Q go install golang.org/x/vuln/cmd/govulncheck@latest
 	$Q go install gotest.tools/gotestsum@latest
 	$Q go install github.com/goreleaser/goreleaser/v2@latest


### PR DESCRIPTION
Reproduces #2694 verbatim on Linux/amd64: `make bootstrap` fails because the `install.sh` script on golangci-lint's `master` branch carries stale SHA-256 checksums (per golangci/golangci-lint#6540, the upstream project migrated `master` to `main`).

Pointing the `bootstrap` target at https://golangci-lint.run/install.sh, the URL the upstream project now publishes as canonical, fixes the failure. After the change the install completes cleanly:

```
golangci/golangci-lint info checking GitHub for tag 'latest'
golangci/golangci-lint info found version: 2.12.2 for v2.12.2/linux/amd64
golangci/golangci-lint info installed <gopath-bin>/golangci-lint
```

The other `raw.githubusercontent.com` reference in this Makefile (`smallstep/workflows/master/.golangci.yml` on line 141) is in smallstep's own workflows repo and resolves on both `master` and `main`, so it is left out of scope here.

Credit to @Bend3r-R for the diagnosis and the original diff in #2694.

Fixes #2694