### PR TITLE
Fix panic when ssh certificate is nil due to an error

### DIFF
--- a/internal/metrix/meter.go
+++ b/internal/metrix/meter.go
@@ -131,14 +131,15 @@ func (m *Meter) X509WebhookEnriched(p provisioner.Interface, err error) {
 }
 
 func sshCertValues(cert *ssh.Certificate) []string {
-	switch cert.CertType {
-	case ssh.UserCert:
-		return []string{"user"}
-	case ssh.HostCert:
-		return []string{"host"}
-	default:
-		return []string{"unknown"}
+	if cert != nil {
+		switch cert.CertType {
+		case ssh.UserCert:
+			return []string{"user"}
+		case ssh.HostCert:
+			return []string{"host"}
+		}
 	}
+	return []string{"unknown"}
 }
 
 func incrProvisionerCounter(cv *prometheus.CounterVec, p provisioner.Interface, err error, extraValues ...string) {

--- a/internal/metrix/meter_test.go
+++ b/internal/metrix/meter_test.go
@@ -1,0 +1,27 @@
+package metrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+)
+
+func Test_sshCertValues(t *testing.T) {
+	tests := []struct {
+		name string
+		cert *ssh.Certificate
+		want []string
+	}{
+		{"user", &ssh.Certificate{CertType: ssh.UserCert}, []string{"user"}},
+		{"host", &ssh.Certificate{CertType: ssh.HostCert}, []string{"host"}},
+		{"host", &ssh.Certificate{CertType: 100}, []string{"unknown"}},
+		{"nil", nil, []string{"unknown"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sshCertValues(tt.cert)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a panic on the metrics  when an SSH certificate sign fails.