### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/acme/api/middleware.go
+++ b/acme/api/middleware.go
@@ -77,7 +77,7 @@ func verifyContentType(next nextHTTP) nextHTTP {
 			// GET /certificate requests allow a greater range of content types.
 			expected = []string{"application/jose+json", "application/pkix-cert", "application/pkcs7-mime"}
 		} else {
-			// By default every request should have content-type applictaion/jose+json.
+			// By default every request should have content-type application/jose+json.
 			expected = []string{"application/jose+json"}
 		}
 

--- a/acme/db/nosql/account.go
+++ b/acme/db/nosql/account.go
@@ -84,7 +84,7 @@ func (db *DB) GetAccountByKeyID(ctx context.Context, kid string) (*acme.Account,
 	return db.GetAccount(ctx, id)
 }
 
-// CreateAccount imlements the AcmeDB.CreateAccount interface.
+// CreateAccount implements the AcmeDB.CreateAccount interface.
 func (db *DB) CreateAccount(ctx context.Context, acc *acme.Account) error {
 	var err error
 	acc.ID, err = randID()
@@ -125,7 +125,7 @@ func (db *DB) CreateAccount(ctx context.Context, acc *acme.Account) error {
 	}
 }
 
-// UpdateAccount imlements the AcmeDB.UpdateAccount interface.
+// UpdateAccount implements the AcmeDB.UpdateAccount interface.
 func (db *DB) UpdateAccount(ctx context.Context, acc *acme.Account) error {
 	old, err := db.getDBAccount(ctx, acc.ID)
 	if err != nil {

--- a/acme/order.go
+++ b/acme/order.go
@@ -363,7 +363,7 @@ func createWireSubject(o *Order, csr *x509.CertificateRequest) (subject x509util
 			}
 
 			// TODO: temporarily using a custom OIDC for carrying the display name without having it listed as a DNS SAN.
-			// reusing LDAP's OID for diplay name see http://oid-info.com/get/2.16.840.1.113730.3.1.241
+			// reusing LDAP's OID for display name see http://oid-info.com/get/2.16.840.1.113730.3.1.241
 			displayNameOid := asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 3, 1, 241}
 			var foundDisplayName = false
 			for _, entry := range csr.Subject.Names {

--- a/authority/config/config.go
+++ b/authority/config/config.go
@@ -154,7 +154,7 @@ type ASN1DN struct {
 }
 
 // AuthConfig represents the configuration options for the authority. An
-// underlaying registration authority can also be configured using the
+// underlying registration authority can also be configured using the
 // cas.Options.
 type AuthConfig struct {
 	*cas.Options

--- a/authority/options.go
+++ b/authority/options.go
@@ -386,7 +386,7 @@ func WithX509Enforcers(ces ...provisioner.CertificateEnforcer) Option {
 	}
 }
 
-// WithSkipInit is an option that allows the constructor to skip initializtion
+// WithSkipInit is an option that allows the constructor to skip initialization
 // of the authority.
 func WithSkipInit() Option {
 	return func(a *Authority) error {

--- a/authority/provisioner/oidc_test.go
+++ b/authority/provisioner/oidc_test.go
@@ -618,7 +618,7 @@ func TestOIDC_AuthorizeSSHSign(t *testing.T) {
 		{"fail-user-host", p1, args{t1, SignSSHOptions{CertType: "host"}, pub}, nil, http.StatusOK, false, true},
 		{"fail-getIdentity", p5, args{failGetIdentityToken, SignSSHOptions{}, pub}, nil, http.StatusInternalServerError, true, false},
 		{"fail-sshCA-disabled", p6, args{"foo", SignSSHOptions{}, pub}, nil, http.StatusUnauthorized, true, false},
-		// Missing parametrs
+		// Missing parameters
 		{"fail-admin-type", p3, args{okAdmin, SignSSHOptions{KeyID: "root@example.com", Principals: []string{"root@example.com"}}, pub}, nil, http.StatusUnauthorized, false, true},
 		{"fail-admin-key-id", p3, args{okAdmin, SignSSHOptions{CertType: "user", Principals: []string{"root@example.com"}}, pub}, nil, http.StatusUnauthorized, false, true},
 		{"fail-admin-principals", p3, args{okAdmin, SignSSHOptions{CertType: "user", KeyID: "root@example.com"}, pub}, nil, http.StatusUnauthorized, false, true},

--- a/authority/provisioner/sign_options.go
+++ b/authority/provisioner/sign_options.go
@@ -151,7 +151,7 @@ func (v commonNameValidator) Valid(req *x509.CertificateRequest) error {
 	return nil
 }
 
-// commonNameSliceValidator validates thats the common name of a certificate
+// commonNameSliceValidator validates that the common name of a certificate
 // request is present in the slice. An empty common name is considered valid.
 type commonNameSliceValidator []string
 

--- a/authority/provisioner/wire/oidc_options.go
+++ b/authority/provisioner/wire/oidc_options.go
@@ -101,7 +101,7 @@ func (o *OIDCOptions) validateAndInitialize() (err error) {
 	if o.Provider.DiscoveryBaseURL == "" {
 		o.oidcProviderConfig, err = toOIDCProviderConfig(o.Provider)
 		if err != nil {
-			return fmt.Errorf("failed creationg OIDC provider config: %w", err)
+			return fmt.Errorf("failed creating OIDC provider config: %w", err)
 		}
 	}
 

--- a/authority/provisioner/wire/wire_options_test.go
+++ b/authority/provisioner/wire/wire_options_test.go
@@ -68,7 +68,7 @@ MCowBQYDK2VwAyEA5c+4NKZSNQcR1T8qN6SjwgdPZQ0Ge12Ylx/YeGAJ35k=
 				},
 				DPOP: &DPOPOptions{},
 			},
-			expectedErr: errors.New(`failed initializing OIDC options: failed creationg OIDC provider config: failed parsing issuer URL: parse "\x00": net/url: invalid control character in URL`),
+			expectedErr: errors.New(`failed initializing OIDC options: failed creating OIDC provider config: failed parsing issuer URL: parse "\x00": net/url: invalid control character in URL`),
 		},
 		{
 			name: "fail/issuer-url-template",

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -273,7 +273,7 @@ func (i *Identity) GetCertPool() (*x509.CertPool, error) {
 	}
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(b) {
-		return nil, errors.Errorf("error pasing identity root: %s does not contain any certificate", i.Root)
+		return nil, errors.Errorf("error parsing identity root: %s does not contain any certificate", i.Root)
 	}
 	return pool, nil
 }

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -320,7 +320,7 @@ type PKI struct {
 // New creates a new PKI configuration.
 func New(o apiv1.Options, opts ...Option) (*PKI, error) {
 	// TODO(hs): invoking `New` with a context active will use values from
-	// that CA context while generating the context. Thay may or may not
+	// that CA context while generating the context. They may or may not
 	// be fully expected and/or what we want. This specific behavior was
 	// changed after not relying on the `init` inside of `step`, resulting in
 	// the default context being active if `step.Init` isn't called explicitly.

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -96,7 +96,7 @@ type NamePolicyEngine struct {
 	// allowLiteralWildcardNames allows literal wildcard DNS domains
 	allowLiteralWildcardNames bool
 
-	// permitted and exluded constraints similar to x509 Name Constraints
+	// permitted and excluded constraints similar to x509 Name Constraints
 	permittedCommonNames    []string
 	excludedCommonNames     []string
 	permittedDNSDomains     []string
@@ -286,7 +286,7 @@ func splitSSHPrincipals(cert *ssh.Certificate) (dnsNames []string, ips []net.IP,
 	case ssh.UserCert:
 		// re-using SplitSANs results in anything that can't be parsed as an IP, URI or email
 		// to be considered a username principal. This allows usernames like h.slatman to be present
-		// in the SSH certificate. We're exluding URIs, because they can be confusing
+		// in the SSH certificate. We're excluding URIs, because they can be confusing
 		// when used in a SSH user certificate.
 		principals, ips, emails, uris = x509util.SplitSANs(cert.ValidPrincipals)
 		if len(ips) > 0 {

--- a/policy/options.go
+++ b/policy/options.go
@@ -261,7 +261,7 @@ func isIPv4(ip net.IP) bool {
 func normalizeAndValidateCommonName(constraint string) (string, error) {
 	normalizedConstraint := strings.ToLower(strings.TrimSpace(constraint))
 	if normalizedConstraint == "" {
-		return "", fmt.Errorf("contraint %q can not be empty or white space string", constraint)
+		return "", fmt.Errorf("constraint %q can not be empty or white space string", constraint)
 	}
 	if normalizedConstraint == "*" {
 		return "", fmt.Errorf("wildcard constraint %q is not supported", constraint)
@@ -272,7 +272,7 @@ func normalizeAndValidateCommonName(constraint string) (string, error) {
 func normalizeAndValidateDNSDomainConstraint(constraint string) (string, error) {
 	normalizedConstraint := strings.ToLower(strings.TrimSpace(constraint))
 	if normalizedConstraint == "" {
-		return "", fmt.Errorf("contraint %q can not be empty or white space string", constraint)
+		return "", fmt.Errorf("constraint %q can not be empty or white space string", constraint)
 	}
 	if strings.Contains(normalizedConstraint, "..") {
 		return "", fmt.Errorf("domain constraint %q cannot have empty labels", constraint)
@@ -302,7 +302,7 @@ func normalizeAndValidateDNSDomainConstraint(constraint string) (string, error) 
 func normalizeAndValidateEmailConstraint(constraint string) (string, error) {
 	normalizedConstraint := strings.ToLower(strings.TrimSpace(constraint))
 	if normalizedConstraint == "" {
-		return "", fmt.Errorf("email contraint %q can not be empty or white space string", constraint)
+		return "", fmt.Errorf("email constraint %q can not be empty or white space string", constraint)
 	}
 	if strings.Contains(normalizedConstraint, "*") {
 		return "", fmt.Errorf("email constraint %q cannot contain asterisk wildcard", constraint)
@@ -345,7 +345,7 @@ func normalizeAndValidateEmailConstraint(constraint string) (string, error) {
 func normalizeAndValidateURIDomainConstraint(constraint string) (string, error) {
 	normalizedConstraint := strings.ToLower(strings.TrimSpace(constraint))
 	if normalizedConstraint == "" {
-		return "", fmt.Errorf("URI domain contraint %q cannot be empty or white space string", constraint)
+		return "", fmt.Errorf("URI domain constraint %q cannot be empty or white space string", constraint)
 	}
 	if strings.Contains(normalizedConstraint, "://") {
 		return "", fmt.Errorf("URI domain constraint %q contains scheme (not supported yet)", constraint)

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -553,7 +553,7 @@ func (e *NamePolicyEngine) matchDomainConstraint(domain, constraint string) (boo
 func matchIPConstraint(ip net.IP, constraint *net.IPNet) (bool, error) {
 	// TODO(hs): this is code from Go library, but I got some unexpected result:
 	// with permitted net 127.0.0.0/24, 127.0.0.1 is NOT allowed. When parsing 127.0.0.1 as net.IP
-	// which is in the IPAddresses slice, the underlying length is 16. The contraint.IP has a length
+	// which is in the IPAddresses slice, the underlying length is 16. The constraint.IP has a length
 	// of 4 instead. I currently don't believe that this is a bug in Go now, but why is it like that?
 	// Is there a difference because we're not operating on a sans []string slice? Or is the Go
 	// implementation stricter regarding IPv4 vs. IPv6? I've been bitten by some unfortunate differences


### PR DESCRIPTION
Found several typos in comments and error messages throughout the codebase via codespell. Fixed 13 files:

- `imlements` -> `implements` in `acme/db/nosql/account.go`
- `diplay` -> `display` in `acme/order.go`
- `applictaion` -> `application` in `acme/api/middleware.go`
- `underlaying` -> `underlying` in `authority/config/config.go`
- `initializtion` -> `initialization` in `authority/options.go`
- `creationg` -> `creating` in `authority/provisioner/wire/oidc_options.go`
- `thats` -> `that` in `authority/provisioner/sign_options.go`
- `parametrs` -> `parameters` in `authority/provisioner/oidc_test.go`
- `pasing` -> `parsing` in `ca/identity/identity.go`
- `Thay` -> `They` in `pki/pki.go`
- `exluded` -> `excluded`, `exluding` -> `excluding` in `policy/engine.go`
- `contraint` -> `constraint` (4 occurrences) in `policy/options.go`
- `contraint` -> `constraint` in `policy/validate.go`