### PR TITLE
Stabilize TestBootstrapClientServerRotation on slow machines

### DIFF
--- a/ca/bootstrap_test.go
+++ b/ca/bootstrap_test.go
@@ -471,7 +471,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 	}
 
 	// wait for renew
-	time.Sleep(5 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	// Reload with configuration with current and future root
 	ca.opts.configFile = "testdata/rotate-ca-1.json"
@@ -484,7 +484,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 	}
 
 	// wait for renew
-	time.Sleep(5 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	// Reload with new and old root
 	ca.opts.configFile = "testdata/rotate-ca-2.json"
@@ -497,7 +497,7 @@ func TestBootstrapClientServerRotation(t *testing.T) {
 	}
 
 	// wait for renew
-	time.Sleep(5 * time.Second)
+	time.Sleep(12 * time.Second)
 
 	// Reload with pnly the new root
 	ca.opts.configFile = "testdata/rotate-ca-3.json"

--- a/ca/testdata/rotate-ca-0.json
+++ b/ca/testdata/rotate-ca-0.json
@@ -33,7 +33,7 @@
                 },
                 "claims": {
                     "minTLSCertDuration": "1s",
-                    "defaultTLSCertDuration": "5s"
+                    "defaultTLSCertDuration": "15s"
                 }
             }
         ],

--- a/ca/testdata/rotate-ca-1.json
+++ b/ca/testdata/rotate-ca-1.json
@@ -33,7 +33,7 @@
                 },
                 "claims": {
                     "minTLSCertDuration": "1s",
-                    "defaultTLSCertDuration": "5s"
+                    "defaultTLSCertDuration": "15s"
                 }
             }
         ],

--- a/ca/testdata/rotate-ca-2.json
+++ b/ca/testdata/rotate-ca-2.json
@@ -33,7 +33,7 @@
                 },
                 "claims": {
                     "minTLSCertDuration": "1s",
-                    "defaultTLSCertDuration": "5s"
+                    "defaultTLSCertDuration": "15s"
                 }
             }
         ],

--- a/ca/testdata/rotate-ca-3.json
+++ b/ca/testdata/rotate-ca-3.json
@@ -33,7 +33,7 @@
                 },
                 "claims": {
                     "minTLSCertDuration": "1s",
-                    "defaultTLSCertDuration": "5s"
+                    "defaultTLSCertDuration": "15s"
                 }
             }
         ],


### PR DESCRIPTION
## Description

Test-only change to make `TestBootstrapClientServerRotation` stable on slow or loaded machines.

**Root cause:** the test issues certificates with a 5s lifetime (`defaultTLSCertDuration` in `ca/testdata/rotate-ca-*.json`), and `TLSRenewer` schedules each renewal at ~2/3 of the certificate lifetime (see #873), leaving only ~1.7–2.9s between the scheduled renewal and the expiry of the certificate in use. On a slow or loaded machine, a scheduling stall longer than that margin means the next mTLS handshake presents an already-expired certificate. Since `/renew` requires a valid client certificate (and the bootstrap token cannot be re-used to re-sign, as OTTs are protected against reuse), the client cannot recover and the test fails — which matches the log in #2713 (a handshake at 15:55:08 hitting a certificate that had just expired at 15:55:08). This is also the same class of instability that led to the test being skipped when `CI=true`. Fixing the underlying unrecoverable state would be a behavior change (e.g. a grace window on `/renew`), so it's left to the discussion in #2713/#873; this PR only stabilizes the test.

**Change:** increase the test certificate lifetime to 15s and the renewal waits from 5s to 12s. This grows the margin before expiry to ~5s while still guaranteeing at least one renewal of both the client and the server certificate on every phase (with 15s certificates, renewals happen every ~9–10s, and the final phase runs ~24s after the first reload).

No production behavior is modified. The only cost is the test itself going from ~21s to ~40s, which only affects local runs (in this repository's CI the test is skipped).

## Validation

- `go test ./ca/ -run TestBootstrapClientServerRotation -count=3` passes 3/3 with the machine under full CPU saturation (4 busy loops on 4 cores), ~39.5s per run.
- `go test -short -count=1 ./ca/...` passes.
- `golangci-lint run` with the project config reports 0 issues; `gofmt` is clean.

Fixes #2713

---

*Transparency note: this contribution was prepared with AI assistance and validated with the commands above.*
