### PR TITLE
Remove deprecated tls.Config and net.Dialer properties

### DIFF
--- a/ca/client.go
+++ b/ca/client.go
@@ -431,9 +431,8 @@ func getTransportFromFile(filename string) (http.RoundTripper, error) {
 		return nil, errors.Errorf("error parsing %s: no certificates found", filename)
 	}
 	return getDefaultTransport(&tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		RootCAs:                  pool,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
 	}), nil
 }
 
@@ -450,9 +449,8 @@ func getTransportFromSHA256(endpoint, sum string) (http.RoundTripper, error) {
 	pool := x509.NewCertPool()
 	pool.AddCert(root.RootPEM.Certificate)
 	return getDefaultTransport(&tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		RootCAs:                  pool,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
 	}), nil
 }
 
@@ -462,9 +460,8 @@ func getTransportFromCABundle(bundle []byte) (http.RoundTripper, error) {
 		return nil, errors.New("error parsing ca bundle: no certificates found")
 	}
 	return getDefaultTransport(&tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		RootCAs:                  pool,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
 	}), nil
 }
 

--- a/ca/identity/identity.go
+++ b/ca/identity/identity.go
@@ -298,10 +298,9 @@ func (i *Identity) Renew(client Renewer) error {
 
 		tr := httptransport.New()
 		tr.TLSClientConfig = &tls.Config{
-			Certificates:             []tls.Certificate{cert},
-			RootCAs:                  client.GetRootCAs(),
-			MinVersion:               tls.VersionTLS12,
-			PreferServerCipherSuites: true,
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      client.GetRootCAs(),
+			MinVersion:   tls.VersionTLS12,
 		}
 
 		sign, err := client.Renew(tr)

--- a/examples/basic-client/client.go
+++ b/examples/basic-client/client.go
@@ -117,8 +117,7 @@ func main() {
 			// Options set in http.DefaultTransport
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				DualStack: true,
+				Timeout: 30 * time.Second,
 			}).DialContext,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
Remove the deprecated PreferServerCipherSuites and DualStack properties to fix linter errors. They do not have any effect on newer versions of Go.