### PR TITLE
Add legacy SCEP compatibility options

### DIFF
--- a/authority/provisioner/scep.go
+++ b/authority/provisioner/scep.go
@@ -43,6 +43,14 @@ type SCEP struct {
 	// MinimumPublicKeyLength is the minimum length for public keys in CSRs
 	MinimumPublicKeyLength int `json:"minimumPublicKeyLength,omitempty"`
 
+	// AllowUnsortedAuthenticatedAttributes permits verification of PKCS#7 messages
+	// from legacy SCEP clients that sign authenticated attributes without DER sorting.
+	AllowUnsortedAuthenticatedAttributes bool `json:"allowUnsortedAuthenticatedAttributes,omitempty"`
+
+	// LegacyRSADigestEncryptionAlgorithm makes SCEP responses use rsaEncryption as the
+	// SignerInfo digestEncryptionAlgorithm for compatibility with legacy SCEP clients.
+	LegacyRSADigestEncryptionAlgorithm bool `json:"legacyRSADigestEncryptionAlgorithm,omitempty"`
+
 	// TODO(hs): also support a separate signer configuration?
 	DecrypterCertificate []byte `json:"decrypterCertificate,omitempty"`
 	DecrypterKeyPEM      []byte `json:"decrypterKeyPEM,omitempty"`
@@ -445,6 +453,18 @@ func (s *SCEP) ShouldIncludeRootInChain() bool {
 // don't pick the right recipient.
 func (s *SCEP) ShouldIncludeIntermediateInChain() bool {
 	return !s.ExcludeIntermediate
+}
+
+// ShouldAllowUnsortedAuthenticatedAttributes indicates whether verification may
+// fall back to the authenticated attribute order used by legacy SCEP clients.
+func (s *SCEP) ShouldAllowUnsortedAuthenticatedAttributes() bool {
+	return s.AllowUnsortedAuthenticatedAttributes
+}
+
+// ShouldUseLegacyRSADigestEncryptionAlgorithm indicates whether SCEP responses
+// should use rsaEncryption as the SignerInfo digestEncryptionAlgorithm.
+func (s *SCEP) ShouldUseLegacyRSADigestEncryptionAlgorithm() bool {
+	return s.LegacyRSADigestEncryptionAlgorithm
 }
 
 // GetContentEncryptionAlgorithm returns the numeric identifier

--- a/scep/api/api.go
+++ b/scep/api/api.go
@@ -345,8 +345,10 @@ func GetCACaps(ctx context.Context) (Response, error) {
 
 // PKIOperation performs PKI operations and returns a SCEP response
 func PKIOperation(ctx context.Context, req request) (Response, error) {
+	auth := scep.MustFromContext(ctx)
+
 	// parse the message using smallscep implementation
-	microMsg, err := smallscep.ParsePKIMessage(req.Message)
+	microMsg, err := smallscep.ParsePKIMessage(req.Message, smallscep.WithUnsortedAuthenticatedAttributes(auth.ShouldAllowUnsortedAuthenticatedAttributes(ctx)))
 	if err != nil {
 		// return the error, because we can't use the msg for creating a CertRep
 		return Response{}, fmt.Errorf("failed parsing SCEP request: %w", err)
@@ -369,7 +371,6 @@ func PKIOperation(ctx context.Context, req request) (Response, error) {
 		P7:            p7,
 	}
 
-	auth := scep.MustFromContext(ctx)
 	if err := auth.DecryptPKIEnvelope(ctx, msg); err != nil {
 		return Response{}, err
 	}

--- a/scep/authority.go
+++ b/scep/authority.go
@@ -372,6 +372,10 @@ func (a *Authority) SignCSR(ctx context.Context, csr *x509.CertificateRequest, m
 		return nil, fmt.Errorf("failed selecting signer: %w", err)
 	}
 
+	if p.ShouldUseLegacyRSADigestEncryptionAlgorithm() {
+		signedData.SetEncryptionAlgorithm(pkcs7.OIDEncryptionAlgorithmRSA)
+	}
+
 	// sign the attributes
 	if err := signedData.AddSigner(signerCert, signer, config); err != nil {
 		return nil, err
@@ -424,6 +428,8 @@ func (a *Authority) encrypt(content []byte, recipients []*x509.Certificate, algo
 
 // CreateFailureResponse creates an appropriately signed reply for PKI operations
 func (a *Authority) CreateFailureResponse(ctx context.Context, _ *x509.CertificateRequest, msg *PKIMessage, info FailInfoName, infoText string) (*PKIMessage, error) {
+	p := provisionerFromContext(ctx)
+
 	config := pkcs7.SignerInfoConfig{
 		ExtraSignedAttributes: []pkcs7.Attribute{
 			{
@@ -465,6 +471,10 @@ func (a *Authority) CreateFailureResponse(ctx context.Context, _ *x509.Certifica
 	signerCert, signer, err := a.selectSigner(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed selecting signer: %w", err)
+	}
+
+	if p.ShouldUseLegacyRSADigestEncryptionAlgorithm() {
+		signedData.SetEncryptionAlgorithm(pkcs7.OIDEncryptionAlgorithmRSA)
 	}
 
 	// sign the attributes
@@ -510,6 +520,13 @@ func (a *Authority) GetCACaps(ctx context.Context) []string {
 	// not be reported in cacaps operation.
 
 	return caps
+}
+
+// ShouldAllowUnsortedAuthenticatedAttributes indicates whether verification may
+// accept authenticated attributes in their encoded order for the current provisioner.
+func (a *Authority) ShouldAllowUnsortedAuthenticatedAttributes(ctx context.Context) bool {
+	p := provisionerFromContext(ctx)
+	return p.ShouldAllowUnsortedAuthenticatedAttributes()
 }
 
 func (a *Authority) ValidateChallenge(ctx context.Context, csr *x509.CertificateRequest, challenge, transactionID string) ([]provisioner.SignCSROption, error) {

--- a/scep/provisioner.go
+++ b/scep/provisioner.go
@@ -17,6 +17,8 @@ type Provisioner interface {
 	GetCapabilities() []string
 	ShouldIncludeRootInChain() bool
 	ShouldIncludeIntermediateInChain() bool
+	ShouldAllowUnsortedAuthenticatedAttributes() bool
+	ShouldUseLegacyRSADigestEncryptionAlgorithm() bool
 	GetDecrypter() (*x509.Certificate, crypto.Decrypter)
 	GetSigner() (*x509.Certificate, crypto.Signer)
 	GetContentEncryptionAlgorithm() int


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->

#### Name of feature:

Opt-in legacy SCEP compatibility options for authenticated attribute verification and RSA `digestEncryptionAlgorithm` encoding.

#### Pain or issue this feature alleviates:

Some legacy SCEP clients are not fully interoperable with the default PKCS#7 behavior used by `smallstep/certificates`.

Two compatibility issues were identified while investigating `smallstep/certificates#1723`:

1. Some legacy clients sign PKCS#7 authenticated attributes in their original encoded order instead of DER SET order. This causes request verification to fail with `crypto/rsa: verification error`.

2. Some legacy clients expect SCEP `CertRep` responses using:

`rsaEncryption` (`1.2.840.113549.1.1.1`)

as the `SignerInfo.digestEncryptionAlgorithm`, rather than:

`sha1WithRSAEncryption` (`1.2.840.113549.1.1.5`)

when SHA-1 and RSA are used.

This change exposes two independent SCEP provisioner compatibility options:

`allowUnsortedAuthenticatedAttributes`

and

`legacyRSADigestEncryptionAlgorithm`

Both options are disabled by default.

#### Why is this important to the project (if not answered above):

This allows `step-ca` SCEP provisioners to interoperate with legacy SCEP implementations without changing behavior for existing deployments.

The compatibility behavior is explicitly opt-in and can be enabled only for provisioners that require it.

The changes were tested successfully against a legacy SCEP client based on strongSwan 5.0.2, where certificate enrollment previously failed.

#### Is there documentation on how to use this feature? If so, where?

The options are configured on an SCEP provisioner, for example:

```json
{
    "allowUnsortedAuthenticatedAttributes": true,
    "legacyRSADigestEncryptionAlgorithm": true
}
```

`allowUnsortedAuthenticatedAttributes` enables compatibility when parsing and verifying incoming SCEP PKI messages.

`legacyRSADigestEncryptionAlgorithm` causes signed SCEP `CertRep` responses to use `rsaEncryption` as the PKCS#7 `SignerInfo.digestEncryptionAlgorithm`.

Both options may be enabled independently.

#### In what environments or workflows is this feature supported?

SCEP provisioners using `step-ca`.

The compatibility options are intended for interoperability with legacy SCEP clients whose PKCS#7 encoding or verification expectations differ from current DER/RSA conventions.

The implementation has been tested with a legacy client based on strongSwan 5.0.2.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Neither compatibility behavior is enabled globally.

Provisioners that do not explicitly configure these options retain the existing SCEP parsing, verification, and response-signing behavior.

The options are intended as targeted compatibility mechanisms rather than changes to the default SCEP behavior.

#### Supporting links/other PRs/issues:

* Addresses the interoperability problem reported in `smallstep/certificates#1723`.
* Related legacy SCEP interoperability discussion: `strongswan/strongswan#2753`.
* Depends on the corresponding `smallstep/pkcs7` PR providing:

  * opt-in verification of authenticated attributes in their encoded order
  * support for honoring an explicitly configured `SignedData` encryption algorithm in `AddSignerChain()`
* Depends on the corresponding `smallstep/scep` PR exposing the authenticated-attribute verification option through `ParsePKIMessage`.

💔Thank you!

