### PR TITLE
Fix `pull-requests: write` permission in triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   triage:


### PR DESCRIPTION
Similar to https://github.com/smallstep/cli/pull/1649