### PR TITLE
Set Content-Type on provisioner webhook requests

### DIFF
--- a/authority/provisioner/webhook.go
+++ b/authority/provisioner/webhook.go
@@ -227,6 +227,8 @@ retry:
 		return nil, err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	if requestID, ok := requestid.FromContext(ctx); ok {
 		req.Header.Set("X-Request-Id", requestID)
 	}

--- a/authority/provisioner/webhook_test.go
+++ b/authority/provisioner/webhook_test.go
@@ -567,6 +567,8 @@ func TestWebhook_Do(t *testing.T) {
 					assert.Equal(t, tc.requestID, r.Header.Get("X-Request-ID"))
 				}
 
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
 				assert.Equal(t, tc.webhook.ID, r.Header.Get("X-Smallstep-Webhook-ID"))
 
 				sig, err := hex.DecodeString(r.Header.Get("X-Smallstep-Signature"))


### PR DESCRIPTION
#### Name of feature:

Provisioner webhooks `Content-Type` header

#### Pain or issue this feature alleviates:

No `Content-Type` header set on outgoing HTTP request

#### Why is this important to the project (if not answered above):

Webhook servers that dispatch on Content-Type reject these requests. Express's `express.json()` and Spring's `@RequestBody` both require `application/json` and respond 400 or hand the handler an empty body.

Set the header alongside the other webhook headers. This covers every webhook kind, since enriching, authorizing and the SCEP challenge and notify webhooks all send through DoWithContext.

💔Thank you!
