### PR TITLE
fix(policy): reject email SANs with empty domain

### DIFF
--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -3399,3 +3399,14 @@ func TestNamePolicyError_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyDomainEmailPanic(t *testing.T) {
+	// Regression test: an email SAN with an empty domain (e.g. "a@") should
+	// be rejected gracefully, not cause a panic.
+	e, err := New(WithPermittedEmailAddresses("@example.com"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = e.AreSANsAllowed([]string{"a@"})
+	assert.Error(t, err, "email with empty domain should be rejected")
+}

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -455,6 +455,11 @@ func parseRFC2821Mailbox(in string) (mailbox rfc2821Mailbox, ok bool) {
 	}
 	in = in[1:]
 
+	// An empty domain after '@' is not valid.
+	if in == "" {
+		return mailbox, false
+	}
+
 	// The RFC species a format for domains, but that's known to be
 	// violated in practice so we accept that anything after an '@' is the
 	// domain part.


### PR DESCRIPTION
## Problem

An email SAN with an empty domain (e.g., `a@`) causes a panic in the name policy engine. The `parseRFC2821Mailbox` function parses the email into `{local: "a", domain: ""}`, and the empty domain is then passed to `domainToReverseLabels` which returns `([], true)`, allowing the invalid email to pass validation.

## Fix

Added an explicit check in `parseRFC2821Mailbox`: if the domain part after `@` is empty, return `false` (invalid email).

## Testing

Added `TestEmptyDomainEmailPanic` regression test that verifies emails with empty domains are rejected gracefully.

Fixes #2714