### PR TITLE
Retry OIDC provisioner initialization instead of disabling it

### DIFF
--- a/authority/authority.go
+++ b/authority/authority.go
@@ -273,9 +273,17 @@ func (a *Authority) ReloadAdminResources(ctx context.Context) error {
 	provClxn := provisioner.NewCollection(provisionerConfig.Audiences)
 	for _, p := range provList {
 		if err := p.Init(provisionerConfig); err != nil {
-			log.Printf("failed to initialize %s provisioner %q: %v\n", p.GetType(), p.GetName(), err)
-			p = provisioner.Uninitialized{
-				Interface: p, Reason: err,
+			// Provisioners that failed for a temporary reason, e.g. an OIDC
+			// provisioner that cannot reach its identity provider, stay enabled
+			// and initialize themselves when they are used.
+			if errors.Is(err, provisioner.ErrRetryInit) {
+				log.Printf("failed to initialize %s provisioner %q, it will be retried when the provisioner is used: %v\n",
+					p.GetType(), p.GetName(), err)
+			} else {
+				log.Printf("failed to initialize %s provisioner %q: %v\n", p.GetType(), p.GetName(), err)
+				p = provisioner.Uninitialized{
+					Interface: p, Reason: err,
+				}
 			}
 		}
 		if err := provClxn.Store(p); err != nil {

--- a/authority/authority_test.go
+++ b/authority/authority_test.go
@@ -200,6 +200,48 @@ func TestAuthorityNew(t *testing.T) {
 	}
 }
 
+func TestAuthorityNew_retryInit(t *testing.T) {
+	c := &Config{
+		Address:          "127.0.0.1:443",
+		Root:             []string{"testdata/certs/root_ca.crt"},
+		IntermediateCert: "testdata/certs/intermediate_ca.crt",
+		IntermediateKey:  "testdata/secrets/intermediate_ca_key",
+		DNSNames:         []string{"example.com"},
+		Password:         "pass",
+		AuthorityConfig: &AuthConfig{
+			Provisioners: provisioner.List{
+				// Nothing listens on port 1, so the identity provider cannot be
+				// reached and the initialization is retried.
+				&provisioner.OIDC{
+					Name:                  "oidc",
+					Type:                  "OIDC",
+					ClientID:              "client-id",
+					ConfigurationEndpoint: "http://127.0.0.1:1/.well-known/openid-configuration",
+				},
+				// A provisioner without a client ID can never be initialized.
+				&provisioner.OIDC{
+					Name:                  "uninitialized",
+					Type:                  "OIDC",
+					ConfigurationEndpoint: "http://127.0.0.1:1/.well-known/openid-configuration",
+				},
+			},
+		},
+	}
+
+	auth, err := New(c)
+	assert.FatalError(t, err)
+
+	p, ok := auth.provisioners.LoadByName("oidc")
+	assert.True(t, ok)
+	_, isUninitialized := p.(provisioner.Uninitialized)
+	assert.False(t, isUninitialized)
+
+	p, ok = auth.provisioners.LoadByName("uninitialized")
+	assert.True(t, ok)
+	_, isUninitialized = p.(provisioner.Uninitialized)
+	assert.True(t, isUninitialized)
+}
+
 func TestAuthorityNew_bundles(t *testing.T) {
 	ca0, err := minica.New()
 	if err != nil {

--- a/authority/provisioner/oidc.go
+++ b/authority/provisioner/oidc.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,6 +20,17 @@ import (
 	"go.step.sm/crypto/x509util"
 
 	"github.com/smallstep/certificates/errs"
+)
+
+const (
+	// oidcInitRetryInterval is the time to wait before the second attempt to
+	// get the OpenID configuration of a provisioner that failed to initialize.
+	// It doubles on every failure up to oidcMaxInitRetryInterval.
+	oidcInitRetryInterval = 5 * time.Second
+
+	// oidcMaxInitRetryInterval is the maximum time between two attempts to get
+	// the OpenID configuration of a provisioner that failed to initialize.
+	oidcMaxInitRetryInterval = 5 * time.Minute
 )
 
 // openIDConfiguration contains the necessary properties in the
@@ -95,9 +107,17 @@ type OIDC struct {
 	Options               *Options `json:"options,omitempty"`
 	Scopes                []string `json:"scopes,omitempty"`
 	AuthParams            []string `json:"authParams,omitempty"`
-	configuration         openIDConfiguration
-	keyStore              *keyStore
+	wellKnownEndpoint     string
 	ctl                   *Controller
+
+	// initMutex guards the fields below it, which are only read after a
+	// successful ensureInitialized.
+	initMutex         sync.Mutex
+	initError         error
+	initRetryAfter    time.Time
+	initRetryInterval time.Duration
+	configuration     openIDConfiguration
+	keyStore          *keyStore
 }
 
 func sanitizeEmail(email string) string {
@@ -156,7 +176,9 @@ func (o *OIDC) GetEncryptedKey() (kid, key string, ok bool) {
 	return "", "", false
 }
 
-// Init validates and initializes the OIDC provider.
+// Init validates and initializes the OIDC provider. If the identity provider
+// cannot be reached, the returned error matches ErrRetryInit and the
+// provisioner initializes itself the next time that it is used.
 func (o *OIDC) Init(config Config) (err error) {
 	switch {
 	case o.Type == "":
@@ -184,6 +206,7 @@ func (o *OIDC) Init(config Config) (err error) {
 	if !strings.Contains(u.Path, "/.well-known/openid-configuration") {
 		u.Path = path.Join(u.Path, "/.well-known/openid-configuration")
 	}
+	o.wellKnownEndpoint = u.String()
 
 	// Initialize the common provisioner controller
 	o.ctl, err = NewController(o, o.Claims, config, o.Options)
@@ -191,23 +214,68 @@ func (o *OIDC) Init(config Config) (err error) {
 		return err
 	}
 
-	// Decode and validate openid-configuration
+	// Get the openid-configuration and the JWK key set. Not being able to reach
+	// the identity provider is usually temporary, e.g. when step-ca starts
+	// before the network is up, so the provisioner retries when it is used.
+	o.initMutex.Lock()
+	defer o.initMutex.Unlock()
+	if o.initError = o.initialize(); o.initError != nil {
+		o.initRetryInterval = oidcInitRetryInterval
+		return retryInit(o.initError)
+	}
+	return nil
+}
+
+// initialize gets and validates the openid-configuration and the JWK key set of
+// the identity provider. Callers must hold o.initMutex.
+func (o *OIDC) initialize() error {
 	httpClient := o.ctl.GetHTTPClient()
-	if err := getAndDecode(httpClient, u.String(), &o.configuration); err != nil {
+
+	// Decode and validate openid-configuration
+	var configuration openIDConfiguration
+	if err := getAndDecode(httpClient, o.wellKnownEndpoint, &configuration); err != nil {
 		return err
 	}
-	if err := o.configuration.Validate(); err != nil {
+	if err := configuration.Validate(); err != nil {
 		return errors.Wrapf(err, "error parsing %s", o.ConfigurationEndpoint)
 	}
 
 	// Replace {tenantid} with the configured one
 	if o.TenantID != "" {
-		o.configuration.Issuer = strings.ReplaceAll(o.configuration.Issuer, "{tenantid}", o.TenantID)
+		configuration.Issuer = strings.ReplaceAll(configuration.Issuer, "{tenantid}", o.TenantID)
 	}
 
 	// Get JWK key set
-	o.keyStore, err = newKeyStore(httpClient, o.configuration.JWKSetURI)
-	return
+	keyStore, err := newKeyStore(httpClient, configuration.JWKSetURI)
+	if err != nil {
+		return err
+	}
+
+	o.configuration = configuration
+	o.keyStore = keyStore
+	return nil
+}
+
+// ensureInitialized initializes the provisioner if a previous attempt failed,
+// e.g. because the identity provider was down when step-ca started. Attempts
+// are spaced using an exponential backoff, so that requests are not blocked on
+// an identity provider that is still unavailable.
+func (o *OIDC) ensureInitialized() error {
+	o.initMutex.Lock()
+	defer o.initMutex.Unlock()
+
+	if o.initError == nil {
+		return nil
+	}
+	now := time.Now()
+	if now.Before(o.initRetryAfter) {
+		return o.initError
+	}
+	if o.initError = o.initialize(); o.initError != nil {
+		o.initRetryAfter = now.Add(o.initRetryInterval)
+		o.initRetryInterval = min(2*o.initRetryInterval, oidcMaxInitRetryInterval)
+	}
+	return o.initError
 }
 
 // ValidatePayload validates the given token payload.
@@ -264,6 +332,11 @@ func (o *OIDC) ValidatePayload(p openIDPayload) error {
 // authorizeToken applies the most common provisioner authorization claims,
 // leaving the rest to context specific methods.
 func (o *OIDC) authorizeToken(token string) (*openIDPayload, error) {
+	if err := o.ensureInitialized(); err != nil {
+		return nil, errs.Wrapf(http.StatusServiceUnavailable, err,
+			"oidc.AuthorizeToken; oidc provisioner '%s' is not initialized", o.GetName())
+	}
+
 	jwt, err := jose.ParseSigned(token)
 	if err != nil {
 		return nil, errs.Wrap(http.StatusUnauthorized, err,

--- a/authority/provisioner/oidc_test.go
+++ b/authority/provisioner/oidc_test.go
@@ -9,8 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -154,6 +157,140 @@ func TestOIDC_Init(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOIDC_Init_unreachableProvider(t *testing.T) {
+	var reachable atomic.Bool
+
+	srv := httptest.NewUnstartedServer(nil)
+	handler := generateJWKServerHandler(2, srv)
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drop the connection to simulate an identity provider that cannot be
+		// reached, e.g. one behind a network that is not up yet.
+		if !reachable.Load() {
+			if conn, _, err := w.(http.Hijacker).Hijack(); err == nil {
+				conn.Close()
+			}
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+	srv.Start()
+	defer srv.Close()
+
+	p := &OIDC{
+		Type:                  "oidc",
+		Name:                  "name",
+		ClientID:              "client-id",
+		ConfigurationEndpoint: srv.URL + "/.well-known/openid-configuration",
+	}
+
+	// The provisioner cannot be initialized, but the failure is temporary, so
+	// it is not disabled.
+	err := p.Init(Config{Claims: globalProvisionerClaims, HTTPClient: srv.Client()})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRetryInit)
+
+	// Tokens cannot be authorized while the identity provider is down. This
+	// also consumes the first retry.
+	_, err = p.authorizeToken("token")
+	require.ErrorContains(t, err, "oidc provisioner 'name' is not initialized")
+	assert.Equals(t, 2*oidcInitRetryInterval, p.initRetryInterval)
+
+	// The next retries are delayed by the backoff.
+	reachable.Store(true)
+	require.Error(t, p.ensureInitialized())
+
+	// The provisioner initializes itself once the backoff expires.
+	p.initRetryAfter = time.Now()
+	require.NoError(t, p.ensureInitialized())
+	assert.Len(t, 2, p.keyStore.keySet.Keys)
+	assert.Equals(t, openIDConfiguration{
+		Issuer:    "the-issuer",
+		JWKSetURI: srv.URL + "/jwks_uri",
+	}, p.configuration)
+
+	// An initialized provisioner does not contact the identity provider again.
+	reachable.Store(false)
+	require.NoError(t, p.ensureInitialized())
+}
+
+func TestOIDC_ensureInitialized_backoff(t *testing.T) {
+	p := &OIDC{
+		Type:     "oidc",
+		Name:     "name",
+		ClientID: "client-id",
+		// Nothing listens on port 1, so every attempt fails.
+		ConfigurationEndpoint: "http://127.0.0.1:1/.well-known/openid-configuration",
+	}
+	require.ErrorIs(t, p.Init(Config{Claims: globalProvisionerClaims}), ErrRetryInit)
+
+	want := oidcInitRetryInterval
+	for range 10 {
+		require.Error(t, p.ensureInitialized())
+		want = min(2*want, oidcMaxInitRetryInterval)
+		assert.Equals(t, want, p.initRetryInterval)
+		p.initRetryAfter = time.Now()
+	}
+	assert.Equals(t, oidcMaxInitRetryInterval, p.initRetryInterval)
+}
+
+func TestOIDC_authorizeToken_concurrentInit(t *testing.T) {
+	reachable := atomic.Bool{}
+	reachable.Store(true)
+
+	srv := httptest.NewUnstartedServer(nil)
+	handler := generateJWKServerHandler(1, srv)
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !reachable.Load() {
+			if conn, _, err := w.(http.Hijacker).Hijack(); err == nil {
+				conn.Close()
+			}
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+	srv.Start()
+	defer srv.Close()
+
+	var keys jose.JSONWebKeySet
+	assert.FatalError(t, getAndDecode(srv.Client(), srv.URL+"/private", &keys))
+
+	p := &OIDC{
+		Type:                  "oidc",
+		Name:                  "name",
+		ClientID:              "client-id",
+		ConfigurationEndpoint: srv.URL + "/.well-known/openid-configuration",
+	}
+	token, err := generateSimpleToken("the-issuer", p.ClientID, &keys.Keys[0])
+	assert.FatalError(t, err)
+
+	// The identity provider is down when the provisioner is initialized.
+	reachable.Store(false)
+	require.ErrorIs(t, p.Init(Config{Claims: globalProvisionerClaims, HTTPClient: srv.Client()}), ErrRetryInit)
+
+	// Authorize tokens while the identity provider comes back, to check that
+	// the initialization does not race with the requests using its results.
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				// Skip the backoff, so that every request retries.
+				p.initMutex.Lock()
+				p.initRetryAfter = time.Time{}
+				p.initMutex.Unlock()
+				_, _ = p.authorizeToken(token)
+			}
+		}()
+	}
+	time.Sleep(10 * time.Millisecond)
+	reachable.Store(true)
+	wg.Wait()
+
+	_, err = p.authorizeToken(token)
+	require.NoError(t, err)
 }
 
 func TestOIDC_authorizeToken(t *testing.T) {

--- a/authority/provisioner/provisioner.go
+++ b/authority/provisioner/provisioner.go
@@ -85,6 +85,32 @@ var ErrTokenFlowNotSupported = stderrors.New("token flow is not supported")
 // ErrNotImplemented is an error returned when one method is not implemented.
 var ErrNotImplemented = stderrors.New("not implemented")
 
+// ErrRetryInit is an error that the errors returned by Init match when the
+// initialization failed for a temporary reason, e.g. an OIDC provisioner that
+// cannot reach its identity provider. Provisioners failing with this error
+// initialize themselves when they are used, so they are not disabled.
+var ErrRetryInit = stderrors.New("retry initialization")
+
+// retryInitError wraps an initialization error to mark it as temporary. It
+// keeps the message of the wrapped error and matches ErrRetryInit.
+type retryInitError struct {
+	err error
+}
+
+func (e *retryInitError) Error() string { return e.err.Error() }
+
+func (e *retryInitError) Unwrap() error { return e.err }
+
+func (*retryInitError) Is(target error) bool { return target == ErrRetryInit }
+
+// retryInit marks an initialization error as temporary.
+func retryInit(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &retryInitError{err: err}
+}
+
 // Audiences stores all supported audiences by request type.
 type Audiences struct {
 	Sign      []string


### PR DESCRIPTION
An OIDC provisioner gets the openid-configuration and the JWK key set of the identity provider on Init. When the provider could not be reached, for example because step-ca started before the network was up, the provisioner was replaced by an Uninitialized one and never recovered: OIDC authentication kept failing until step-ca was restarted.

Init now marks a failure to reach the identity provider as temporary, and the provisioner gets the configuration again when it is used, using an exponential backoff between attempts. Any other initialization error, e.g. an invalid configuration, still disables the provisioner.

Fixes #2724

#### Name of feature:

Automatic recovery of OIDC provisioners after a temporary initialization failure.

#### Pain or issue this feature alleviates:

`step-ca` reaches its identity provider once, at startup. On a machine where `step-ca` starts before the network is usable — a common systemd ordering problem on homelab and cloud hosts — that single attempt fails and the provisioner is permanently replaced by an `Uninitialized` one. The process keeps running and looks healthy from the outside, `/health` is fine, systemd reports the unit as active, but every OIDC authentication returns `provisioner "…" is disabled due to an initialization error` forever. The only fix is a manual restart, and nothing in the running service indicates that a restart is what's needed.

After this change the provisioner retries on its own and the first login after connectivity returns succeeds.

#### Why is this important to the project (if not answered above):

It removes a class of silent, restart-only failures from the operator's plate. There is no configuration to add and no new failure mode: an unreachable provider is now a self-healing condition rather than a permanent one, while genuinely broken configuration still fails loudly at startup exactly as before.

#### Is there documentation on how to use this feature? If so, where?

None needed — no configuration surface changes and nothing for a user to enable. Three observable behaviours are worth knowing:

- The startup log line for an unreachable provider now reads `failed to initialize OIDC provisioner "name", it will be retried when the provisioner is used: …` instead of `failed to initialize OIDC provisioner "name": …`.
- While uninitialized, requests get `503` with `oidc provisioner 'name' is not initialized`, instead of `401 provisioner "name" is disabled due to an initialization error`.
- Backoff is `5s`, doubling to a `5m` ceiling (`oidcInitRetryInterval` / `oidcMaxInitRetryInterval` in `authority/provisioner/oidc.go`). `Init` deliberately leaves the deadline unset, so the very first request after startup retries immediately — a brief boot-time blip recovers on the first login attempt rather than after a delay.

Happy to add a note to the docs site if maintainers want the changed log line and status code written down.

#### In what environments or workflows is this feature supported?

- Any `step-ca` with one or more OIDC provisioners, from `ca.json` or from the admin database / `linkedca`.
- All OIDC token paths, since the retry hangs off `authorizeToken`: x509 sign, SSH sign, revoke and SSH revoke.
- Recovery is driven by incoming requests, so it works the same under systemd, Docker and Kubernetes with no goroutine or lifecycle hook to manage.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

- **OIDC only.** It is the only provisioner type that performs network I/O in `Init`. The `ErrRetryInit` contract is general, so another provisioner could opt in later, but none does today.
- **Permanent errors still disable the provisioner.** An empty `clientID`, an unparseable endpoint, bad claims — all still produce `Uninitialized`, unchanged.
- **Admin API create/update is unchanged.** `StoreProvisioner` and `UpdateProvisioner` still reject a provisioner whose endpoint is unreachable, so an admin gets immediate feedback rather than a silently deferred failure.
- **Retries are request-driven, not background.** A provisioner nobody uses never retries; the first request after the backoff expires pays one connect timeout.
- **No strict startup mode.** Points 2 and 3 of the issue — fail the service if a provisioner cannot initialize, and surface that to systemd — are not implemented. They were workarounds for the missing recovery path, and a strict mode is a new global config surface deserving its own discussion. Glad to follow up if it is still wanted.
- **Loss of `Uninitialized` state for this case.** An unreachable OIDC provider no longer shows `state: Uninitialized` in the admin API, because the provisioner stays enabled. The condition is still visible in the startup log and in the `503` on every request.

#### Supporting links/other PRs/issues:

- Fixes #2724

**Notes for review**

- Adds one exported symbol, `provisioner.ErrRetryInit`, alongside the existing `ErrAllowTokenReuse` / `ErrNotImplemented` sentinels. `Init` still returns an error on an unreachable provider, so callers that only check `err != nil` behave as before; `authority.ReloadAdminResources` uses `errors.Is` to decide whether to disable.
- `configuration` and `keyStore` moved under an `initMutex`, written only while holding it and read only after a successful `ensureInitialized`, which also serializes concurrent authorization attempts during an outage instead of letting them stampede the provider.
- Tests: unreachable-provider recovery, backoff saturation, a concurrent-initialization test under `-race`, and an authority-level test that an unreachable provider stays enabled while a permanent error still disables. Verified with the full suite, `go vet`, `gofmt`, and `golangci-lint` using the shared smallstep config, plus an end-to-end run of the built binary against a mock provider started after the CA, with a control run on `master` confirming it never recovers.



This code is AI-generated. While I kind of understand the codebase (a little), I'm not a Go developer but I tested it.
