### PR TITLE
Fix name policy panic on empty or short domain

### DIFF
--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -55,6 +55,20 @@ func TestNamePolicyEngine_matchDomainConstraint(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "fail/empty-domain",
+			domain:     "",
+			constraint: "host.example.com",
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "fail/single-asterisk-domain",
+			domain:     "*",
+			constraint: "host.example.com",
+			want:       false,
+			wantErr:    false,
+		},
+		{
 			name:       "fail/period-domain",
 			domain:     ".host.example.com",
 			constraint: ".example.com",

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -480,13 +480,18 @@ func (e *NamePolicyEngine) matchDomainConstraint(domain, constraint string) (boo
 		return false, nil
 	}
 
+	// An empty domain never matches a constraint.
+	if domain == "" {
+		return false, nil
+	}
+
 	// Block domains that start with just a period
 	if domain[0] == '.' {
 		return false, nil
 	}
 
 	// Block wildcard domains that don't start with exactly "*." (i.e. double wildcards and such)
-	if domain[0] == '*' && domain[1] != '.' {
+	if domain[0] == '*' && (len(domain) < 2 || domain[1] != '.') {
 		return false, nil
 	}
 


### PR DESCRIPTION
Closes #2714

A SAN with an empty domain (e.g. an email like `a@`) panicked during name-policy validation with a slice index out of range. Guard the empty and single-character domain cases in `matchDomainConstraint`. The existing `matchDomainConstraint` table test gets the two cases, which panic before this change and pass after.
